### PR TITLE
feat: add ability to reference python constants in _flow.py form the CLI

### DIFF
--- a/src/inspect_flow/_cli/constants.py
+++ b/src/inspect_flow/_cli/constants.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import ModuleType
+
+import click
+from inspect_ai._util.module import load_module
+
+from inspect_flow._util.path_util import find_auto_includes
+
+
+def _is_constant_name(name: str) -> bool:
+    return bool(name) and not name.startswith("_") and name.isupper()
+
+
+def _module_constants(module: ModuleType) -> dict[str, str]:
+    return {
+        name: value
+        for name, value in vars(module).items()
+        if _is_constant_name(name) and isinstance(value, str)
+    }
+
+
+def _discover_constants() -> dict[str, list[tuple[str, str]]]:
+    result: dict[str, list[tuple[str, str]]] = {}
+    for flow_file in find_auto_includes(str(Path.cwd())):
+        module = load_module(Path(flow_file))
+        if module is None:
+            continue
+        for name, value in _module_constants(module).items():
+            result.setdefault(name, []).append((flow_file, value))
+    return result
+
+
+def _discover_constants_from_file(file_path: str) -> dict[str, str]:
+    path = Path(file_path)
+    if not path.is_absolute():
+        path = Path.cwd() / path
+    path = path.resolve()
+    if not path.exists():
+        raise click.BadParameter(f"File not found: {file_path}")
+    module = load_module(path)
+    if module is None:
+        return {}
+    return _module_constants(module)
+
+
+def _resolve_token(
+    token: str,
+    global_constants: dict[str, list[tuple[str, str]]] | None,
+) -> str:
+    if not token.startswith("@"):
+        return token
+    body = token[1:]
+    if "@" in body:
+        file_path, name = body.rsplit("@", 1)
+        constants = _discover_constants_from_file(file_path)
+        if name not in constants:
+            raise click.BadParameter(f"Constant '{name}' not found in {file_path}.")
+        return constants[name]
+    if global_constants is None:
+        global_constants = _discover_constants()
+    entries = global_constants.get(body)
+    if not entries:
+        raise click.BadParameter(
+            f"Constant '{body}' not found in any _flow.py. "
+            f"Define it as an UPPERCASE module-level string."
+        )
+    values = {v for _, v in entries}
+    if len(values) > 1:
+        files = ", ".join(f for f, _ in entries)
+        raise click.BadParameter(
+            f"Constant '{body}' is defined in multiple files with "
+            f"different values: {files}. Use file.py@{body} to disambiguate."
+        )
+    return entries[0][1]
+
+
+def resolve_tokens(args: list[str]) -> list[str]:
+    """Resolve @NAME and @file.py@NAME tokens in a list of CLI args.
+
+    Tokens not starting with `@` are returned unchanged. Raises
+    click.BadParameter on missing name or on collision (same name defined
+    in multiple _flow.py files with different values).
+    """
+    needs_global = any(a.startswith("@") and "@" not in a[1:] for a in args)
+    global_constants = _discover_constants() if needs_global else None
+    return [_resolve_token(a, global_constants) for a in args]

--- a/src/inspect_flow/_cli/main.py
+++ b/src/inspect_flow/_cli/main.py
@@ -5,6 +5,7 @@ from dotenv import find_dotenv, load_dotenv
 
 from inspect_flow._cli.check import check_command
 from inspect_flow._cli.config import config_command
+from inspect_flow._cli.constants import resolve_tokens
 from inspect_flow._cli.list import list_command
 from inspect_flow._cli.step import step_command
 from inspect_flow._cli.store import store_command
@@ -15,7 +16,17 @@ from .. import __version__
 from .run import run_command
 
 
