### PR TITLE
chore: add make docs-publish command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,3 +20,9 @@ hooks:
 docs:
 	uv sync --extra doc
 	uv run quarto render docs
+
+.PHONY: docs-publish
+docs-publish:
+	uv sync --extra doc
+	git worktree prune
+	cd docs && PRE_COMMIT_ALLOW_NO_CONFIG=1 uv run quarto publish gh-pages --no-prompt


### PR DESCRIPTION
## Summary
- Adds `make docs-publish` target that syncs deps, prunes stale worktrees, and publishes docs to gh-pages in one command

🤖 Generated with [Claude Code](https://claude.com/claude-code)