### PR TITLE
docs: correct README to reflect inproc as the default execution mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,11 +57,13 @@ FlowSpec(
 )
 ```
 
-To run the evaluations, run the following command in your shell. This will create a virtual environment for this spec run and install the dependencies. Note that task and model dependencies (like the `inspect-evals` and `openai` Python packages) are inferred and installed automatically.
+To run the evaluations, run the following command in your shell:
 
 ```bash
 flow run config.py
 ```
+
+By default, Flow runs in-process using your current Python environment, so the task and model dependencies (like the `inspect-evals` and `openai` Python packages) need to be installed in it. To run in an isolated, reproducible virtual environment instead—where those dependencies are inferred and installed automatically—use the `--venv` flag (or set `execution_type="venv"`). See [Execution modes](https://meridianlabs-ai.github.io/inspect_flow/advanced.html) for details.
 
 This will run both tasks and display progress in your terminal.
 


### PR DESCRIPTION
## Problem

The Basic Example in the README states that `flow run config.py`:

> will create a virtual environment for this spec run and install the dependencies. Note that task and model dependencies (like the `inspect-evals` and `openai` Python packages) are inferred and installed automatically.

This is inaccurate for the default. Since #421 the default `execution_type` is `inproc` (`src/inspect_flow/_types/flow_types.py` — *"defaults to `'inproc'`"*), which runs in the **current** Python environment and does **not** create a venv or auto-install dependencies. Creating a per-run virtual environment and inferring/installing dependencies only happens in **venv mode** (`--venv` / `execution_type="venv"`), as documented in [Execution modes](https://meridianlabs-ai.github.io/inspect_flow/advanced.html).

A reader following the Basic Example expects a venv and automatic dependency installation, but gets neither — and if their current environment is missing a task/model dependency, the run fails.

## Fix

Reword the Basic Example to describe the default `inproc` behavior accurately, and point to `--venv` / `execution_type="venv"` (and the Execution modes docs) for isolated, reproducible runs with automatic dependency installation.

Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)