### PR TITLE
fix: preserve task name when provided

### DIFF
--- a/src/inspect_flow/_runner/instantiate.py
+++ b/src/inspect_flow/_runner/instantiate.py
@@ -104,13 +104,14 @@ def instantiate_tasks(spec: FlowSpec, base_dir: str) -> list[InstantiatedTask]:
 def _create_model(task: FlowTask, model: FlowModel | Model) -> Model:
     if isinstance(model, Model):
         return model
-    if model.factory:
+    if model.factory and callable(model.factory):
         return model.factory(**(model.model_args or {}))
-    if not model.name:
+    name = model.factory or model.name
+    if not name:
         raise ValueError(f"Model name is required. Model: {model}")
 
     return get_model(
-        model=model.name,
+        model=name,
         role=default_none(model.role),
         default=default_none(model.default),
         config=model.config or GenerateConfig(),
@@ -135,12 +136,13 @@ def _create_single_scorer(task: FlowTask, scorer: str | FlowScorer | Scorer) -> 
         return scorer
     if isinstance(scorer, str):
         scorer = FlowScorer(name=scorer)
-    if scorer.factory:
+    if scorer.factory and callable(scorer.factory):
         return scorer.factory(**(scorer.args or {}))
-    if not scorer.name:
+    name = scorer.factory or scorer.name
+    if not name:
         raise ValueError(f"Scorer name is required. Scorer: {scorer}")
     return scorer_from_spec(
-        ScorerSpec(scorer=scorer.name),
+        ScorerSpec(scorer=name),
         task_path=None,
         **_kwargs("scorer", scorer.args, task),
     )
@@ -171,24 +173,26 @@ def _create_single_solver(task: FlowTask, solver: str | FlowSolver | Solver) -> 
         return solver
     if not isinstance(solver, FlowSolver):
         raise ValueError(f"Solver should have been resolved. Solver: {solver}")
-    if solver.factory:
+    if solver.factory and callable(solver.factory):
         return solver.factory(**(solver.args or {}))
-    if not solver.name:
+    name = solver.factory or solver.name
+    if not name:
         raise ValueError(f"Solver name is required. Solver: {solver}")
 
     return registry_create(
-        type="solver", name=solver.name, **_kwargs("solver", solver.args, task)
+        type="solver", name=name, **_kwargs("solver", solver.args, task)
     )
 
 
 def _create_agent(task: FlowTask, agent: FlowAgent) -> Agent:
-    if agent.factory:
+    if agent.factory and callable(agent.factory):
         return agent.factory(**(agent.args or {}))
-    if not agent.name:
+    name = agent.factory or agent.name
+    if not name:
         raise ValueError(f"Agent name is required. Agent: {agent}")
 
     return registry_create(
-        type="agent", name=agent.name, **_kwargs("agent", agent.args, task)
+        type="agent", name=name, **_kwargs("agent", agent.args, task)
     )
 
 
@@ -240,6 +244,9 @@ def _instantiate_task(
         init_active_model(model, model.config)
     tasks = _create_task(flow_task, base_dir=base_dir)
 
+    # Try to preserve the task name provided in the flow_task, but if a file with multiple tasks is provided need to use the default names to ensure there are not duplicates.
+    task_name = flow_task.name if len(tasks) == 1 else NOT_GIVEN
+
     for task in tasks:
         if is_set(flow_task.sample_id):
             task.dataset = slice_dataset(
@@ -282,7 +289,7 @@ def _instantiate_task(
             working_limit=ng(flow_task.working_limit),
             cost_limit=ng(flow_task.cost_limit),
             early_stopping=ng(flow_task.early_stopping),
-            # name= should be set when loaded
+            name=ng(task_name),
             version=ng(flow_task.version),
             metadata=ng(flow_task.metadata),
         )
@@ -292,18 +299,19 @@ def _instantiate_task(
 def _create_task(task: FlowTask, base_dir: str) -> list[Task]:
     task_args = registry_kwargs(**(task.args or {}))
     # Use factory if provided
-    if task.factory:
+    if task.factory and callable(task.factory):
         return [task.factory(**task_args)]
 
-    if not task.name:
+    name = task.factory or task.name
+    if not name:
         raise ValueError(f"Task name is required. Task: {task}")
 
     # Try to create by finding task functions in files
     if filesystem(base_dir).is_local():
         with chdir_python(base_dir):
-            tasks = load_tasks(task_specs=[task.name], task_args=task_args)
+            tasks = load_tasks(task_specs=[name], task_args=task_args)
     else:
-        tasks = load_tasks(task_specs=[task.name], task_args=task_args)
+        tasks = load_tasks(task_specs=[name], task_args=task_args)
     if not tasks:
-        raise LookupError(f"No tasks found for name: {task.name}")
+        raise LookupError(f"No tasks found for name: {name}")
     return tasks

--- a/src/inspect_flow/_types/flow_types.py
+++ b/src/inspect_flow/_types/flow_types.py
@@ -63,15 +63,6 @@ class FlowBase(BaseModel, extra="forbid"):
     def __str__(self) -> str:
         return str(model_dump(self))
 
-    @model_validator(mode="before")
-    @classmethod
-    def factory_string_to_name(cls, data: Any) -> Any:
-        """If factory is a string, move it to name and clear factory."""
-        if isinstance(data, dict) and isinstance(data.get("factory"), str):
-            data["name"] = data["factory"]
-            del data["factory"]
-        return data
-
     def __rich_repr__(self) -> rich.repr.Result:
         for field in self.model_fields_set:
             if (value := getattr(self, field)) is not not_given:
@@ -86,7 +77,7 @@ class FlowModel(FlowBase):
         description="Name of the model to use. If factory is not provided, this is used to create the model.",
     )
 
-    factory: Callable[..., Model] | None | NotGiven = Field(
+    factory: Callable[..., Model] | str | None | NotGiven = Field(
         default=not_given,
         description="Factory function to create the model instance.",
     )
@@ -139,7 +130,7 @@ class FlowScorer(FlowBase):
         description="Name of the scorer. Used to create the scorer if the factory is not provided.",
     )
 
-    factory: Callable[..., Scorer] | None | NotGiven = Field(
+    factory: Callable[..., Scorer] | str | None | NotGiven = Field(
         default=not_given,
         description="Factory function to create the scorer instance.",
     )
@@ -163,7 +154,7 @@ class FlowSolver(FlowBase):
         description="Name of the solver. Used to create the solver if the factory is not provided.",
     )
 
-    factory: Callable[..., Solver] | None | NotGiven = Field(
+    factory: Callable[..., Solver] | str | None | NotGiven = Field(
         default=not_given,
         description="Factory function to create the solver instance.",
     )
@@ -187,7 +178,7 @@ class FlowAgent(FlowBase):
         description="Name of the agent. Used to create the agent if the factory is not provided.",
     )
 
-    factory: Callable[..., Agent] | None | NotGiven = Field(
+    factory: Callable[..., Agent] | str | None | NotGiven = Field(
         default=not_given,
         description="Factory function to create the agent instance.",
     )
@@ -261,7 +252,7 @@ class FlowTask(FlowBase, arbitrary_types_allowed=True):
         description='Task name. Any of registry name (`"inspect_evals/mbpp"`), file name (`"./my_task.py"`), or a file name and attr (`"./my_task.py@task_name"`). Used to create the task if the factory is not provided.',
     )
 
-    factory: Callable[..., Task] | None | NotGiven = Field(
+    factory: Callable[..., Task] | str | None | NotGiven = Field(
         default=not_given,
         description="Factory function to create the task instance.",
     )

--- a/src/inspect_flow/_types/generated.py
+++ b/src/inspect_flow/_types/generated.py
@@ -36,7 +36,7 @@ class FlowAgentDict(TypedDict, closed=True):
 
     name: NotRequired[str | NotGiven | None]
     """Name of the agent. Used to create the agent if the factory is not provided."""
-    factory: NotRequired[NotGiven | None]
+    factory: NotRequired[str | NotGiven | None]
     """Factory function to create the agent instance."""
     args: NotRequired[Mapping[str, Any] | NotGiven | None]
     """Additional args to pass to agent constructor."""
@@ -58,7 +58,7 @@ class FlowModelDict(TypedDict, closed=True):
 
     name: NotRequired[str | NotGiven | None]
     """Name of the model to use. If factory is not provided, this is used to create the model."""
-    factory: NotRequired[NotGiven | None]
+    factory: NotRequired[str | NotGiven | None]
     """Factory function to create the model instance."""
     role: NotRequired[str | NotGiven | None]
     """Optional named role for model (e.g. for roles specified at the task or eval level). Provide a default as a fallback in the case where the role hasn't been externally specified."""
@@ -90,7 +90,7 @@ class FlowSolverDict(TypedDict, closed=True):
 
     name: NotRequired[str | NotGiven | None]
     """Name of the solver. Used to create the solver if the factory is not provided."""
-    factory: NotRequired[NotGiven | None]
+    factory: NotRequired[str | NotGiven | None]
     """Factory function to create the solver instance."""
     args: NotRequired[Mapping[str, Any] | NotGiven | None]
     """Additional args to pass to solver constructor."""
@@ -114,7 +114,7 @@ class FlowTaskDict(TypedDict, closed=True):
 
     name: NotRequired[str | NotGiven | None]
     """Task name. Any of registry name (`"inspect_evals/mbpp"`), file name (`"./my_task.py"`), or a file name and attr (`"./my_task.py@task_name"`). Used to create the task if the factory is not provided."""
-    factory: NotRequired[NotGiven | None]
+    factory: NotRequired[str | NotGiven | None]
     """Factory function to create the task instance."""
     args: NotRequired[Mapping[str, Any] | NotGiven | None]
     """Additional args to pass to task constructor"""

--- a/tests/test_helpers/log_helpers.py
+++ b/tests/test_helpers/log_helpers.py
@@ -29,7 +29,10 @@ def _task_name(task: FlowTask) -> str | None:
     if task.name:
         return task.name
     if task.factory:
-        return callable_name(task.factory)
+        if callable(task.factory):
+            return callable_name(task.factory)
+        else:
+            return task.factory
     return None
 
 

--- a/tests/test_inspect_objects.py
+++ b/tests/test_inspect_objects.py
@@ -268,6 +268,46 @@ def test_factory_instantiation() -> None:
     verify_test_logs(spec, log_dir)
 
 
+def test_559_factory_name() -> None:
+    log_dir = init_test_logs()
+    spec = FlowSpec(
+        log_dir=log_dir,
+        tasks=[
+            FlowTask(
+                name="custom_task_name",
+                factory=a_task,
+                model="mockllm/model",
+            ),
+        ],
+    )
+    result = run_eval_set(spec=(spec), base_dir=".")
+    logs = result[1]
+    assert len(logs) == 1
+    assert logs[0].eval.task == "custom_task_name"
+    verify_test_logs(spec, log_dir)
+
+
+def test_559_factory_name_after_dump() -> None:
+    log_dir = init_test_logs()
+    spec = FlowSpec(
+        log_dir=log_dir,
+        tasks=[
+            FlowTask(
+                name="custom_task_name",
+                factory=a_task,
+                model="mockllm/model",
+            ),
+        ],
+    )
+    dump = model_dump(spec)
+    spec = FlowSpec.model_validate(dump)
+    result = run_eval_set(spec=(spec), base_dir=".")
+    logs = result[1]
+    assert len(logs) == 1
+    assert logs[0].eval.task == "custom_task_name"
+    verify_test_logs(spec, log_dir)
+
+
 def test_duplicate_task_objects() -> None:
     spec = FlowSpec(
         log_dir=init_test_logs(),

--- a/tests/test_instantiate.py
+++ b/tests/test_instantiate.py
@@ -270,7 +270,7 @@ def test_additional_args_agent_tools_dict() -> None:
 def test_instantiate_s3(mock_s3: BaseClient) -> None:
     spec = FlowSpec(
         tasks=[
-            FlowTask(name="./tests/local_eval/src/local_eval/noop.py@noop"),
+            FlowTask(factory="./tests/local_eval/src/local_eval/noop.py@noop"),
         ]
     )
     tasks = instantiate_tasks(spec=spec, base_dir="s3://test-bucket/configs/")


### PR DESCRIPTION
Fixes #559 

@alexandraabbas note that this changes factory fields to allow strings. For tasks, this can be the name of an @task decorated function. If the factory and name are both provided, then the factory will be used to create the task and the name will be set as the task name. If only the name field is used then that will be used both to lookup the factory and as the name of the task. If only the factory is used, then that will be used to lookup the factory and the name will use default naming from inspect. So:

FlowTask(name="custom_name", factory="task.py@task") - name will be "custom_name"
FlowTask(name="task.py@task") - name will be "task.py@task"
FlowTask(factory="task.py@task") - name will be "task"