### PR TITLE
fix: `flow store list --display plain` outputs only log paths

### DIFF
--- a/src/inspect_flow/_cli/store.py
+++ b/src/inspect_flow/_cli/store.py
@@ -361,6 +361,7 @@ def store_list(
 ) -> None:
     assert format in ("flat", "tree")
     log_filter = _resolve_cli_filter(filter_name, exclude_name)
-    flow_store = init_store(**kwargs)
+    quiet = kwargs.get("display") == "plain"
+    flow_store = init_store(quiet=quiet, **kwargs)
     if flow_store:
         _echo_logs(flow_store, format=format, filter=log_filter)

--- a/src/inspect_flow/_store/deltalake.py
+++ b/src/inspect_flow/_store/deltalake.py
@@ -211,12 +211,12 @@ class DeltaLakeStore(FlowStoreInternal):
         self.exists = False
         found = [self._init_table(table, create=create) for table in TABLES]
         if any(found):
-            logger.debug("Using store: %s", path(store_path))
+            logger.info("Using store: %s", path(store_path))
             self.exists = True
         else:
-            logger.debug("Store not found")
+            logger.info("Store not found")
             if create:
-                logger.debug("Creating store: %s", path(store_path))
+                logger.info("Creating store: %s", path(store_path))
                 self.exists = True
 
     def _filter_logs(self, logs: set[str], filter: LogFilter | None) -> set[str]:
@@ -287,11 +287,11 @@ class DeltaLakeStore(FlowStoreInternal):
     def _init_table(self, table: TableDef, create: bool) -> bool:
         table_path = self._table_path(table.name)
         if dt := self._get_table(table_path):
-            logger.debug(f"Existing table: {table_path}")
+            logger.info(f"Existing table: {table_path}")
             _check_table_description(table, dt.metadata().description)
             return True
         elif create:
-            logger.debug(f"Creating table: {table_path}")
+            logger.info(f"Creating table: {table_path}")
             fs = filesystem(table_path)
             # Create _store_path first to make it less likely to need to create an s3 bucket, which can cause errors
             fs.mkdir(self._store_path, exist_ok=True)

--- a/src/inspect_flow/_store/deltalake.py
+++ b/src/inspect_flow/_store/deltalake.py
@@ -211,12 +211,12 @@ class DeltaLakeStore(FlowStoreInternal):
         self.exists = False
         found = [self._init_table(table, create=create) for table in TABLES]
         if any(found):
-            logger.info("Using store: %s", path(store_path))
+            logger.debug("Using store: %s", path(store_path))
             self.exists = True
         else:
-            logger.info("Store not found")
+            logger.debug("Store not found")
             if create:
-                logger.info("Creating store: %s", path(store_path))
+                logger.debug("Creating store: %s", path(store_path))
                 self.exists = True
 
     def _filter_logs(self, logs: set[str], filter: LogFilter | None) -> set[str]:
@@ -287,11 +287,11 @@ class DeltaLakeStore(FlowStoreInternal):
     def _init_table(self, table: TableDef, create: bool) -> bool:
         table_path = self._table_path(table.name)
         if dt := self._get_table(table_path):
-            logger.info(f"Existing table: {table_path}")
+            logger.debug(f"Existing table: {table_path}")
             _check_table_description(table, dt.metadata().description)
             return True
         elif create:
-            logger.info(f"Creating table: {table_path}")
+            logger.debug(f"Creating table: {table_path}")
             fs = filesystem(table_path)
             # Create _store_path first to make it less likely to need to create an s3 bucket, which can cause errors
             fs.mkdir(self._store_path, exist_ok=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,7 @@ from unittest.mock import MagicMock, patch
 import boto3
 import pytest
 from botocore.client import BaseClient
-from inspect_ai._util.logger import LogHandlerVar
+from inspect_ai._util.logger import LogHandlerVar, _logHandler
 from inspect_flow._util.constants import DEFAULT_LOG_LEVEL
 from inspect_flow._util.logging import init_flow_logging
 from rich.console import Console
@@ -33,9 +33,35 @@ def mock_call_arg(
 
 
 @pytest.fixture(autouse=True)
-def init_log_handler() -> None:
+def init_log_handler() -> Generator[None, None, None]:
+    # Snapshot logger handler state so a test calling `init_flow_logging` without
+    # an explicit `log_handler_var` can't permanently pollute global handlers
+    # (and their display levels) for subsequent tests.
+    import logging
+
+    saved_global = _logHandler["handler"]
+    saved_handlers = {
+        name: list(logging.getLogger(name).handlers)
+        for name in ("", "inspect_flow", "inspect_ai")
+    }
+    saved_levels = {
+        name: logging.getLogger(name).level
+        for name in ("", "inspect_flow", "inspect_ai")
+    }
+
     log_handler: LogHandlerVar = {"handler": None}
     init_flow_logging(log_level=DEFAULT_LOG_LEVEL, log_handler_var=log_handler)
+    # Route any in-test `init_flow_logging()` calls (which default to the global
+    # `_logHandler`) at this test's fresh handler so they no-op cleanly.
+    _logHandler["handler"] = log_handler["handler"]
+    try:
+        yield
+    finally:
+        _logHandler["handler"] = saved_global
+        for name, handlers in saved_handlers.items():
+            logging.getLogger(name).handlers = handlers
+        for name, level in saved_levels.items():
+            logging.getLogger(name).setLevel(level)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_store_cli.py
+++ b/tests/test_store_cli.py
@@ -138,6 +138,31 @@ def test_store_list_tree(recording_console: Console) -> None:
     assert "├" in captured or "└" in captured
 
 
+def test_store_list_plain_outputs_only_paths(recording_console: Console) -> None:
+    """`flow store list --display plain` should emit only log paths.
+
+    Regression test for https://github.com/meridianlabs-ai/inspect_flow/issues/683 —
+    the output must be pipeable to `xargs flow store import` without a
+    "Using store ..." preamble.
+    """
+    runner = CliRunner()
+    _import_logs(runner)
+    recording_console.export_text()  # discard import output
+
+    result = runner.invoke(
+        store_command, ["list", "--display", "plain"], catch_exceptions=False
+    )
+    assert result.exit_code == 0
+    captured = recording_console.export_text()
+
+    assert "Using store" not in captured
+
+    lines = [line for line in captured.splitlines() if line.strip()]
+    assert lines, "Expected at least one log path line"
+    for line in lines:
+        assert line.endswith(".eval"), f"Unexpected non-path line: {line!r}"
+
+
 def test_store_list_empty(recording_console: Console) -> None:
     runner = CliRunner()
     _import_logs(runner)


### PR DESCRIPTION
## Summary
- Suppress the "Using store ..." preamble when `flow store list --display plain` is used, so the output can be piped to `xargs flow store import` without filtering.
- Other display modes (`full`, `rich`) keep the preamble as helpful interactive context.

Closes #683.

## Test plan
- [x] New regression test `test_store_list_plain_outputs_only_paths` verifies the plain output contains no "Using store" line and every non-empty line is a `.eval` path.
- [x] Existing `test_store_list_flat` / `test_store_list_tree` still pass (preamble preserved for default `full` display).
- [x] `make check` passes (ruff + pyright).

🤖 Generated with [Claude Code](https://claude.com/claude-code)