### PR TITLE
feat: add --resume flag to reuse previous log dir

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,9 +22,9 @@ Inspect Flow is designed for researchers and engineers running systematic AI eva
 ## Key Modules
 
 - [_types](src/inspect_flow/_types) defines the types used in inspect flow configurations.
-- [_api](src/inspect_flow/_api) defines the public API for inspect flow (`init`, `run`, `config`, `store_get`).
+- [_api](src/inspect_flow/_api) defines the public API for inspect flow (`init`, `load_spec`, `run`, `config`, `store_get`).
 - [_cli](src/inspect_flow/_cli) defines the command line interface for inspect flow. Commands: `run`, `config`, `store`.
-- [_config](src/inspect_flow/_config) is responsible for loading and validating the flow configuration. The main function is `load_config`, defined in [config.py](src/inspect_flow/_config/config.py).
+- [_config](src/inspect_flow/_config) is responsible for loading and validating the flow configuration. The main function is `int_load_spec`, defined in [load.py](src/inspect_flow/_config/load.py).
 - [_launcher](src/inspect_flow/_launcher) is responsible for creating the virtual environment, installing package dependencies, and starting the flow runner process. The main function is `launch`, defined in [launch.py](src/inspect_flow/_launcher/launch.py).
 - [_runner](src/inspect_flow/_runner) is responsible for running the flow tasks either in-process or within the virtual environment. The main function is `run_eval_set`, defined in [run.py](src/inspect_flow/_runner/run.py).
 - [_store](src/inspect_flow/_store) provides a persistent Delta Lake store for tracking evaluation logs across runs, enabling reuse of completed evaluations.
@@ -35,6 +35,7 @@ See [src/inspect_flow/README.md](src/inspect_flow/README.md) for detailed module
 
 ## Build/Lint/Test Commands
 - Repo setup: `uv sync`
+- Lint + type check: `make check` (runs ruff + pyright)
 - Run all tests: `pytest`
 - Run a single test: `pytest tests/path/to/test_file.py::test_function_name -v`
 - Format code: `ruff format`


### PR DESCRIPTION
Above was done in #528 but used wrong conventional commit message, so this is to force the CHANGELOG.md to update.

Since a change was required, fixed a few things in CLAUDE.md