### PR TITLE
fix: _flow.py should not include itself when loaded directly

### DIFF
--- a/src/inspect_flow/_config/load.py
+++ b/src/inspect_flow/_config/load.py
@@ -50,7 +50,7 @@ def int_load_spec(file: str, options: ConfigOptions) -> FlowSpec:
         raise ValueError(f"No value returned from Python config file: {file}")
 
     base_dir = Path(file).parent.as_posix()
-    spec = expand_spec(spec, base_dir=base_dir, options=options)
+    spec = expand_spec(spec, base_dir=base_dir, options=options, state=state)
     print(
         f"Loaded {quantity(len(spec.tasks or []), 'task')}\n",
         format="success",
@@ -59,10 +59,13 @@ def int_load_spec(file: str, options: ConfigOptions) -> FlowSpec:
 
 
 def expand_spec(
-    spec: FlowSpec, base_dir: str, options: ConfigOptions | None = None
+    spec: FlowSpec,
+    base_dir: str,
+    options: ConfigOptions | None = None,
+    state: LoadState | None = None,
 ) -> FlowSpec:
     options = options or ConfigOptions()
-    state = LoadState()
+    state = state or LoadState()
     spec = _expand_includes(
         spec,
         state,
@@ -312,16 +315,21 @@ def _apply_auto_includes(
         if protocol:
             auto_file = f"{protocol}://{auto_file}"
         if exists(auto_file):
-            auto_spec = _load_spec_from_file(auto_file, args=options.args, state=state)
-            if (auto_include_count := auto_include_count + 1) > 1:
-                print(
-                    f"Applying multiple {AUTO_INCLUDE_FILENAME}. #{auto_include_count}: {path(auto_file)}",
-                    format="warning",
+            # Skip if this file was already loaded (e.g., when loading _flow.py directly)
+            absolute_auto_file = absolute_file_path(auto_file)
+            if absolute_auto_file not in state.files_to_specs:
+                auto_spec = _load_spec_from_file(
+                    auto_file, args=options.args, state=state
                 )
-            else:
-                print(f"Auto-include: {path(auto_file)}", format="info")
-            if auto_spec:
-                spec = _apply_include(spec, auto_spec)
+                if (auto_include_count := auto_include_count + 1) > 1:
+                    print(
+                        f"Applying multiple {AUTO_INCLUDE_FILENAME}. #{auto_include_count}: {path(auto_file)}",
+                        format="warning",
+                    )
+                else:
+                    print(f"Auto-include: {path(auto_file)}", format="info")
+                if auto_spec:
+                    spec = _apply_include(spec, auto_spec)
         if parent_dir.parent == parent_dir:
             break
         parent_dir = parent_dir.parent

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -711,3 +711,13 @@ def test_389_tool_config() -> None:
 def test_419_python_include() -> None:
     config = load_spec(str(Path(__file__).parent / "config" / "python_import_flow.py"))
     validate_config(config, "python_import_flow.yaml")
+
+
+def test_465_flow_file_should_not_include_itself(recording_console: Console) -> None:
+    """Loading a _flow.py file directly should not auto-include itself."""
+    load_spec(str(Path(__file__).parent / "config" / "auto" / "_flow.py"))
+    out = recording_console.export_text()
+    # Remove all whitespace from rich console formatting to handle line wrapping
+    out_normalized = "".join(out.split())
+    # The _flow.py file should NOT be auto-included when loaded directly
+    assert "Auto-include" not in out_normalized


### PR DESCRIPTION
## Summary
- Fixed bug where loading a `_flow.py` file directly would incorrectly auto-include itself
- Root cause: `int_load_spec` tracked loaded files in a `LoadState`, but `expand_spec` created a new `LoadState` losing that tracking
- Fix: Pass the state through and check `state.files_to_specs` before auto-including files

Fixes #465

## Test plan
- [x] Added `test_465_flow_file_should_not_include_itself` test that verifies no "Auto-include" message when loading `_flow.py` directly
- [x] All existing auto-include tests pass
- [x] Full `test_config.py` suite passes (48 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)