### PR TITLE
fix: avoid extra output on Ctrl+C

### DIFF
--- a/src/inspect_flow/_runner/run.py
+++ b/src/inspect_flow/_runner/run.py
@@ -128,13 +128,18 @@ def run_eval_set(
             eval_set_id=default_none(options.eval_set_id),
             # kwargs= FlowSpec, FlowTask, and FlowModel allow setting the generate config
         )
-    except Exception as e:
+    except BaseException as e:
         if isinstance(e, PrerequisiteError):
             _fix_prerequisite_error_message(e)
-        print(str(e))
-        raise FlowHandledError from e
-    finally:
-        print(Rule("Eval Set Finished"))
+        if error_string := str(e):
+            print(error_string, format="error")
+        print(Rule("Eval Set Failed with Exception"))
+        if error_string:
+            raise FlowHandledError from e
+        else:
+            raise
+
+    print(Rule("Eval Set Finished"))
     elapsed_time = time.time() - start_time
 
     _print_result(resolved_config, result, elapsed_time)

--- a/src/inspect_flow/_util/error.py
+++ b/src/inspect_flow/_util/error.py
@@ -18,6 +18,12 @@ def exception_hook() -> Callable[..., None]:
         if isinstance(exception, (FlowHandledError, subprocess.CalledProcessError)):
             # Exception already handled, do not print again
             sys.exit(getattr(exception, "returncode", 1))
+        elif isinstance(exception, KeyboardInterrupt):
+            # Exit cleanly without traceback (130 = 128 + SIGINT)
+            sys.exit(130)
+        elif isinstance(exception, click.Abort):
+            # Exit cleanly without traceback
+            sys.exit(1)
         else:
             sys_handler(exception_type, exception, traceback)
 

--- a/tests/test_error.py
+++ b/tests/test_error.py
@@ -4,6 +4,7 @@ import pytest
 from inspect_flow._util import error
 from inspect_flow._util.error import FlowHandledError, set_exception_hook
 from pytest import CaptureFixture
+from rich.console import Console
 
 
 @pytest.fixture(autouse=True)
@@ -69,3 +70,47 @@ def test_exception_hook_handles_other_exceptions(capsys: CaptureFixture[str]) ->
     sys.excepthook(type(exc), exc, None)
 
     assert "Exception: test" in capsys.readouterr().err
+
+
+def test_469_exception_hook_handles_keyboard_interrupt(
+    recording_console: Console,
+) -> None:
+    """Test that the custom hook exits cleanly for KeyboardInterrupt without traceback.
+
+    Issue #469: When a user presses Ctrl+C, the exception hook should exit cleanly
+    without printing a full traceback (which is "clutter").
+    """
+    set_exception_hook()
+
+    exc = KeyboardInterrupt()
+
+    with pytest.raises(SystemExit) as exc_info:
+        sys.excepthook(type(exc), exc, None)
+
+    # Should exit with code 130 (standard Unix exit code for SIGINT)
+    assert exc_info.value.code == 130
+
+    # Should NOT print anything (clean exit)
+    assert recording_console.export_text() == ""
+
+
+def test_469_exception_hook_handles_click_abort(recording_console: Console) -> None:
+    """Test that the custom hook exits cleanly for click.Abort without traceback.
+
+    Issue #469: When a user aborts a click prompt (Ctrl+C), the exception hook
+    should exit cleanly without printing a full traceback.
+    """
+    import click
+
+    set_exception_hook()
+
+    exc = click.Abort()
+
+    with pytest.raises(SystemExit) as exc_info:
+        sys.excepthook(type(exc), exc, None)
+
+    # Should exit with code 1
+    assert exc_info.value.code == 1
+
+    # Should NOT print anything (clean exit)
+    assert recording_console.export_text() == ""

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -1156,3 +1156,20 @@ def test_eval_set_error(mock_eval_set: MagicMock) -> None:
     assert e.value.__cause__ is not None
     assert isinstance(e.value.__cause__, ValueError)
     assert "Test error from eval_set" in str(e.value.__cause__)
+
+
+def test_eval_set_keyboard_interrupt(
+    mock_eval_set: MagicMock, recording_console: Console
+) -> None:
+    log_dir = init_test_logs()
+    spec = FlowSpec(
+        log_dir=log_dir,
+        tasks=tasks_matrix(task=[task_file + "@noop"], model=["mockllm/model1"]),
+    )
+    mock_eval_set.side_effect = KeyboardInterrupt()
+
+    with pytest.raises(KeyboardInterrupt):
+        run_eval_set(spec=spec, base_dir=".")
+
+    out = recording_console.export_text()
+    assert "Eval Set Failed with Exception" in out


### PR DESCRIPTION
Fixes #469 