### PR TITLE
docs: document @CONST CLI feature

### DIFF
--- a/docs/defaults.qmd
+++ b/docs/defaults.qmd
@@ -113,7 +113,7 @@ Inspect Flow supports configuration inheritance to share settings across multipl
 
 Inspect Flow automatically discovers and includes files named `_flow.py` in parent directories. Starting from your config file's location, it searches upward through the directory tree for `_flow.py` files and automatically merges them.
 
-This allows you to define shared defaults (model settings, dependencies, etc.) at a repository root that apply to all configs in subdirectories without explicit includes. These files also serve as discovery locations for [`@step`](steps.qmd) functions and [`@log_filter`](store.qmd#filtering) definitions.
+This allows you to define shared defaults (model settings, dependencies, etc.) at a repository root that apply to all configs in subdirectories without explicit includes. These files also serve as discovery locations for [`@step`](steps.qmd) functions, [`@log_filter`](store.qmd#filtering) definitions, and [string constants](steps.qmd#referencing-constants) referenced from CLI args.
 
 ::: callout-note
 When using `run()` from the Python API to run the `FlowSpec` directly instead of the command line, the `base_dir` argument is used as the starting point for searching upward through the directory tree, rather than the config file's location.

--- a/docs/steps.qmd
+++ b/docs/steps.qmd
@@ -159,6 +159,43 @@ For team workflows, import your steps in a `_flow.py` at the repository root so 
 from my_project.steps import promote, review_scores  # noqa: F401
 ```
 
+## Referencing Constants {#referencing-constants}
+
+Define module-level string constants in your `_flow.py` and reference them from any `flow` CLI command with `@NAME`. This lets you share the same tag values, log directories, and other strings across commands and teammates without retyping them — and without worrying about typos drifting them apart over time.
+
+``` {.python filename="_flow.py"}
+LOG_DIR_DEV = "s3://my-bucket/dev/logs"
+LOG_DIR_PROD = "s3://my-bucket/prod/logs"
+TAG_QA_NEEDED = "qa_needed"
+```
+
+``` bash
+flow step tag @LOG_DIR_DEV --add @TAG_QA_NEEDED
+flow check spec.py --log-dir @LOG_DIR_DEV
+flow list log @LOG_DIR_DEV --tag @TAG_QA_NEEDED
+```
+
+This works for all `flow` subcommands — `run`, `check`, `step`, `list`, `config`, `store` — wherever you would otherwise type a literal string.
+
+### Discovery Rules
+
+Constants are discovered from `_flow.py` files walking up from your current directory (same [automatic discovery](defaults.qmd#automatic-discovery) as for defaults, steps, and filters). To be eligible, a name must be:
+
+- **UPPERCASE** (e.g. `LOG_DIR_DEV`, not `log_dir_dev` or `MixedCase`)
+- **String-valued** (lists, ints, and other types are skipped)
+- **Module-level** (not nested inside a class or function)
+- **Public** (no leading underscore)
+
+If the same name is defined in multiple `_flow.py` files with **different** values, resolution fails and asks you to disambiguate. Identical values across files are fine.
+
+### Disambiguating
+
+Use `@file.py@NAME` to resolve from a specific file, bypassing the global lookup and the collision check:
+
+``` bash
+flow step tag logs/ --add @prod/_flow.py@TAG_QA_NEEDED
+```
+
 ## Filtering {#filtering}
 
 Use `@log_filter` to define named functions that select logs based on their properties:


### PR DESCRIPTION
- Adds a `## Referencing Constants` section to `docs/steps.qmd` documenting the `@NAME` / `@file.py@NAME` shorthand introduced in #674.
- Adds a one-phrase pointer from the `_flow.py` automatic-discovery paragraph in `docs/defaults.qmd` to the new section.