### PR TITLE
Enable Meridian agents

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,28 @@
+# Copy to .github/workflows/claude-review.yml in any Meridian repo to add the
+# read-only reviewer. Auto-reviews PRs when they open and on demand via an
+# @review comment. Independent of the dev agent (claude.yml) — different
+# trigger, different (lower) permissions.
+
+name: Review
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review]
+  issue_comment:
+    types: [created]
+
+jobs:
+  review:
+    # Run on PR events, or on a PR comment containing @review. `@review` does
+    # not collide with the dev agent's `@claude` trigger.
+    if: >
+      github.event_name == 'pull_request' ||
+      (github.event.issue.pull_request != null &&
+       contains(github.event.comment.body, '@review'))
+    uses: meridianlabs-ai/agents/.github/workflows/claude-review.yml@main
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: read
+      id-token: write
+      actions: read

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,37 @@
+# Copy this file to .github/workflows/claude.yml in any Meridian repo
+# (or run scripts/enable-claude.sh <org/repo> to open a PR that adds it).
+#
+# Requires only that the Claude GitHub App is installed on the repo
+# (org-level install covers this). Auth uses Workload Identity Federation —
+# no secrets needed, but `id-token: write` below is required for the OIDC
+# exchange.
+
+name: Claude
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+  issues:
+    types: [opened, labeled]
+
+jobs:
+  claude:
+    # Cheap gate to avoid spending runner minutes on unrelated events; the
+    # action does its own authoritative trigger check.
+    if: |
+      contains(github.event.comment.body, '@claude') ||
+      contains(github.event.review.body, '@claude') ||
+      contains(github.event.issue.body, '@claude') ||
+      contains(github.event.issue.title, '@claude') ||
+      github.event.label.name == 'claude'
+    uses: meridianlabs-ai/agents/.github/workflows/claude.yml@main
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read


### PR DESCRIPTION
Adds workflow stubs from [meridianlabs-ai/agents](https://github.com/meridianlabs-ai/agents): claude.yml,claude-review.yml.

Once merged:
- **Dev agent** — mention `@claude` in an issue or PR comment, or add the `claude` label to an issue.
- **Reviewer** — auto-reviews PRs on open; or comment `@review` on a PR.