### PR TITLE
fix: apply substitutions, defaults, and call @after_load functions after overrides

### DIFF
--- a/src/inspect_flow/_config/load.py
+++ b/src/inspect_flow/_config/load.py
@@ -61,8 +61,7 @@ def expand_spec(
         base_dir=base_dir,
     )
     spec = _apply_auto_includes(spec, base_dir=base_dir, options=options, state=state)
-    if options.overrides:
-        return _apply_overrides(spec, options.overrides)
+    spec = _apply_overrides(spec, options.overrides)
     spec = _apply_substitutions(spec, base_dir=base_dir)
     spec = apply_defaults(spec)
     _after_flow_spec_loaded(spec, state)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -27,7 +27,7 @@ from inspect_flow._config.load import (
     expand_spec,
     int_load_spec,
 )
-from inspect_flow._types.flow_types import FlowDependencies
+from inspect_flow._types.flow_types import FlowDependencies, not_given
 from inspect_flow._util.logging import init_flow_logging
 from pydantic import ValidationError
 
@@ -207,10 +207,8 @@ def test_load_config_overrides():
     assert config.log_dir == "./logs/overridden_flow"
     assert config.options
     assert config.options.limit == 2
-    assert config.defaults
-    assert config.defaults.solver
-    assert config.defaults.solver.args
-    assert config.defaults.solver.args["tool_calls"] == "none"
+    # Defaults are applied as part of loading the spec
+    assert config.defaults is not_given
 
 
 def test_overrides_of_lists():
@@ -355,6 +353,16 @@ def test_absolute_include() -> None:
     spec = expand_spec(
         FlowSpec(includes=[include_path]),
         base_dir=config_dir,
+    )
+    validate_config(spec, "absolute_include_flow.yaml")
+
+
+def test_437_absolute_include() -> None:
+    include_path = str(Path(__file__).parent / "config" / "model_and_task_flow.py")
+    spec = expand_spec(
+        FlowSpec(includes=[include_path]),
+        base_dir=config_dir,
+        options=ConfigOptions(overrides=["options.limit=1"]),
     )
     validate_config(spec, "absolute_include_flow.yaml")
 

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -162,7 +162,7 @@ def test_relative_bundle_dir() -> None:
             options=ConfigOptions(
                 overrides=[
                     "options.bundle_dir=bundle_dir",
-                    "options.bundle_url_mappings.bundle_dir=http://example.com/bundle}",
+                    "options.bundle_url_mappings.bundle_dir=http://example.com/bundle",
                 ]
             ),
         )


### PR DESCRIPTION
Fixes #437 