### PR TITLE
fix: drive store task-identifier column by TASK_IDENTIFIER_VERSION

### DIFF
--- a/src/inspect_flow/_store/deltalake.py
+++ b/src/inspect_flow/_store/deltalake.py
@@ -10,8 +10,9 @@ from urllib.parse import urlparse
 
 import pyarrow as pa
 import pyarrow.compute as pc
-from deltalake import DeltaTable, write_deltalake
+from deltalake import DeltaTable, Field, write_deltalake
 from deltalake.exceptions import TableNotFoundError
+from deltalake.schema import PrimitiveType
 from inspect_ai._eval.evalset import (
     TASK_IDENTIFIER_VERSION,
     list_all_eval_logs,
@@ -54,10 +55,6 @@ def _task_id_col() -> str:
     return f"task_identifier_{TASK_IDENTIFIER_VERSION}"
 
 
-def _task_id_cols() -> list[str]:
-    return [f"task_identifier_{v}" for v in range(1, TASK_IDENTIFIER_VERSION + 1)]
-
-
 def _escape_sql_string(s: str) -> str:
     return s.replace("'", "''")
 
@@ -97,17 +94,21 @@ class LogRecord:
             self.ts = now()
 
     def to_dict(self) -> dict[str, Any]:
-        row: dict[str, Any] = {"log_path": self.log_path, "ts": self.ts}
-        for col in _task_id_cols():
-            row[col] = self.task_identifier if col == _task_id_col() else None
-        return row
+        return {
+            "log_path": self.log_path,
+            _task_id_col(): self.task_identifier,
+            "ts": self.ts,
+        }
 
     @classmethod
     def to_schema(cls) -> pa.Schema:
-        cols: list[tuple[str, pa.DataType]] = [("log_path", pa.string())]
-        cols += [(col, pa.string()) for col in _task_id_cols()]
-        cols.append(("ts", pa.timestamp("ms")))
-        return pa.schema(cols)
+        return pa.schema(
+            [
+                ("log_path", pa.string()),
+                (_task_id_col(), pa.string()),
+                ("ts", pa.timestamp("ms")),
+            ]
+        )
 
 
 TABLES: list[TableDef] = [
@@ -462,6 +463,7 @@ class DeltaLakeStore(FlowStoreInternal):
             self._table_path(LOGS),
             new_data,
             mode="append",
+            schema_mode="merge",
             storage_options=self._storage_options,
         )
         return len(new_entries)
@@ -537,9 +539,17 @@ class DeltaLakeStore(FlowStoreInternal):
             result[task_id].add(log_path)
         return result
 
+    def _ensure_task_id_col(self) -> DeltaTable:
+        """Add the current task identifier column to a store written by older code."""
+        dt = self._open_table(LOGS)
+        if _task_id_col() not in [f.name for f in dt.schema().fields]:
+            dt.alter.add_columns(Field(_task_id_col(), PrimitiveType("string")))
+            dt = self._open_table(LOGS)
+        return dt
+
     def _set_task_identifiers(self) -> None:
         """Find logs with missing task_identifier and compute it from the log header."""
-        dt = self._open_table(LOGS)
+        dt = self._ensure_task_id_col()
         table = dt.to_pyarrow_table()
 
         # Find entries with empty or null task_identifier

--- a/src/inspect_flow/_store/deltalake.py
+++ b/src/inspect_flow/_store/deltalake.py
@@ -1,6 +1,6 @@
 import json
 import os
-from dataclasses import asdict, dataclass, field, fields
+from dataclasses import dataclass
 from datetime import datetime
 from functools import partial
 from logging import getLogger
@@ -42,13 +42,6 @@ from inspect_flow._util.util import now
 logger = PrefixLogger(getLogger(__name__), prefix="flow-store")
 
 
-def pa_field(pa_type: pa.DataType, **kwargs: Any) -> Any:
-    """Create a dataclass field with PyArrow type metadata."""
-    metadata = kwargs.pop("metadata", {})
-    metadata["pa_type"] = pa_type
-    return field(metadata=metadata, **kwargs)
-
-
 def to_uri(path_or_uri: str) -> str:
     """Convert a file path to a URI. Already-URI inputs are returned as-is."""
     parsed = urlparse(path_or_uri)
@@ -59,6 +52,10 @@ def to_uri(path_or_uri: str) -> str:
 
 def _task_id_col() -> str:
     return f"task_identifier_{TASK_IDENTIFIER_VERSION}"
+
+
+def _task_id_cols() -> list[str]:
+    return [f"task_identifier_{v}" for v in range(1, TASK_IDENTIFIER_VERSION + 1)]
 
 
 def _escape_sql_string(s: str) -> str:
@@ -91,20 +88,26 @@ LOGS = "_table_logs"
 
 @dataclass
 class LogRecord:
-    log_path: str = pa_field(pa.string())
-    task_identifier_1: str = pa_field(pa.string())
-    ts: datetime = pa_field(pa.timestamp("ms"), default=None)
+    log_path: str
+    task_identifier: str
+    ts: datetime | None = None
 
     def __post_init__(self) -> None:
         if self.ts is None:
             self.ts = now()
 
     def to_dict(self) -> dict[str, Any]:
-        return asdict(self)
+        row: dict[str, Any] = {"log_path": self.log_path, "ts": self.ts}
+        for col in _task_id_cols():
+            row[col] = self.task_identifier if col == _task_id_col() else None
+        return row
 
     @classmethod
     def to_schema(cls) -> pa.Schema:
-        return pa.schema([(f.name, f.metadata["pa_type"]) for f in fields(cls)])
+        cols: list[tuple[str, pa.DataType]] = [("log_path", pa.string())]
+        cols += [(col, pa.string()) for col in _task_id_cols()]
+        cols.append(("ts", pa.timestamp("ms")))
+        return pa.schema(cols)
 
 
 TABLES: list[TableDef] = [
@@ -448,7 +451,7 @@ class DeltaLakeStore(FlowStoreInternal):
             [
                 LogRecord(
                     log_path=e.log_path,
-                    task_identifier_1=e.task_identifier,
+                    task_identifier=e.task_identifier,
                 ).to_dict()
                 for e in new_entries
             ],
@@ -579,7 +582,7 @@ class DeltaLakeStore(FlowStoreInternal):
         update_table = pa.Table.from_pydict(
             {
                 "log_path": [log_path for log_path, _ in logs_to_update],
-                "task_identifier_1": [task_id for _, task_id in logs_to_update],
+                _task_id_col(): [task_id for _, task_id in logs_to_update],
             }
         )
 

--- a/tests/test_deltalake.py
+++ b/tests/test_deltalake.py
@@ -73,7 +73,7 @@ def test_missing_task_identifier(tmp_path: Path) -> None:
 
     record = LogRecord(
         log_path=to_uri(log1_path),
-        task_identifier_1="invalid",
+        task_identifier="invalid",
     )
     dict = record.to_dict()
     dict.pop(_task_id_col())  # don't set the task_identifier

--- a/tests/test_deltalake.py
+++ b/tests/test_deltalake.py
@@ -96,6 +96,65 @@ def test_missing_task_identifier(tmp_path: Path) -> None:
     assert logs[entry.task_identifier].log_file == log1_path
 
 
+def test_task_identifier_version_bump(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A store created at one task-identifier version is migrated on access by newer code."""
+    store_path = str(tmp_path)
+
+    # Create the store and import logs while at version 1.
+    store = DeltaLakeStore(store_path=store_path, create=True)
+    store.import_log_path(dir1base, recursive=True)
+
+    entry = _file_to_log_entry(log1_path)
+
+    dt = store._open_table(LOGS)
+    v1_table = dt.to_pyarrow_table()
+    assert "task_identifier_1" in v1_table.column_names
+    assert "task_identifier_2" not in v1_table.column_names
+    v1_ids = {
+        log: tid
+        for log, tid in zip(
+            v1_table["log_path"].to_pylist(),
+            v1_table["task_identifier_1"].to_pylist(),
+            strict=True,
+        )
+    }
+    assert v1_ids[log1_path] == entry.task_identifier
+
+    # Bump the task identifier version: newer code reads/writes task_identifier_2.
+    monkeypatch.setattr("inspect_flow._store.deltalake.TASK_IDENTIFIER_VERSION", 2)
+    assert _task_id_col() == "task_identifier_2"
+
+    # Reading triggers on-demand migration: the new column is added and backfilled.
+    store = DeltaLakeStore(store_path=store_path)
+    logs = store.search_for_logs({entry.task_identifier})
+    assert logs[entry.task_identifier].log_file == log1_path
+
+    migrated = store._open_table(LOGS).to_pyarrow_table()
+    assert "task_identifier_2" in migrated.column_names
+    migrated_ids = {
+        log: (tid1, tid2)
+        for log, tid1, tid2 in zip(
+            migrated["log_path"].to_pylist(),
+            migrated["task_identifier_1"].to_pylist(),
+            migrated["task_identifier_2"].to_pylist(),
+            strict=True,
+        )
+    }
+    # The old column is preserved and the new column is backfilled.
+    assert migrated_ids[log1_path][0] == entry.task_identifier
+    assert migrated_ids[log1_path][1] == entry.task_identifier
+
+    # Appending new logs under the bumped version works against the legacy table.
+    store.import_log_path(dir2base, recursive=True)
+    log2_name = "2026-01-09T18-27-59+00-00_mmlu-0-shot_AaMwC64MK8EccYgfhUqy3n.eval"
+    log2_path = dir2 + "/" + log2_name
+    entry2 = _file_to_log_entry(log2_path)
+    logs2 = store.search_for_logs({entry2.task_identifier})
+    assert logs2[entry2.task_identifier].log_file == log2_path
+
+
 class TestCheckTableDescription:
     """Tests for _check_table_description version validation."""
 


### PR DESCRIPTION
Fixes #705.

The Delta Lake store hardcoded the `task_identifier_1` column in its schema and inserts, while reads used `_task_id_col()` (`task_identifier_{TASK_IDENTIFIER_VERSION}`). After inspect-ai main bumped `TASK_IDENTIFIER_VERSION` to 3, reads queried `task_identifier_3`, a column absent from the schema. This makes the column name version-driven everywhere.

Generated with [Claude Code](https://claude.ai/code)