### PR TITLE
fix: scout.yaml writes paths in a single consistent form (#686)

### DIFF
--- a/src/inspect_flow/_steps/scan.py
+++ b/src/inspect_flow/_steps/scan.py
@@ -9,7 +9,13 @@ from inspect_ai._cli.util import (
     parse_model_role_cli_args,
 )
 from inspect_ai._util.config import resolve_args
-from inspect_ai._util.file import dirname, file, filesystem
+from inspect_ai._util.file import (
+    absolute_file_path,
+    dirname,
+    file,
+    filesystem,
+    local_path,
+)
 from inspect_ai.log import EvalLog
 from inspect_ai.model import BatchConfig, CachePolicy, GenerateConfig
 from inspect_scout import (
@@ -48,6 +54,16 @@ ScannersSpec = (
     | ScanJobConfig
     | str
 )
+
+
+def _canonical_path(path: str) -> str:
+    """Canonical form for scout.yaml path values.
+
+    Local paths are returned as absolute paths without a file:// prefix; remote
+    paths (s3://, etc.) are returned unchanged. Keeps the two keys in scout.yaml
+    in a single consistent form.
+    """
+    return absolute_file_path(local_path(path))
 
 
 def _write_scout_project_file(*, scans: str, transcripts: str) -> None:
@@ -175,9 +191,8 @@ def scan(
                 "directories. Specify scans explicitly."
             )
     elif len(log_dirs) == 1:
-        log_dir = next(iter(log_dirs))
-        if scans is None:
-            scans = path_join(log_dir, "scans")
+        log_dir = _canonical_path(next(iter(log_dirs)))
+        scans = _canonical_path(scans) if scans else path_join(log_dir, "scans")
         _write_scout_project_file(scans=scans, transcripts=log_dir)
 
     parsed_validation = _parse_validation(validation) if validation else None

--- a/tests/test_steps.py
+++ b/tests/test_steps.py
@@ -964,8 +964,8 @@ def test_scan_writes_scout_project_file_for_bare_scans_path(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """When scans is a bare relative path (no parent dir, e.g. 'scan_dir'),
-    the scout.yaml should be written in the current working directory rather
-    than at the filesystem root."""
+    it should be resolved to an absolute path under the current working
+    directory before being written to scout.yaml."""
     from unittest.mock import patch
 
     import yaml
@@ -980,7 +980,10 @@ def test_scan_writes_scout_project_file_for_bare_scans_path(
     project_file = tmp_path / "scout.yaml"
     assert project_file.exists()
     project = yaml.safe_load(project_file.read_text())
-    assert project == {"transcripts": str(tmp_path), "scans": "scan_dir"}
+    assert project == {
+        "transcripts": str(tmp_path),
+        "scans": str(tmp_path / "scan_dir"),
+    }
 
 
 def test_scan_preserves_existing_scout_project_file(tmp_path: Path) -> None:
@@ -1001,6 +1004,60 @@ def test_scan_preserves_existing_scout_project_file(tmp_path: Path) -> None:
         scan([log], scanners=[], scans=scans_dir)
 
     assert project_file.read_text() == original
+
+
+def test_scan_scout_project_paths_consistent_when_location_is_file_uri(
+    tmp_path: Path,
+) -> None:
+    """scout.yaml paths should be plain absolute (no file://) regardless of
+    whether log.location includes a file:// prefix (e.g. when logs came via
+    list_eval_logs)."""
+    from unittest.mock import patch
+
+    import yaml
+    from inspect_ai.log import list_eval_logs
+    from inspect_flow._steps.scan import scan
+
+    _make_log(tmp_path)
+    # list_eval_logs returns names with file:// prefix on local filesystems
+    infos = list_eval_logs(str(tmp_path))
+    log = read_eval_log(infos[0].name)
+    assert log.location.startswith("file://")
+
+    scans_dir = str(tmp_path / "out" / "scans")
+    with patch("inspect_flow._steps.scan.scout_scan") as mock:
+        scan([log], scanners=[], scans=scans_dir)
+
+    project_file = tmp_path / "out" / "scout.yaml"
+    assert project_file.exists()
+    project = yaml.safe_load(project_file.read_text())
+    assert project == {"transcripts": str(tmp_path), "scans": scans_dir}
+    assert mock.call_args.kwargs["scans"] == scans_dir
+
+
+def test_scan_default_scans_absolute_when_location_is_file_uri(
+    tmp_path: Path,
+) -> None:
+    """When scans is None and log.location has file:// prefix, the inferred
+    scans path should be a plain absolute path (no file://)."""
+    from unittest.mock import patch
+
+    import yaml
+    from inspect_ai.log import list_eval_logs
+    from inspect_flow._steps.scan import scan
+
+    _make_log(tmp_path)
+    infos = list_eval_logs(str(tmp_path))
+    log = read_eval_log(infos[0].name)
+
+    with patch("inspect_flow._steps.scan.scout_scan") as mock:
+        scan([log], scanners=[])
+
+    expected_scans = str(tmp_path / "scans")
+    assert mock.call_args.kwargs["scans"] == expected_scans
+    project_file = tmp_path / "scout.yaml"
+    project = yaml.safe_load(project_file.read_text())
+    assert project == {"transcripts": str(tmp_path), "scans": expected_scans}
 
 
 def test_cli_scan_help_describes_default_scans() -> None:


### PR DESCRIPTION
## Summary
- Fixes #686: `scout.yaml` had inconsistent path styles — `scans` as a plain absolute path, `transcripts` as a `file://` URI (because it came from `dirname(log.location)`, and `log.location` carries `file://` when logs are enumerated via `list_eval_logs`).
- Added `_canonical_path()` in `_steps/scan.py` that strips `file://` and resolves to an absolute path for local paths; `s3://` and other URI schemes pass through unchanged. Applied to both the inferred `log_dir` and the user-supplied `scans` before they're written to `scout.yaml` and passed to `scout_scan`.

## Test plan
- [x] New `test_scan_scout_project_paths_consistent_when_location_is_file_uri` — reads logs via `list_eval_logs` (which produces `file://` locations) and asserts both keys are plain absolute paths.
- [x] New `test_scan_default_scans_absolute_when_location_is_file_uri` — same scenario for the `scans=None` inference path.
- [x] Updated `test_scan_writes_scout_project_file_for_bare_scans_path` to reflect the new behavior (bare relative paths resolve to absolute paths).
- [x] `make check` clean; full `tests/test_steps.py` passes (64/64).

🤖 Generated with [Claude Code](https://claude.com/claude-code)