### PR TITLE
do not preload tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -187,6 +187,16 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file. However, if you prefer, 
 #  you could uncomment the following to ignore the entire vscode folder
 # .vscode/
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+#!.vscode/launch.json
+!.vscode/extensions.json
+!.vscode/*.code-snippets
+!*.code-workspace
+
+# Built Visual Studio Code Extensions
+*.vsix
 
 # python version
 .python-version


### PR DESCRIPTION
fixes #6 

The error was caused by loading tasks before loading models. As a result no default model was set for the tasks. 

Fix by not preloading tasks or models and instead passing the task and model strings to eval_set and defering to eval_set to resolve