### PR TITLE
docs: update docs for PRs #592, #593

### DIFF
--- a/docs/defaults.qmd
+++ b/docs/defaults.qmd
@@ -311,7 +311,7 @@ flow run config.py
 | `INSPECT_FLOW_STORE`                  | `--store`                  | Path to Flow Store directory. Use `auto` for default location, `none` to disable |
 | `INSPECT_FLOW_STORE_READ`             | `--store-read`             | Match existing logs from the store (default: off) |
 | `INSPECT_FLOW_STORE_WRITE`            | `--store-write`            | Index completed logs in the store (default: on) |
-| `INSPECT_FLOW_STORE_FILTER`           | `--store-filter`           | Registered log filter name to apply when matching logs from the store |
+| `INSPECT_FLOW_STORE_FILTER`           | `--store-filter`           | Registered log filter name to apply when matching logs from the store. Space-separate multiple names (all must pass) |
 | `INSPECT_FLOW_LIMIT`                  | `--limit`                  | Limit number of samples                                  |
 | `INSPECT_FLOW_SET`                    | `--set`                    | Set config overrides (can be specified multiple times)   |
 | `INSPECT_FLOW_ARG`                    | `--arg`                    | Args to pass to spec functions in the config file (can be multiple)      |

--- a/docs/flow_concepts.qmd
+++ b/docs/flow_concepts.qmd
@@ -198,9 +198,10 @@ FlowTask(
     args={"subject": "physics"},        # <6>
     sandbox="docker",                   # <7>
     sample_id=[0, 1, 2],                # <8>
-    extra_args=FlowExtraArgs(           # <9>
-        solver={"max_attempts": 3}      # <9>
-    ),                                  # <9>
+    tags=["safety-testing"],            # <9>
+    extra_args=FlowExtraArgs(           # <10>
+        solver={"max_attempts": 3}      # <10>
+    ),                                  # <10>
 )
 ```
 
@@ -220,7 +221,9 @@ FlowTask(
 
 8.  **Sample selection** — Evaluate specific samples from the dataset. Accepts a single ID (`sample_id=0`), list of IDs (`sample_id=[0, 1, 2]`), or list of string IDs.
 
-9.  **Extra arguments** — Additional arguments to pass when creating Inspect AI objects (models, solvers, agents, scorers) for this specific task. Useful for per-task customization, such as providing different tools to an agent depending on the task. Values in `extra_args` override any args specified in the object's own `args` field.
+9.  **Tags** — Maps to Inspect AI `Task.tags`. A list of string tags to associate with the task, useful for categorizing and filtering evaluations.
+
+10.  **Extra arguments** — Additional arguments to pass when creating Inspect AI objects (models, solvers, agents, scorers) for this specific task. Useful for per-task customization, such as providing different tools to an agent depending on the task. Values in `extra_args` override any args specified in the object's own `args` field.
 
 ## Models
 

--- a/docs/store.qmd
+++ b/docs/store.qmd
@@ -246,7 +246,7 @@ This workflow lets you validate results before sharing them with the team.
 
 ## Filtering
 
-You can filter which logs are eligible for reuse by providing a log filter. A log filter is a function that receives an `EvalLog` (loaded in header-only mode) and returns `True` to include the log or `False` to exclude it.
+You can filter which logs are eligible for reuse by providing one or more log filters. A log filter is a function that receives an `EvalLog` (loaded in header-only mode) and returns `True` to include the log or `False` to exclude it. When multiple filters are provided, all must pass for a log to be included.
 
 ### Defining a filter
 
@@ -271,16 +271,17 @@ from inspect_flow import FlowSpec, FlowStoreConfig
 FlowSpec(
     store=FlowStoreConfig(
         path="auto",
-        filter=production_ready,  # callable or registered name
+        filter=production_ready,  # callable, registered name, or list
     ),
     tasks=[...]
 )
 ```
 
-**From the CLI** — use `--store-filter` with a registered filter name:
+**From the CLI** — use `--store-filter` with a registered filter name. Use it multiple times to require all filters to pass:
 
 ```bash
 flow run config.py --store-filter production_ready
+flow run config.py --store-filter production_ready --store-filter only_success
 ```
 
 The CLI flag overrides any filter set in the spec's `FlowStoreConfig`.
@@ -292,6 +293,9 @@ The `flow store list`, `flow store remove`, and `flow list log` commands support
 ```bash
 # Only show logs that pass the filter
 flow store list --filter production_ready
+
+# Multiple filters (all must pass)
+flow store list --filter production_ready --filter only_success
 
 # Only show logs that do NOT pass the filter
 flow store list --exclude production_ready
@@ -394,7 +398,7 @@ flow store remove logs/old/ --dry-run
 - `INSPECT_FLOW_STORE_RECURSIVE` - Enable recursive search (`true`/`false`)
 - `INSPECT_FLOW_STORE_REMOVE_MISSING` - Remove missing logs (`true`/`false`)
 - `INSPECT_FLOW_STORE_REMOVE_DRY_RUN` - Enable dry run mode (`true`/`false`)
-- `INSPECT_FLOW_STORE_FILTER` - Registered filter name; only remove logs that pass (`--filter`)
+- `INSPECT_FLOW_STORE_FILTER` - Registered filter name; only remove logs that pass (`--filter`). Space-separate multiple names (all must pass)
 - `INSPECT_FLOW_STORE_EXCLUDE` - Registered filter name; only remove logs that do NOT pass (`--exclude`)
 
 ### The `flow store list` Command
@@ -415,7 +419,7 @@ flow store list --format tree
 
 - `INSPECT_FLOW_STORE` - Store location (same as `--store`)
 - `INSPECT_FLOW_STORE_LIST_FORMAT` - Output format (`flat` or `tree`)
-- `INSPECT_FLOW_STORE_FILTER` - Registered filter name; only show logs that pass (`--filter`)
+- `INSPECT_FLOW_STORE_FILTER` - Registered filter name; only show logs that pass (`--filter`). Space-separate multiple names (all must pass)
 - `INSPECT_FLOW_STORE_EXCLUDE` - Registered filter name; only show logs that do NOT pass (`--exclude`)
 
 ::: {.callout-tip}


### PR DESCRIPTION
- Document multiple log filter support (PR #592): `FlowStoreConfig.filter` accepts a list, `--store-filter`/`--filter` can be repeated, env vars support space-separated names
- Document `tags` field on `FlowTask` (PR #593): added to `flow_concepts.qmd` configuration example and numbered list