### PR TITLE
docs: update docs for store_read/store_write changes

### DIFF
--- a/docs/defaults.qmd
+++ b/docs/defaults.qmd
@@ -220,12 +220,17 @@ The `_flow.py` inheritance pattern is especially useful for team collaboration. 
 
 ```python
 # _flow.py (at repository root)
+from inspect_flow import FlowSpec, FlowStoreConfig
+
 FlowSpec(
-    store="s3://my-team-bucket/flow-store"
+    store=FlowStoreConfig(
+        path="s3://my-team-bucket/flow-store",
+        read=True,
+    )
 )
 ```
 
-All team members working in the repository will automatically use the shared store, enabling log reuse across the team. See [Flow Store](store.qmd#team-collaboration) for more details.
+All team members working in the repository will automatically inherit the shared store configuration — including `read=True` for log matching. See [Flow Store](store.qmd#team-collaboration) for more details.
 :::
 
 ## CLI Overrides {#cli-overrides}
@@ -304,7 +309,9 @@ flow run config.py
 | `INSPECT_FLOW_LOG_LEVEL`              | `--log-level`              | Inspect Flow log level. Defaults to Info. Use `options.log_level` to set the Inspect AI log level.   |
 | `INSPECT_FLOW_DISPLAY`                | `--display`                | Display mode: `rich` (rich formatting without live updates, default), `full` (live progress), or `plain` (simple text for CI) |
 | `INSPECT_FLOW_STORE`                  | `--store`                  | Path to Flow Store directory. Use `auto` for default location, `none` to disable |
-| `INSPECT_FLOW_STORE_FILTER`           | `--store-filter`           | Registered log filter name to apply when searching the store for existing logs |
+| `INSPECT_FLOW_STORE_READ`             | `--store-read`             | Match existing logs from the store (default: off) |
+| `INSPECT_FLOW_STORE_WRITE`            | `--store-write`            | Index completed logs in the store (default: on) |
+| `INSPECT_FLOW_STORE_FILTER`           | `--store-filter`           | Registered log filter name to apply when matching logs from the store |
 | `INSPECT_FLOW_LIMIT`                  | `--limit`                  | Limit number of samples                                  |
 | `INSPECT_FLOW_SET`                    | `--set`                    | Set config overrides (can be specified multiple times)   |
 | `INSPECT_FLOW_ARG`                    | `--arg`                    | Args to pass to spec functions in the config file (can be multiple)      |
@@ -355,4 +362,4 @@ flow config config.py
 flow run config.py --dry-run
 ```
 
-The `flow config` command quickly displays the expanded configuration as YAML. The `--dry-run` flag performs the full setup process—instantiating tasks from the registry and checking for existing logs—showing exactly which tasks would run and which logs would be reused, but stops before actually running the evaluations.
+The `flow config` command quickly displays the expanded configuration as YAML. The `--dry-run` flag performs the full setup process—instantiating tasks from the registry and checking for existing logs in the log directory (and the Flow Store if `--store-read` is enabled)—showing exactly which tasks would run and which logs would be reused, but stops before actually running the evaluations.

--- a/docs/flow_concepts.qmd
+++ b/docs/flow_concepts.qmd
@@ -66,7 +66,7 @@ flow run first_config.py --venv
 **What happens when you run this (default in-process mode)?**
 
 1.  Flow loads the `gpqa_diamond` task from the `inspect_evals` registry
-2.  Searches the Flow Store for existing logs to reuse (see [Flow Store](store.qmd))
+2.  Checks for existing logs to reuse in the log directory (and the [Flow Store](store.qmd) if `--store-read` is enabled)
 3.  Runs the evaluation with GPT-5 in the current Python process
 4.  Stores results in `logs/`
 
@@ -95,7 +95,7 @@ When using `--venv`, Flow additionally creates an isolated virtual environment, 
 | `env` | Environment variables to set when running tasks | `None` |
 | `options` | Runtime options passed to `eval_set` (see `FlowOptions` reference) | `None` |
 | `defaults` | Default values applied across tasks, models, solvers, and agents (see [Defaults](defaults.qmd) and `FlowDefaults` reference) | `None` |
-| `store` | Flow Store location for tracking and reusing logs across runs. Set to `None` to disable. See [Flow Store](store.qmd) | `"auto"` |
+| `store` | Flow Store configuration for indexing and reusing logs across runs. Accepts a path string, `FlowStoreConfig`, or `None` to disable. `"auto"` uses the platform-specific [default location](store.qmd#backend). See [Flow Store](store.qmd) | `"auto"` |
 | `flow_metadata` | Metadata stored in the flow config (not passed to Inspect AI, see [flow_metadata](advanced.qmd#flow_metadata-flow-only-metadata)) | `None` |
 
 ## Tasks

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -11,7 +11,7 @@ Inspect Flow is a workflow orchestration tool for [Inspect AI](https://inspect.a
 **Why Inspect Flow?** As evaluation workflows grow in complexity—running multiple tasks across different models with varying parameters—managing these experiments becomes challenging. Inspect Flow addresses this by providing:
 
 1.  [**Declarative Configuration**](flow_concepts.qmd): Define complex evaluations with tasks, models, and parameters in type-safe schemas
-2.  [**Global Log Reuse**](store.qmd): Flow Store tracks and reuses past evaluation logs, so you only run what's new or changed
+2.  [**Global Log Reuse**](store.qmd): Flow Store indexes evaluation logs and enables cross-directory reuse, so you only run what's new or changed
 3.  [**Powerful Defaults**](defaults.qmd): Define defaults once and reuse them everywhere with automatic inheritance
 4.  [**Parameter Sweeping**](matrix.qmd): Matrix patterns for systematic exploration across tasks, models, and hyperparameters
 
@@ -186,7 +186,7 @@ inspect view --log-dir logs
 See the following articles to learn more about using Flow:
 
 -   [Flow Concepts](flow_concepts.qmd): Flow type system, config structure and basics.
--   [Flow Store](store.qmd): How Flow tracks and reuses evaluation logs across runs—automatically skipping redundant work.
+-   [Flow Store](store.qmd): How Flow indexes evaluation logs and enables cross-directory reuse across runs.
 -   [Defaults](defaults.qmd): Define defaults once and reuse them everywhere with automatic inheritance.
 -   [Matrixing](matrix.qmd): Systematic parameter exploration with matrix and with functions.
 -   [Reference](reference/index.qmd): Detailed documentation on the Flow Python API and CLI commands.

--- a/docs/matrix.qmd
+++ b/docs/matrix.qmd
@@ -185,7 +185,7 @@ Results in 3 × 4 × 5 × 3 = **180 evaluations**.
 
 Always preview with `--dry-run` to check the number of evaluations before running expensive grids.
 
-The [Flow Store](store.qmd) helps by automatically reusing logs from previous runs, so re-running a large sweep only evaluates what's new or changed.
+The [Flow Store](store.qmd) indexes logs from every run. With `--store-read` enabled, re-running a large sweep only evaluates what's new or changed.
 :::
 
 ## Matrix Merge

--- a/docs/run.qmd
+++ b/docs/run.qmd
@@ -23,10 +23,10 @@ flow run config.yaml
 
 1.  Flow loads your configuration file
 2.  Resolves all defaults and matrix expansions
-3.  Searches the Flow Store for existing logs to reuse
+3.  Checks for existing logs in the log directory (and the [Flow Store](store.qmd) if `--store-read` is enabled)
 4.  Executes evaluations via Inspect AI's `eval_set()` in the current Python process
 5.  Stores logs in `log_dir`
-6.  Adds logs to the Flow Store and generates `flow-requirements.txt`
+6.  Indexes logs in the [Flow Store](store.qmd) and generates `flow-requirements.txt`
 
 ::: callout-tip
 ### Virtual Environment Mode
@@ -52,7 +52,7 @@ Performs the full setup process and shows what would run:
 
 - Applies all defaults and expands all matrix functions
 - Instantiates tasks from the registry
-- Checks for existing logs (in log directory and Flow Store)
+- Checks for existing logs in the log directory (and the Flow Store if `--store-read` is enabled)
 - Shows which tasks would run and which logs would be reused
 - Stops before actually running evaluations
 
@@ -159,7 +159,7 @@ logs/
 -   The `eval-set.json` file contains eval set metadata
 
 ::: callout-note
-Logs in this directory are automatically tracked by the [Flow Store](store.qmd), enabling log reuse across future runs.
+Logs in this directory are indexed in the [Flow Store](store.qmd), enabling log reuse across future runs when `--store-read` is enabled.
 :::
 
 **Log formats:**

--- a/docs/store.qmd
+++ b/docs/store.qmd
@@ -3,27 +3,44 @@ title: "Flow Store"
 tbl-colwidths: [30,70]
 ---
 
-The Flow Store automatically skips redundant evaluations by tracking which logs you've already completed—across directories, projects, and even team members.
-
-The Flow Store is a **centralized registry of evaluation log file paths** that enables **global log reuse across Flow runs**.
+The Flow Store is a **centralized registry of evaluation log file paths** that tracks your completed evaluations and enables **log reuse across directories, projects, and team members**.
 
 ::: callout-note
 Unlike Inspect AI's [Eval Set](https://inspect.aisi.org.uk/eval-sets.html) which only reuses logs from the same log directory, the Flow Store indexes logs from multiple locations and makes them available for reuse across any Flow run.
 :::
 
-## Basics
+## How It Works
 
-The Flow Store is enabled by default and requires zero configuration. On your first run, the Flow Store is automatically created in the background. When you run an evaluation, Flow automatically:
+The Flow Store has two independent capabilities: **log indexing** (writing to the store) and **log matching** (reading from the store). By default, indexing is on and matching is off — you opt into matching when you want cross-directory log reuse.
+
+### Log Indexing
+
+Log indexing is **on by default** and requires zero configuration. After each `flow run`, Flow automatically adds your completed logs to the Flow Store. This builds up a registry of all your evaluations over time, ready for reuse when you need it.
+
+On your first run, the Flow Store is automatically created in the background at the [default location](#backend).
+
+### Log Matching {#log-matching}
+
+Log matching is **off by default**. Enable it with `--store-read` to reuse logs from across directories and projects:
+
+```bash
+flow run config.py --store-read
+```
+
+When log matching is enabled, Flow:
 
 1. **Searches the Flow Store** for logs matching your task (based on task configuration)
 2. **Selects the best log** (most completed samples, then most recent)
 3. **Copies it to your log directory** for Inspect AI's Eval Set to reuse
 4. **Resumes incomplete logs** by only running missing samples
-5. **Adds the final log** back to the Flow Store after completion
 
-### Example
+::: {.callout-note}
+Even without `--store-read`, Inspect AI's Eval Set still reuses logs already present in your `log_dir`. Store matching adds cross-directory reuse on top of that.
+:::
 
-Let's walk through a concrete example showing how the Flow Store automatically tracks and reuses logs across multiple runs.
+#### Example
+
+Let's walk through a concrete example showing how the Flow Store tracks and reuses logs across runs.
 
 **Run 1: Initial evaluation**
 
@@ -37,12 +54,11 @@ Start with a simple configuration evaluating one model:
 
 When you run `flow run config.py`, Flow:
 
-1. Searches the Flow Store for existing logs (none found)
-2. Runs the evaluation
-3. Saves logs to `project-1/`
-4. Adds to Flow Store: `project-1/2026-01-31T15-55_gpqa-diamond_ABCeD.eval`
+1. Runs the evaluation
+2. Saves logs to `project-1/`
+3. Indexes the log in the Flow Store: `project-1/2026-01-31T15-55_gpqa-diamond_ABCeD.eval`
 
-**Run 2: Modified configuration**
+**Run 2: Cross-directory reuse**
 
 Now modify your config to use a new log directory and add a second model:
 
@@ -69,20 +85,25 @@ FlowSpec(
 2. Same task from Run 1 (gpt-4o on gpqa_diamond)
 3. New task (gpt-5 on gpqa_diamond)
 
-When you run `flow run config.py` again, Flow:
+Since you're using a new log directory with no existing logs, enable store matching to reuse Run 1's results:
 
-1. Searches the Flow Store for existing logs matching your tasks
-2. Finds Run 1's gpt-4o log from `project-1/`
-3. Copies it to `project-2/` for reuse
-4. Skips re-evaluating gpt-4o (already complete)
-5. Only evaluates the new gpt-5 task
-6. Saves both logs to `project-2/`
-7. Updates Flow Store with both log paths
+```bash
+flow run config.py --store-read
+```
+
+Flow:
+
+1. Searches the Flow Store and finds Run 1's gpt-4o log from `project-1/`
+2. Copies it to `project-2/` for reuse
+3. Skips re-evaluating gpt-4o (already complete)
+4. Only evaluates the new gpt-5 task
+5. Saves both logs to `project-2/`
+6. Indexes both log paths in the Flow Store
 
 **Result:** The second run completes much faster by reusing the gpt-4o evaluation from Run 1.
 
 ::: {.callout-note}
-If Run 1 was interrupted with only 80/100 samples completed, Run 2 would automatically resume from where it left off and only evaluate the remaining 20 samples for gpt-4o.
+If Run 1 was interrupted with only 80/100 samples completed, Run 2 would copy the partial log and automatically resume from where it left off, only evaluating the remaining 20 samples for gpt-4o.
 :::
 
 ## Backend
@@ -103,9 +124,48 @@ C:\Users\<username>\AppData\Local\inspect_flow  # Windows
 
 ## Configuration
 
+### Read and write control
+
+Log indexing (write) and log matching (read) are controlled independently via CLI flags or `FlowStoreConfig`:
+
+**CLI flags:**
+
+```bash
+--store-read / --no-store-read    # Match logs from the store (default: --no-store-read)
+--store-write / --no-store-write  # Index completed logs in the store (default: --store-write)
+```
+
+**FlowSpec:**
+
+```python
+from inspect_flow import FlowSpec, FlowStoreConfig
+
+FlowSpec(
+    store=FlowStoreConfig(
+        read=True,   # match logs from the store (default: False)
+        write=True,  # index completed logs (default: True)
+    ),
+    tasks=[...]
+)
+```
+
+CLI flags override `FlowStoreConfig` values. Here's how the flags combine:
+
+: {tbl-colwidths="[60,20,20]"}
+
+| Command | Store read | Store write |
+|---|---|---|
+| `flow run spec.py` | no | yes |
+| `flow run spec.py --store-read` | yes | yes |
+| `flow run spec.py --no-store-write` | no | no |
+| `flow run spec.py --store-read --no-store-write` | yes | no |
+| `flow run spec.py --store none` | no | no |
+
+`--store none` disables the store entirely — no store instance is created, and neither reading nor writing occurs.
+
 ### Setting store location
 
-By default, Flow uses the platform-specific store location shown in [Backend](#backend) to search for and track logs. You can configure which store to use for the `flow run` command with the following precedence:
+By default, Flow uses the platform-specific store location shown in [Backend](#backend) to index and match logs. You can configure which store to use for the `flow run` command with the following precedence:
 
 1. **CLI flag or environment variable** (highest priority):
 ```bash
@@ -140,7 +200,9 @@ FlowSpec(
 )
 ```
 
-This prevents automatic log reuse and Flow Store operations.
+This prevents all Flow Store operations — no logs are indexed or matched.
+
+To disable only matching or only indexing while keeping the other, use the `read` and `write` flags instead (see [Read and write control](#read-and-write-control)).
 
 ### Team collaboration
 
@@ -150,26 +212,22 @@ Set up a shared store on S3 for team collaboration:
 
 ```python
 FlowSpec(
-    store="s3://my-team-bucket/flow-store",
+    store=FlowStoreConfig(
+        path="s3://my-team-bucket/flow-store",
+        read=True,
+    ),
     tasks=[...]
 )
 ```
 
-Team members with access to the S3 bucket can share and reuse logs. Delta Lake supports concurrent access, so multiple team members can safely use the same store simultaneously. See [Inspect AI's S3 documentation](https://inspect.aisi.org.uk/eval-logs.html#sec-amazon-s3) for S3 authentication setup.
+With `read=True`, team members reuse each other's logs automatically. Delta Lake supports concurrent access, so multiple team members can safely use the same store simultaneously. See [Inspect AI's S3 documentation](https://inspect.aisi.org.uk/eval-logs.html#sec-amazon-s3) for S3 authentication setup.
 
 ::: {.callout-tip}
 ## Recommended workflows
 
-**Master FlowSpec approach:** Create a `_flow.py` file at your repository root with the team store location:
+**Master FlowSpec approach:** Create a `_flow.py` file at your repository root with the team store location and `read=True`:
 
-```python
-# _flow.py (at repository root)
-FlowSpec(
-    store="s3://my-team-bucket/flow-store"
-)
-```
-
-Flow automatically discovers and inherits from `_flow.py` files in parent directories, so all team members working in the repository will automatically use the shared store—no explicit includes needed. See [Automatic Discovery](defaults.qmd#inheritance) for details on how `_flow.py` inheritance works.
+Flow automatically discovers and inherits from `_flow.py` files in parent directories, so all team members working in the repository will inherit the shared store configuration — including `read=True` for log matching. No explicit includes needed. See [Automatic Discovery](defaults.qmd#inheritance) for details on how `_flow.py` inheritance works.
 
 **Local-then-import approach:** Run evaluations locally first, then import quality-assured logs to the shared store:
 
@@ -400,7 +458,7 @@ flow store delete -y
 
 ### Matching logs
 
-The Flow Store matches logs using a **task identifier** computed by Inspect AI. This identifier is a hash of your task configuration including:
+When [log matching](#log-matching) is enabled, the Flow Store matches logs using a **task identifier** computed by Inspect AI. This identifier is a hash of your task configuration including:
 
 - Task name, model, solver, scorer, and task arguments
 - Model configuration (temperature, top_p, max_tokens, seed, etc.)
@@ -419,7 +477,7 @@ Note that `limit`, `sample_shuffle`, retry parameters, and parallelism settings 
 
 ### Resuming incomplete samples
 
-Flow uses Inspect AI's [Eval Set](https://inspect.aisi.org.uk/eval-sets.html#sec-sample-preservation) logic to resume incomplete logs. When the Flow Store finds a matching log, Flow copies it to your current log directory where Inspect's eval_set automatically resumes from it.
+Flow uses Inspect AI's [Eval Set](https://inspect.aisi.org.uk/eval-sets.html#sec-sample-preservation) logic to resume incomplete logs. When log matching is enabled and the Flow Store finds a matching log, Flow copies it to your current log directory where Inspect's eval_set automatically resumes from it. Logs already present in your `log_dir` are always resumed regardless of store settings.
 
 **Sample matching**: For resumption to work, Inspect must match samples from the old log to the current run using sample IDs. There are two approaches:
 

--- a/src/inspect_flow/_cli/options.py
+++ b/src/inspect_flow/_cli/options.py
@@ -114,19 +114,19 @@ def config_options(f: F) -> F:
         "--store-filter",
         type=str,
         default=None,
-        help="Log filter to apply when searching the store for existing logs. Accepts a registered name, file.py@name, or a name defined in _flow.py.",
+        help="Log filter to apply when searching the store for existing logs. Accepts a registered name, `file.py@name`, or a name defined in `_flow.py`.",
         envvar="INSPECT_FLOW_STORE_FILTER",
     )(f)
     f = click.option(
         "--store-read/--no-store-read",
         default=None,
-        help="Read existing logs from the store (default: --no-store-read).",
+        help="Read existing logs from the store (default: `--no-store-read`).",
         envvar="INSPECT_FLOW_STORE_READ",
     )(f)
     f = click.option(
         "--store-write/--no-store-write",
         default=None,
-        help="Write completed logs to the store (default: --store-write).",
+        help="Write completed logs to the store (default: `--store-write`).",
         envvar="INSPECT_FLOW_STORE_WRITE",
     )(f)
     f = click.option(


### PR DESCRIPTION
- Update documentation to reflect that store read (log matching) is now off by default (#585)
- Restructure `store.qmd` around the two independent capabilities: log indexing (write, on by default) and log matching (read, opt-in)
- Add new "Read and Write Control" section with CLI flags, `FlowStoreConfig` examples, and behavior matrix
- Update all docs (`run.qmd`, `flow_concepts.qmd`, `index.qmd`, `defaults.qmd`, `matrix.qmd`) to qualify store matching as opt-in
- Update team collaboration examples to use `FlowStoreConfig(read=True)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)