### PR TITLE
docs: update docs for --resume, {DATETIME}, and --log-dir-create-unique

### DIFF
--- a/docs/advanced.qmd
+++ b/docs/advanced.qmd
@@ -181,6 +181,16 @@ FlowSpec(
 
 For nested fields, use bracket notation: `{options[eval_set_id]}` or `{flow_metadata[key]}`. Substitutions are resolved recursively until no more remain.
 
+#### Built-in Substitutions
+
+In addition to `FlowSpec` field names, the following built-in substitution keys are available:
+
+| Key | Description | Example Output |
+|-----|-------------|----------------|
+| `{DATETIME}` | Current timestamp | `2026-03-04T16-56-25` |
+
+Built-in keys use uppercase names to distinguish them from `FlowSpec` field names (which are lowercase). For example, `{DATETIME}` is a built-in key while `{log_dir}` references the `log_dir` field.
+
 ## Metadata
 
 Flow supports two types of metadata with distinct purposes: `metadata` and `flow_metadata`.

--- a/docs/run.qmd
+++ b/docs/run.qmd
@@ -52,6 +52,14 @@ Performs the full setup process and shows what would run:
 
 This is invaluable for debugging what will actually run in your evaluations.
 
+**Resume a previous run:**
+
+``` bash
+flow run config.py --resume
+```
+
+Reuses the log directory from the most recent run. Use this to pick up where you left off after an interruption, or to add new evaluations to an existing log directory after updating your config. Mutually exclusive with `--log-dir`.
+
 **Override log directory:**
 
 ``` bash
@@ -59,6 +67,14 @@ flow run config.py --log-dir ./experiments/baseline
 ```
 
 Changes where logs and results are stored.
+
+**Create a unique log directory:**
+
+``` bash
+flow run config.py --log-dir ./experiments/baseline --log-dir-create-unique
+```
+
+Creates a subdirectory within the specified `log_dir` using the current timestamp (e.g., `./experiments/baseline/2026-03-04T16-56-25/`). Useful for keeping separate log directories across repeated runs without overwriting previous results.
 
 **Runtime overrides:**
 

--- a/src/inspect_flow/_cli/options.py
+++ b/src/inspect_flow/_cli/options.py
@@ -127,14 +127,14 @@ def config_options(f: F) -> F:
         "--log-dir-create-unique",
         type=bool,
         is_flag=True,
-        help="If set, create a new log directory by appending an `_` and numeric suffix if the specified `log_dir` already exists. If the directory exists and has a `_numeric suffix`, that suffix will be incremented. If not set, use the existing `log_dir` (which must be empty or have `log_dir_allow_dirty=True`).",
+        help="If set, create a unique log directory by appending a datetime subdirectory (e.g. `2025-12-09T17-36-43`) under the specified `log_dir`. If not set, use the existing `log_dir` (which must be empty or have `log_dir_allow_dirty=True`).",
         envvar="INSPECT_FLOW_LOG_DIR_CREATE_UNIQUE",
     )(f)
     f = click.option(
         "--resume",
         type=bool,
         is_flag=True,
-        help="Resume from the previous run by reusing its log directory.",
+        help="Resume from the previous run by reusing its log directory. Mutually exclusive with `--log-dir`.",
         envvar="INSPECT_FLOW_RESUME",
     )(f)
     f = click.option(


### PR DESCRIPTION
## Summary

- Add `--resume` flag and `--log-dir-create-unique` to "Common CLI Flags" section in `run.qmd`
- Document `{DATETIME}` built-in substitution key in `advanced.qmd`
- Fix outdated `--log-dir-create-unique` CLI help string (was describing old numeric suffix behavior, now describes datetime subdirectory)
- Add mutual exclusivity note to `--resume` CLI help

🤖 Generated with [Claude Code](https://claude.com/claude-code)