### PR TITLE
docs: add llms.txt and llms-full.txt generation

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -1,7 +1,11 @@
 project:
   type: website
-  pre-render: 
+  resources:
+    - llms.txt
+  pre-render:
     - reference/filter/sidebar.py
+  post-render:
+    - scripts/post-render.sh
 
 metadata-files:
   - reference/_sidebar.yml

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,0 +1,24 @@
+# Inspect Flow
+
+> Workflow orchestration for Inspect AI that enables you to run evaluations at scale with repeatability and maintainability. Provides declarative configuration, powerful defaults, and parameter sweeping for systematic AI evaluations.
+
+## Docs
+
+- [Welcome](https://meridianlabs-ai.github.io/inspect_flow/index.html.md): Introduction, getting started, and basic example
+- [Flow Concepts](https://meridianlabs-ai.github.io/inspect_flow/flow_concepts.html.md): Core concepts — FlowSpec, FlowTask, FlowModel, FlowSolver, FlowAgent, FlowScorer, FlowOptions, FlowDefaults, FlowDependencies
+- [Defaults](https://meridianlabs-ai.github.io/inspect_flow/defaults.html.md): Defaults, inheritance, and overrides for configuration
+- [Matrixing](https://meridianlabs-ai.github.io/inspect_flow/matrix.html.md): Parameter sweeping with matrix functions for systematic exploration
+- [Running Flows](https://meridianlabs-ai.github.io/inspect_flow/run.html.md): How to run flows, execution modes, and CLI flags
+- [Store](https://meridianlabs-ai.github.io/inspect_flow/store.html.md): Persistent log store for reuse across runs
+- [Advanced](https://meridianlabs-ai.github.io/inspect_flow/advanced.html.md): Execution modes and virtual environments
+
+## Reference: Python API
+
+- [inspect_flow](https://meridianlabs-ai.github.io/inspect_flow/reference/inspect_flow.html.md): Core types and functions
+- [inspect_flow.api](https://meridianlabs-ai.github.io/inspect_flow/reference/inspect_flow.api.html.md): Public API — init, run, load_spec, config, store_get, delete_store, copy_all_logs
+
+## Reference: CLI
+
+- [flow config](https://meridianlabs-ai.github.io/inspect_flow/reference/flow_config.html.md): Display resolved flow configuration
+- [flow run](https://meridianlabs-ai.github.io/inspect_flow/reference/flow_run.html.md): Run flow evaluations
+- [flow store](https://meridianlabs-ai.github.io/inspect_flow/reference/flow_store.html.md): Manage the flow log store

--- a/docs/scripts/post-render.sh
+++ b/docs/scripts/post-render.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# Post-render script to generate llms-full.txt and individual .html.md files.
+# Follows the inspect-ai approach: renders each .qmd to GFM markdown, concatenates
+# into llms-full.txt, and places individual .html.md files alongside HTML output.
+
+files=(
+    "index"
+    "flow_concepts"
+    "defaults"
+    "matrix"
+    "run"
+    "store"
+    "advanced"
+    "reference/index"
+    "reference/inspect_flow"
+    "reference/inspect_flow.api"
+    "reference/flow_config"
+    "reference/flow_run"
+    "reference/flow_store"
+)
+
+if [ "$QUARTO_PROJECT_RENDER_ALL" = "1" ]; then
+    llms_full="_site/llms-full.txt"
+    rm -f "${llms_full}"
+    mv _quarto.yml _quarto.yml.bak
+    for file in "${files[@]}"; do
+        echo "llms: ${file}.qmd"
+        quarto render "${file}.qmd" --to gfm-raw_html --quiet --no-execute
+        output_file="${file}.md"
+        cat "${output_file}" >> "${llms_full}"
+        echo "" >> "${llms_full}"
+        mv "${output_file}" "_site/${file}.html.md"
+    done
+    mv _quarto.yml.bak _quarto.yml
+fi


### PR DESCRIPTION
## Summary
- Add `llms.txt` for LLM-friendly documentation discovery following the [llms.txt spec](https://llmstxt.org/)
- Add post-render script that generates `llms-full.txt` (all docs concatenated) and individual `.html.md` files
- Update `_quarto.yml` with resource and post-render configuration

After deployment, files will be served at:
- https://meridianlabs-ai.github.io/inspect_flow/llms.txt
- https://meridianlabs-ai.github.io/inspect_flow/llms-full.txt

🤖 Generated with [Claude Code](https://claude.com/claude-code)