### PR TITLE
docs: document embed_viewer option

### DIFF
--- a/docs/advanced.qmd
+++ b/docs/advanced.qmd
@@ -226,7 +226,14 @@ The `flow_metadata` field is available on `FlowSpec`, `FlowTask`, `FlowModel`, `
 
 ## Viewer Bundling
 
-Viewer bundling works the same way as [`eval_set()`](https://inspect.aisi.org.uk/eval-sets.html) in Inspect AI and is configurable via `FlowOptions`. An additional feature allows you to print bundle URLs for users running evaluations.
+Flow provides two ways to make evaluation results browsable without running `inspect view`, both configurable via `FlowOptions`:
+
+-   **`embed_viewer`** — Embeds a viewer into the log directory by creating a `viewer/` subdirectory with viewer assets that reference logs in the parent directory. No log files are copied.
+-   **`bundle_dir`** — Creates a self-contained package in a separate directory with the viewer and copies of all log files. The bundle can be moved or deployed independently of the log directory.
+
+Both options work with static hosting (S3, web servers) and can be used together. The key difference is that `embed_viewer` keeps everything in the log directory, while `bundle_dir` produces a standalone copy that can be deployed separately.
+
+### Bundle URL Mappings
 
 Convert local bundle paths to public URLs for sharing evaluation results. The `bundle_url_mappings` in `FlowOptions` applies string replacements to `bundle_dir` to generate a shareable URL that's printed to stdout after the evaluation completes.
 


### PR DESCRIPTION
## Summary
- Documents the new `embed_viewer` option (from #544) in the Viewer Bundling section of `docs/advanced.qmd`
- Compares `embed_viewer` vs `bundle_dir` to clarify when to use each
- Adds a "Bundle URL Mappings" subheading for better structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)