### PR TITLE
docs: add docstring to DisplayType for quarto docs build

### DIFF
--- a/src/inspect_flow/_display/display.py
+++ b/src/inspect_flow/_display/display.py
@@ -13,6 +13,13 @@ from inspect_flow._display.action import DisplayAction
 from inspect_flow._util.console import Formats
 
 DisplayType = Literal["full", "rich", "plain"]
+"""Display mode for flow output.
+
+Options:
+    - "full": Full interactive display with progress bars and rich formatting
+    - "rich": Rich text formatting without interactive elements
+    - "plain": Plain text output
+"""
 _display_type: DisplayType = "full"
 _display: Display | None = None
 


### PR DESCRIPTION
Fixed quarto documentation build failure by adding a docstring to the `DisplayType` type alias

The quarto documentation filter requires all exported API attributes to have docstrings. The `DisplayType` type alias (`Literal["full", "rich", "plain"]`) was missing a docstring, which caused an `AssertionError` during the `quarto publish gh-pages` command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)