### PR TITLE
docs: document flow step scan command

### DIFF
--- a/docs/reference/inspect_flow.api.qmd
+++ b/docs/reference/inspect_flow.api.qmd
@@ -18,6 +18,7 @@ description: Public API — run, check, steps, config, store helpers.
 ### tag
 ### metadata
 ### copy
+### scan
 ### FlowStore
 ### StepResult
 ### DisplayType

--- a/docs/steps.qmd
+++ b/docs/steps.qmd
@@ -1,10 +1,10 @@
 ---
 title: "Steps"
-llms-description: Post-evaluation workflows — tag, validate, copy, and promote logs with composable steps.
+llms-description: Post-evaluation workflows — tag, scan, validate, copy, and promote logs with composable steps.
 tbl-colwidths: [30,70]
 ---
 
-Steps are operations you run on evaluation logs *after* `flow run` completes. Use them to tag logs, set metadata, copy logs between directories, validate results, or compose these into multi-stage workflows like QA pipelines.
+Steps are operations you run on evaluation logs *after* `flow run` completes. Use them to tag logs, set metadata, copy logs between directories, scan transcripts, validate results, or compose these into multi-stage workflows like QA pipelines.
 
 ## The `flow step` Command
 
@@ -75,6 +75,20 @@ flow step copy logs/ --dest ./archive/ --source-prefix ./logs/
 
 Without `--source-prefix`, files are copied flat into the destination. With it, directory structure relative to the prefix is preserved. Use `--overwrite` to replace existing files. Use `--store` to add copied logs to the Flow Store index.
 
+### [**scan**](reference/inspect_flow.api.qmd#scan)
+
+Run Inspect Scout scanners against the transcripts of eval logs:
+
+``` bash
+flow step scan logs/ --scanners scanners.py
+flow step scan logs/ --scanners scanners.py --model openai/gpt-5
+flow step scan logs/ --scanners scanjob.yaml -S threshold=0.8
+```
+
+`--scanners` accepts a path to a Python or YAML file containing `@scanjob` or `@scanner` definitions (or, from the Python API, a `ScanJob`, `ScanJobConfig`, sequence, or dict of scanners). Scan results are written to `<log_dir>/scans` by default — set `--scans` to override, which is required when input logs span multiple directories. A `scout.yaml` project file is written alongside to link transcripts and scans.
+
+Logs pass through unmodified, so `scan` composes with other steps. The full set of scanner, model, and execution options mirrors `scout scan` — run `flow step scan --help` or see the [Inspect Scout docs](https://meridianlabs-ai.github.io/inspect_scout/reference/scanning.html#scan) for details.
+
 ## Custom Steps
 
 Define custom steps with the `@step` decorator. A step is a function that takes a `list[EvalLog]` and returns a `list[EvalLog]`:
@@ -142,7 +156,7 @@ def audit(logs: list[EvalLog]) -> StepResult:
 
 Steps are discovered from multiple sources:
 
-1. **Built-in steps** — `tag`, `metadata`, `copy`
+1. **Built-in steps** — `tag`, `metadata`, `copy`, `scan`
 2. **`_flow.py` files** — any `@step` functions defined or imported in `_flow.py` files in the current directory or parent directories are automatically discovered (same [automatic discovery](defaults.qmd#automatic-discovery) as for defaults)
 3. **Arbitrary files** — load steps from any Python file, without needing them in `_flow.py`:
 

--- a/src/inspect_flow/_cli/step.py
+++ b/src/inspect_flow/_cli/step.py
@@ -377,10 +377,11 @@ directory tree, and Python entry points.
 
 You can also load steps from an arbitrary Python file:
 
-\b
-  flow step file.py --help          List steps in a file
-  flow step file.py STEP [ARGS]     Run a step from a file
-  flow step file.py@STEP [ARGS]     Shorthand for the above
+    flow step file.py --help          List steps in a file
+
+    flow step file.py STEP [ARGS]     Run a step from a file
+
+    flow step file.py@STEP [ARGS]     Shorthand for the above
 """,
 )
 def step_command() -> None:


### PR DESCRIPTION
- Add a `scan` section to the Steps page covering CLI usage, `--scanners` spec shapes, the inferred `<log_dir>/scans` output dir and `scout.yaml` side effect, and a link out to the [Inspect Scout docs](https://meridianlabs-ai.github.io/inspect_scout/reference/scanning.html#scan) for the full option surface.
- Fix `flow step --help` example formatting so the docs reference page renders the three examples as a monospace code block instead of collapsing them into a run-on paragraph.