### PR TITLE
fix: compile with conflicting git urls

### DIFF
--- a/src/inspect_flow/_launcher/freeze.py
+++ b/src/inspect_flow/_launcher/freeze.py
@@ -36,6 +36,7 @@ def write_flow_requirements(
                 "--generate-hashes",
                 "--no-header",
                 "--no-annotate",
+                "--no-deps",
                 str(requirements_in),
             ],
             cwd=cwd,


### PR DESCRIPTION
adds `--no-deps` to `uv pip compile` to prevent transitive dependency resolution from conflicting with pinned git URLs

`uv pip freeze` should already include transitive dependencies, so there's no need to re-explore those at the compile step.