### PR TITLE
docs: add documentation for matrix limits, function configs, and YAML support

### DIFF
--- a/docs/flow_concepts.qmd
+++ b/docs/flow_concepts.qmd
@@ -25,8 +25,12 @@ Flow configuration files are Python files where the last expression is either:
 
 Since config files are standard Python code, you can use all Python features including variables, loops, comprehensions, imports, and comments. Flow configs are just Python!
 
+When using a function, its parameters become CLI arguments via `--arg`, letting you design a custom CLI interface for your config. See [this example](https://github.com/meridianlabs-ai/inspect_flow/blob/main/examples/flow_args.py) for usage.
+
+Flow also supports YAML config files (`.yaml`/`.yml`) for purely declarative specs. See [this example](https://github.com/meridianlabs-ai/inspect_flow/blob/main/examples/first_config.yml) for usage.
+
 ::: {.callout-note appearance="default"}
-This last expression requirement only applies when loading configs from files (via CLI or `load_spec()`). When using the Python API directly with `run()`, you pass the `FlowSpec` object programmatically—no file or last expression needed.
+The last expression requirement only applies when loading Python configs from files (via CLI or `load_spec()`). When using the Python API directly with `run()`, you pass the `FlowSpec` object programmatically—no file or last expression needed.
 :::
 
 ## Basic Example

--- a/docs/matrix.qmd
+++ b/docs/matrix.qmd
@@ -23,6 +23,8 @@ Generate task configurations by combining tasks with models, configs, solvers, a
 
 This creates **4 tasks** (2 tasks × 2 models).
 
+In addition to `model`, `config`, `solver`, and `args`, you can also sweep over sample limit fields: `message_limit`, `token_limit`, `time_limit`, `working_limit`, and `cost_limit`. See [this example](https://github.com/meridianlabs-ai/inspect_flow/blob/main/examples/tasks_matrix_limits.py) for usage.
+
 ### models_matrix()
 
 Generate model configurations with different generation settings:

--- a/docs/run.qmd
+++ b/docs/run.qmd
@@ -13,6 +13,12 @@ Execute your evaluation workflow:
 flow run config.py
 ```
 
+You can also run from a YAML config file (see [this example](https://github.com/meridianlabs-ai/inspect_flow/blob/main/examples/first_config.yml) for the YAML format):
+
+``` bash
+flow run config.yaml
+```
+
 **What happens when you run this:**
 
 1.  Flow loads your configuration file

--- a/examples/first_config.yml
+++ b/examples/first_config.yml
@@ -1,7 +1,4 @@
 log_dir: logs
-dependencies:
-- inspect-evals
 tasks:
 - name: inspect_evals/gpqa_diamond
-  model:
-    name: openai/gpt-5
+  model: openai/gpt-5

--- a/examples/tasks_matrix_limits.py
+++ b/examples/tasks_matrix_limits.py
@@ -1,0 +1,10 @@
+from inspect_flow import FlowSpec, FlowTask, tasks_matrix
+
+FlowSpec(
+    log_dir="logs",
+    tasks=tasks_matrix(
+        task=FlowTask(name="inspect_evals/mmlu_0_shot", model="openai/gpt-4o"),
+        message_limit=[50, 100],
+        cost_limit=[0.01, 0.05],
+    ),
+)

--- a/tests/expected/tasks_matrix_limits.yaml
+++ b/tests/expected/tasks_matrix_limits.yaml
@@ -1,0 +1,22 @@
+log_dir: logs
+tasks:
+- name: inspect_evals/mmlu_0_shot
+  model:
+    name: openai/gpt-4o
+  message_limit: 50
+  cost_limit: 0.01
+- name: inspect_evals/mmlu_0_shot
+  model:
+    name: openai/gpt-4o
+  message_limit: 50
+  cost_limit: 0.05
+- name: inspect_evals/mmlu_0_shot
+  model:
+    name: openai/gpt-4o
+  message_limit: 100
+  cost_limit: 0.01
+- name: inspect_evals/mmlu_0_shot
+  model:
+    name: openai/gpt-4o
+  message_limit: 100
+  cost_limit: 0.05


### PR DESCRIPTION
## Summary
- Document matrix-able limit fields (`message_limit`, `token_limit`, `time_limit`, `working_limit`, `cost_limit`) in matrixing guide
- Add notes about function-based config files with `--arg` CLI support and YAML config file support in flow concepts and running flows guides
- Fix stale `first_config.yml` example (removed old dependencies format, simplified model field)
- Add `tasks_matrix_limits.py` example and expected test output

Addresses doc updates for #538 and #268.

🤖 Generated with [Claude Code](https://claude.com/claude-code)