### PR TITLE
build: post release notes to Slack on release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,6 +39,7 @@ jobs:
                   def convert(text):
                       out = []
                       for line in text.split("\n"):
+                          line = line.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
                           line = re.sub(r"\[([^\]]+)\]\(([^)]+)\)", r"<\2|\1>", line)
                           heading = re.match(r"^#{1,6}\s+(.*)$", line)
                           if heading:
@@ -46,11 +47,16 @@ jobs:
                           else:
                               line = re.sub(r"^(\s*)[*-]\s+", r"\1• ", line)
                           out.append(line)
-                      return "\n".join(out)
+                      return out
 
-                  text = convert(os.environ["RELEASE_BODY"])
-                  if len(text) > 2900:
-                      text = text[:2900].rstrip() + "\n… _(truncated — see full release below)_"
+                  kept, total = [], 0
+                  for line in convert(os.environ["RELEASE_BODY"]):
+                      if total + len(line) + 1 > 2900:
+                          kept.append("… _(truncated — see full release below)_")
+                          break
+                      kept.append(line)
+                      total += len(line) + 1
+                  text = "\n".join(kept)
 
                   delim = f"SLACK_EOF_{secrets.token_hex(16)}"
                   with open(os.environ["GITHUB_OUTPUT"], "a") as f:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,6 +13,8 @@ jobs:
         outputs:
             release_created: ${{ steps.release.outputs.release_created }}
             tag_name: ${{ steps.release.outputs.tag_name }}
+            html_url: ${{ steps.release.outputs.html_url }}
+            body: ${{ steps.release.outputs.body }}
         steps:
             - uses: googleapis/release-please-action@v4
               id: release
@@ -20,6 +22,56 @@ jobs:
                   token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
                   release-type: python
                   config-file: .release-please-config.json
+
+    notify-slack:
+        needs: release-please
+        if: ${{ needs.release-please.outputs.release_created }}
+        runs-on: ubuntu-latest
+        steps:
+            - name: Convert release notes to Slack mrkdwn
+              id: transform
+              env:
+                  RELEASE_BODY: ${{ needs.release-please.outputs.body }}
+              run: |
+                  python3 <<'PY'
+                  import os, re
+
+                  def convert(text):
+                      out = []
+                      for line in text.split("\n"):
+                          line = re.sub(r"\[([^\]]+)\]\(([^)]+)\)", r"<\2|\1>", line)
+                          heading = re.match(r"^#{1,6}\s+(.*)$", line)
+                          if heading:
+                              line = f"*{heading.group(1)}*"
+                          else:
+                              line = re.sub(r"^(\s*)[*-]\s+", r"\1• ", line)
+                          out.append(line)
+                      return "\n".join(out)
+
+                  with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+                      f.write("text<<SLACK_EOF\n")
+                      f.write(convert(os.environ["RELEASE_BODY"]))
+                      f.write("\nSLACK_EOF\n")
+                  PY
+
+            - uses: slackapi/slack-github-action@v2
+              with:
+                  webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+                  webhook-type: incoming-webhook
+                  payload: |
+                      blocks:
+                        - type: header
+                          text:
+                            type: plain_text
+                            text: ":rocket: inspect-flow ${{ needs.release-please.outputs.tag_name }} released"
+                        - type: section
+                          text:
+                            type: mrkdwn
+                            text: ${{ toJSON(steps.transform.outputs.text) }}
+                        - type: section
+                          text:
+                            type: mrkdwn
+                            text: "<${{ needs.release-please.outputs.html_url }}|View the full release>"
 
     publish:
         needs: release-please

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,7 +34,7 @@ jobs:
                   RELEASE_BODY: ${{ needs.release-please.outputs.body }}
               run: |
                   python3 <<'PY'
-                  import os, re
+                  import os, re, secrets
 
                   def convert(text):
                       out = []
@@ -48,10 +48,15 @@ jobs:
                           out.append(line)
                       return "\n".join(out)
 
+                  text = convert(os.environ["RELEASE_BODY"])
+                  if len(text) > 2900:
+                      text = text[:2900].rstrip() + "\n… _(truncated — see full release below)_"
+
+                  delim = f"SLACK_EOF_{secrets.token_hex(16)}"
                   with open(os.environ["GITHUB_OUTPUT"], "a") as f:
-                      f.write("text<<SLACK_EOF\n")
-                      f.write(convert(os.environ["RELEASE_BODY"]))
-                      f.write("\nSLACK_EOF\n")
+                      f.write(f"text<<{delim}\n")
+                      f.write(text)
+                      f.write(f"\n{delim}\n")
                   PY
 
             - uses: slackapi/slack-github-action@v2


### PR DESCRIPTION
## Summary

Adds a `notify-slack` job to the release workflow so that when release-please publishes a release, the changelog is posted to Slack.

- Exposes `html_url` and `body` from the release-please job outputs.
- New `notify-slack` job runs only when `release_created` is set.
- Converts the release notes from GitHub markdown to Slack mrkdwn (headings → bold, `*`/`-` bullets → `•`, `[text](url)` → `<url|text>`).
- Posts a Block Kit message via an incoming webhook (`SLACK_WEBHOOK_URL` secret) with a `:rocket:` header and a link to the full release.

## Notes

- The `SLACK_WEBHOOK_URL` repo secret is already configured.
- The markdown→mrkdwn conversion is a small regex tailored to release-please's stable CHANGELOG format, kept dependency-free rather than pulling in a Node library.
- Verified the conversion locally against the real v0.9.0 release body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)