### PR TITLE
fix: allow user to pin inspect-ai version via dependencies

### DIFF
--- a/src/inspect_flow/_launcher/venv.py
+++ b/src/inspect_flow/_launcher/venv.py
@@ -11,6 +11,13 @@ from inspect_ai import Task
 from inspect_ai._util.file import absolute_file_path
 from inspect_ai.model import Model
 from inspect_ai.scorer import Scorer
+from packaging.requirements import InvalidRequirement, Requirement
+from packaging.utils import canonicalize_name
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
 
 from inspect_flow._config.write import write_config_file
 from inspect_flow._display.display import display, get_display_type
@@ -185,8 +192,11 @@ def _create_venv(
     if auto_detect_dependencies:
         dependencies.extend(collect_auto_dependencies(spec))
     dependencies.append(get_pip_string("inspect-flow"))
-    # Ensure same version of inspect-ai is installed (supports -e installs)
-    dependencies.append(get_pip_string("inspect-ai"))
+    if not any(
+        _spec_is_inspect_ai(d) for d in dependencies
+    ) and not _explicit_dependency_file_specifies_inspect_ai(spec, base_dir):
+        # Ensure same version of inspect-ai is installed (supports -e installs)
+        dependencies.append(get_pip_string("inspect-ai"))
 
     _uv_pip_install(dependencies, temp_dir, env)
 
@@ -199,6 +209,43 @@ def _resolve_dependency(dependency: str, base_dir: str) -> str:
     if "/" in dependency:
         return absolute_path_relative_to(dependency, base_dir=base_dir)
     return dependency
+
+
+def _spec_is_inspect_ai(requirement: str) -> bool:
+    try:
+        return canonicalize_name(Requirement(requirement).name) == "inspect-ai"
+    except InvalidRequirement:
+        return False
+
+
+def _file_specifies_inspect_ai(file_path: str) -> bool:
+    if file_path.endswith("pyproject.toml"):
+        with open(file_path, "rb") as f:
+            data = tomllib.load(f)
+        deps = data.get("project", {}).get("dependencies") or []
+        return any(isinstance(d, str) and _spec_is_inspect_ai(d) for d in deps)
+    with open(file_path) as f:
+        for raw_line in f:
+            line = raw_line.strip()
+            if not line or line.startswith(("#", "-")):
+                continue
+            if _spec_is_inspect_ai(line):
+                return True
+    return False
+
+
+def _explicit_dependency_file_specifies_inspect_ai(
+    spec: FlowSpec, base_dir: str
+) -> bool:
+    if not spec.dependencies:
+        return False
+    df = spec.dependencies.dependency_file
+    if not isinstance(df, str) or df in ("auto", "no_file"):
+        return False
+    file_path = absolute_path_relative_to(df, base_dir=base_dir)
+    if not Path(file_path).exists():
+        return False
+    return _file_specifies_inspect_ai(file_path)
 
 
 def _get_create_venv_with_base_dependencies(

--- a/tests/test_venv.py
+++ b/tests/test_venv.py
@@ -614,6 +614,137 @@ def test_325_uv_sync_args() -> None:
                 ]
 
 
+def test_inspect_ai_version_via_additional_dependencies() -> None:
+    """When the user pins inspect-ai in additional_dependencies, the venv
+    setup must install that exact version rather than the auto-pinned
+    currently-installed version."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=[], returncode=0, stdout="mocked output"
+            )
+
+            _create_venv(
+                spec=FlowSpec(
+                    dependencies=FlowDependencies(
+                        additional_dependencies=["inspect-ai==0.3.100"],
+                    ),
+                    tasks=[FlowTask(name="task_name")],
+                ),
+                base_dir=".",
+                temp_dir=temp_dir,
+                env=os.environ.copy(),
+                dry_run=False,
+                action=_test_action,
+            )
+
+            args = mock_run.call_args.args[0]
+            flow_path = str((Path(__file__).parents[1]).resolve())
+            assert args == [
+                "uv",
+                "pip",
+                "install",
+                "inspect-ai==0.3.100",
+                f"-e {flow_path}",
+            ]
+
+
+def test_inspect_ai_version_via_dependency_file_requirements() -> None:
+    """When the user pins inspect-ai in a requirements.txt dependency_file,
+    the venv setup must install that file and must not also append the
+    auto-pinned inspect-ai (which would override the user's version)."""
+    with tempfile.TemporaryDirectory() as base_dir:
+        req_file = Path(base_dir) / "requirements.txt"
+        req_file.write_text("inspect-ai==0.3.100\n")
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with patch("subprocess.run") as mock_run:
+                mock_run.return_value = subprocess.CompletedProcess(
+                    args=[], returncode=0, stdout="mocked output"
+                )
+
+                _create_venv(
+                    spec=FlowSpec(
+                        dependencies=FlowDependencies(
+                            dependency_file=req_file.as_posix(),
+                        ),
+                        tasks=[FlowTask(name="task_name")],
+                    ),
+                    base_dir=base_dir,
+                    temp_dir=temp_dir,
+                    env=os.environ.copy(),
+                    dry_run=False,
+                    action=_test_action,
+                )
+
+            assert mock_run.call_count == 3
+
+            install_req_args = mock_run.mock_calls[1].args[0]
+            assert install_req_args == [
+                "uv",
+                "pip",
+                "install",
+                "-r",
+                req_file.as_posix(),
+            ]
+
+            last_args = mock_run.call_args.args[0]
+            flow_path = str((Path(__file__).parents[1]).resolve())
+            assert last_args == [
+                "uv",
+                "pip",
+                "install",
+                f"-e {flow_path}",
+            ]
+
+
+def test_inspect_ai_version_via_dependency_file_pyproject() -> None:
+    """When the user pins inspect-ai in a pyproject.toml dependency_file,
+    the venv setup must use that file and must not also append the
+    auto-pinned inspect-ai (which would override the user's version)."""
+    with tempfile.TemporaryDirectory() as base_dir:
+        pyproject_file = Path(base_dir) / "pyproject.toml"
+        pyproject_file.write_text(
+            "[project]\n"
+            'name = "test_project"\n'
+            'version = "0.1.0"\n'
+            'requires-python = ">=3.10"\n'
+            'dependencies = ["inspect-ai==0.3.100"]\n'
+        )
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with patch("subprocess.run") as mock_run:
+                mock_run.return_value = subprocess.CompletedProcess(
+                    args=[], returncode=0, stdout="mocked output"
+                )
+
+                _create_venv(
+                    spec=FlowSpec(
+                        dependencies=FlowDependencies(
+                            dependency_file=pyproject_file.as_posix(),
+                        ),
+                        python_version="3.11",
+                        tasks=[FlowTask(name="task_name")],
+                    ),
+                    base_dir=base_dir,
+                    temp_dir=temp_dir,
+                    env=os.environ.copy(),
+                    dry_run=False,
+                    action=_test_action,
+                )
+
+            assert mock_run.call_count == 2
+
+            last_args = mock_run.call_args.args[0]
+            flow_path = str((Path(__file__).parents[1]).resolve())
+            assert last_args == [
+                "uv",
+                "pip",
+                "install",
+                f"-e {flow_path}",
+            ]
+
+
 @pytest.mark.slow
 def test_369_flow_requirements_s3(mock_s3: BaseClient) -> None:
     with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
Fixes #687 

## Summary
- Inspect Flow used to always pin the in-venv `inspect-ai` to the host's currently-installed version, which silently overrode any version the user specified in `additional_dependencies` or in a `dependency_file`.
- Now the auto-pin is skipped when an `inspect-ai` requirement is already present in `additional_dependencies` or in an explicitly-set `dependency_file` (requirements.txt or pyproject.toml), letting users choose the inspect-ai version they want.
- Auto-discovered dependency files keep the existing auto-pin behavior to preserve backward compatibility — users opt in to overriding by setting `dependency_file` explicitly.

## Test plan
- [x] `pytest tests/test_venv.py --runslow` (24 passed)
- [x] `make check` (ruff + pyright, 0 errors)
- [x] New tests cover all three entry points: `additional_dependencies`, `dependency_file=requirements.txt`, `dependency_file=pyproject.toml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)