### PR TITLE
test: make task-identifier-version-bump test version-agnostic

### DIFF
--- a/tests/test_deltalake.py
+++ b/tests/test_deltalake.py
@@ -102,29 +102,38 @@ def test_task_identifier_version_bump(
     """A store created at one task-identifier version is migrated on access by newer code."""
     store_path = str(tmp_path)
 
-    # Create the store and import logs while at version 1.
+    def set_version(version: int) -> str:
+        monkeypatch.setattr(
+            "inspect_flow._store.deltalake.TASK_IDENTIFIER_VERSION", version
+        )
+        col = f"task_identifier_{version}"
+        assert _task_id_col() == col
+        return col
+
+    # Create the store and import logs at an older task-identifier version. Pin the
+    # version explicitly so the test does not depend on inspect-ai's current value.
+    old_col = set_version(1)
     store = DeltaLakeStore(store_path=store_path, create=True)
     store.import_log_path(dir1base, recursive=True)
 
     entry = _file_to_log_entry(log1_path)
 
     dt = store._open_table(LOGS)
-    v1_table = dt.to_pyarrow_table()
-    assert "task_identifier_1" in v1_table.column_names
-    assert "task_identifier_2" not in v1_table.column_names
-    v1_ids = {
+    old_table = dt.to_pyarrow_table()
+    assert old_col in old_table.column_names
+    assert "task_identifier_2" not in old_table.column_names
+    old_ids = {
         log: tid
         for log, tid in zip(
-            v1_table["log_path"].to_pylist(),
-            v1_table["task_identifier_1"].to_pylist(),
+            old_table["log_path"].to_pylist(),
+            old_table[old_col].to_pylist(),
             strict=True,
         )
     }
-    assert v1_ids[log1_path] == entry.task_identifier
+    assert old_ids[log1_path] == entry.task_identifier
 
-    # Bump the task identifier version: newer code reads/writes task_identifier_2.
-    monkeypatch.setattr("inspect_flow._store.deltalake.TASK_IDENTIFIER_VERSION", 2)
-    assert _task_id_col() == "task_identifier_2"
+    # Bump the task identifier version: newer code reads/writes the new column.
+    new_col = set_version(2)
 
     # Reading triggers on-demand migration: the new column is added and backfilled.
     store = DeltaLakeStore(store_path=store_path)
@@ -132,13 +141,13 @@ def test_task_identifier_version_bump(
     assert logs[entry.task_identifier].log_file == log1_path
 
     migrated = store._open_table(LOGS).to_pyarrow_table()
-    assert "task_identifier_2" in migrated.column_names
+    assert new_col in migrated.column_names
     migrated_ids = {
-        log: (tid1, tid2)
-        for log, tid1, tid2 in zip(
+        log: (tid_old, tid_new)
+        for log, tid_old, tid_new in zip(
             migrated["log_path"].to_pylist(),
-            migrated["task_identifier_1"].to_pylist(),
-            migrated["task_identifier_2"].to_pylist(),
+            migrated[old_col].to_pylist(),
+            migrated[new_col].to_pylist(),
             strict=True,
         )
     }


### PR DESCRIPTION
## Problem

CI is failing on `test_task_identifier_version_bump` (e.g. [this run](https://github.com/meridianlabs-ai/inspect_flow/actions/runs/27708884809/job/81964518558)) even after #706 landed.

The failure is in the **test**, not the production code from #706. The test assumed inspect-ai's `TASK_IDENTIFIER_VERSION` was `1`:

- It created the store at the *real* version, then monkeypatched *down* to `2` and asserted a `task_identifier_1` column existed.
- This passed locally (version `1`) but CI runs against a newer inspect-ai where the version is **`3`**, so the store was created with a `task_identifier_3` column and `assert "task_identifier_1" in [...]` failed.

## Fix

Pin both versions explicitly via `monkeypatch` and derive the column names from the patched value, so the test no longer depends on inspect-ai's actual `TASK_IDENTIFIER_VERSION`. The store is created at version `1`, then bumped to `2`, and migration is verified using version-derived column names — robust regardless of the real version.

## Testing

`pytest tests/test_deltalake.py` — all 9 pass; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)