-@click.group(invoke_without_command=True, context_settings={"max_content_width": 120})
+class FlowGroup(click.Group):
+    def parse_args(self, ctx: click.Context, args: list[str]) -> list[str]:
+        args = resolve_tokens(args)
+        return super().parse_args(ctx, args)
+
+
+@click.group(
+    cls=FlowGroup,
+    invoke_without_command=True,
+    context_settings={"max_content_width": 120},
+)
 @click.option(
     "--version",
     type=bool,

--- a/src/inspect_flow/_config/load.py
+++ b/src/inspect_flow/_config/load.py
@@ -59,7 +59,7 @@ def int_load_spec(file: str, options: ConfigOptions) -> FlowSpec:
         file = absolute_file_path(file)
         spec = _load_spec_from_file(file, args=options.args, state=state)
         if spec is None:
-            raise ValueError(f"No value returned from Python config file: {file}")
+            raise ValueError(f"No FlowSpec returned from Python config file: {file}")
 
         base_dir = Path(file).parent.as_posix()
         spec = expand_spec(spec, base_dir=base_dir, options=options, state=state)
@@ -247,20 +247,16 @@ def _load_spec_from_file(
         with file(config_file, "r") as f:
             if config_path.suffix == ".py":
                 spec, globals = execute_file_and_get_last_result(config_file, args=args)
-                if spec is None or isinstance(spec, FlowSpec):
-                    state.files_to_specs[config_file] = spec
-                    state.after_flow_spec_loaded_funcs.extend(
-                        [
-                            v
-                            for v in globals.values()
-                            if hasattr(v, INSPECT_FLOW_AFTER_LOAD_ATTR)
-                        ]
-                    )
-
-                else:
-                    raise TypeError(
-                        f"Expected FlowSpec from Python config file, got {type(spec)}"
-                    )
+                if not isinstance(spec, FlowSpec):
+                    spec = None
+                state.files_to_specs[config_file] = spec
+                state.after_flow_spec_loaded_funcs.extend(
+                    [
+                        v
+                        for v in globals.values()
+                        if hasattr(v, INSPECT_FLOW_AFTER_LOAD_ATTR)
+                    ]
+                )
             else:
                 if config_path.suffix in [".yaml", ".yml"]:
                     data = yaml.safe_load(f)

--- a/tests/config/constants/_flow.py
+++ b/tests/config/constants/_flow.py
@@ -1,0 +1,9 @@
+TAG_QA_NEEDED = "qa_auto_needed"
+LOG_DIR_DEV = "s3://dev/logs"
+SHARED_SAME = "shared_value"
+
+_PRIVATE = "private"
+lower_case = "lower"
+MixedCase = "mixed"
+INTEGER = 42
+STRING_LIST = ["not", "a", "string"]

--- a/tests/config/constants/explicit_module.py
+++ b/tests/config/constants/explicit_module.py
@@ -1,0 +1,1 @@
+FROM_FILE = "from_file_value"

--- a/tests/config/constants/other_flow.py
+++ b/tests/config/constants/other_flow.py
@@ -1,0 +1,6 @@
+from inspect_flow import FlowOptions, FlowSpec, FlowTask
+
+FlowSpec(
+    options=FlowOptions(limit=1),
+    tasks=[FlowTask(name="inspect_evals/mmlu_0_shot", model="openai/gpt-4o-mini")],
+)

--- a/tests/config/constants/sub/_flow.py
+++ b/tests/config/constants/sub/_flow.py
@@ -1,0 +1,3 @@
+TAG_QA_NEEDED = "override_value"
+SUB_ONLY = "sub_only_value"
+SHARED_SAME = "shared_value"

--- a/tests/test_cli_constants.py
+++ b/tests/test_cli_constants.py
@@ -1,0 +1,135 @@
+import click
+import pytest
+from click.testing import CliRunner
+from inspect_flow._cli.constants import resolve_tokens
+from inspect_flow._cli.main import flow
+
+FIXTURES = "tests/config/constants"
+
+
+def test_passthrough_non_at_tokens(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(FIXTURES)
+    assert resolve_tokens(["run", "--flag", "s3://logs"]) == [
+        "run",
+        "--flag",
+        "s3://logs",
+    ]
+
+
+def test_no_discovery_when_no_at_tokens(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No _flow.py load happens when no @ token is present."""
+    monkeypatch.chdir(FIXTURES)
+    import inspect_flow._cli.constants as mod
+
+    called = False
+
+    def _boom() -> dict[str, list[tuple[str, str]]]:
+        nonlocal called
+        called = True
+        return {}
+
+    monkeypatch.setattr(mod, "_discover_constants", _boom)
+    resolve_tokens(["--add", "plain", "s3://logs"])
+    assert called is False
+
+
+def test_resolve_bare_constant(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(FIXTURES)
+    assert resolve_tokens(["@LOG_DIR_DEV"]) == ["s3://dev/logs"]
+
+
+def test_resolve_unknown_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(FIXTURES)
+    with pytest.raises(click.BadParameter, match="UNKNOWN_CONSTANT"):
+        resolve_tokens(["@UNKNOWN_CONSTANT"])
+
+
+def test_collision_with_different_values_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(f"{FIXTURES}/sub")
+    with pytest.raises(click.BadParameter, match="multiple files"):
+        resolve_tokens(["@TAG_QA_NEEDED"])
+
+
+def test_collision_with_same_value_ok(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Same name in parent and child with same value is not an error."""
+    monkeypatch.chdir(f"{FIXTURES}/sub")
+    assert resolve_tokens(["@SHARED_SAME"]) == ["shared_value"]
+
+
+def test_parent_only_discovered_from_child(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Parent _flow.py constants are visible when cwd is a child dir."""
+    monkeypatch.chdir(f"{FIXTURES}/sub")
+    assert resolve_tokens(["@LOG_DIR_DEV"]) == ["s3://dev/logs"]
+
+
+def test_child_only_not_discovered_from_parent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Child _flow.py constants are NOT visible when cwd is the parent."""
+    monkeypatch.chdir(FIXTURES)
+    with pytest.raises(click.BadParameter, match="SUB_ONLY"):
+        resolve_tokens(["@SUB_ONLY"])
+
+
+def test_file_scope_resolves(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(FIXTURES)
+    assert resolve_tokens(["@explicit_module.py@FROM_FILE"]) == ["from_file_value"]
+
+
+def test_file_scope_unknown_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(FIXTURES)
+    with pytest.raises(click.BadParameter, match="NOT_DEFINED"):
+        resolve_tokens(["@explicit_module.py@NOT_DEFINED"])
+
+
+def test_file_scope_disambiguates_collision(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """file.py@NAME form bypasses the global collision check."""
+    monkeypatch.chdir(FIXTURES)
+    assert resolve_tokens(["@sub/_flow.py@TAG_QA_NEEDED"]) == ["override_value"]
+    assert resolve_tokens(["@_flow.py@TAG_QA_NEEDED"]) == ["qa_auto_needed"]
+
+
+def test_file_scope_missing_file_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(FIXTURES)
+    with pytest.raises(click.BadParameter, match="File not found"):
+        resolve_tokens(["@does_not_exist.py@X"])
+
+
+@pytest.mark.parametrize(
+    "token",
+    [
+        "@lower_case",
+        "@MixedCase",
+        "@_PRIVATE",
+        "@INTEGER",
+        "@STRING_LIST",
+    ],
+)
+def test_exclusions(token: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Lowercase, mixed-case, underscore-prefixed, and non-string values are excluded."""
+    monkeypatch.chdir(FIXTURES)
+    with pytest.raises(click.BadParameter, match="not found"):
+        resolve_tokens([token])
+
+
+def test_multiple_tokens_mixed(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(FIXTURES)
+    assert resolve_tokens(["--add", "@TAG_QA_NEEDED", "@LOG_DIR_DEV", "literal"]) == [
+        "--add",
+        "qa_auto_needed",
+        "s3://dev/logs",
+        "literal",
+    ]
+
+
+def test_cli_wiring_resolves_tokens(monkeypatch: pytest.MonkeyPatch) -> None:
+    """End-to-end: FlowGroup.parse_args runs resolve_tokens before Click parses."""
+    monkeypatch.chdir(FIXTURES)
+    runner = CliRunner()
+    result = runner.invoke(flow, ["step", "@UNDEFINED_IN_FIXTURES"])
+    assert result.exit_code != 0
+    assert "UNDEFINED_IN_FIXTURES" in str(result.output) + str(result.exception)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -435,6 +435,17 @@ def test_auto_include_two(recording_console: Console) -> None:
     assert "Applyingmultiple_flow.py.#2:" in out_normalized
 
 
+def test_auto_include_constants_only_flow() -> None:
+    """Auto-included _flow.py that contains only constants (no FlowSpec) should
+    not raise. Previously raised TypeError at load.py:261 because
+    execute_file_and_get_last_result returns the last constant value."""
+    spec = load_spec(
+        str(Path(__file__).parent / "config" / "constants" / "other_flow.py")
+    )
+    assert isinstance(spec.tasks, list)
+    assert len(spec.tasks) == 1
+
+
 def test_216_auto_include_from_sub_dir(monkeypatch: pytest.MonkeyPatch) -> None:
     flow_file = (
         Path(__file__).parent / "config" / "auto" / "sub" / "model_and_task_flow.py"
@@ -671,9 +682,8 @@ def test_unsupported_format() -> None:
 
 def test_not_flow_spec() -> None:
     config_path = str(Path(config_dir) / "not_flow.py")
-    with pytest.raises(TypeError) as e:
+    with pytest.raises(ValueError, match="No FlowSpec returned"):
         load_spec(config_path)
-    assert "got <class 'int'>" in str(e.value)
 
 
 def test_auto_include_protocol() -> None:


### PR DESCRIPTION
Fixes #657 

Support @CONST for module level consts in _flow.py or @file.py@CONST