### PR TITLE
build: add 10m timeout to test steps and document PR title conventions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -60,6 +60,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Run tests with coverage
+        timeout-minutes: 10
         run: uv run pytest --cov --cov-report=term --cov-report=xml --cov-branch
           --runslow
       - name: Coverage comment

--- a/.github/workflows/inspect_ai_main.yaml
+++ b/.github/workflows/inspect_ai_main.yaml
@@ -62,6 +62,7 @@ jobs:
       - name: Install inspect-ai main
         run: uv pip install git+https://github.com/UKGovernmentBEIS/inspect_ai.git
       - name: Run tests
+        timeout-minutes: 10
         run: uv run --no-sync pytest --runslow
 
   check-type-gen:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,12 @@ See [src/inspect_flow/README.md](src/inspect_flow/README.md) for detailed module
 - **Error Handling**: Use appropriate exception types; include context in error messages. Avoid try/except blocks unless absolutely necessary—if you add one, include a test that exercises that code path.
 - **Testing**: Write tests with pytest. Prefer integration tests that exercise real behavior through public entry points (CLI commands, public API) over unit tests that mock internal details. Only mock at system boundaries (external APIs, file system, network). Avoid mocking internal classes or methods—this couples tests to implementation and makes refactoring harder. Test what the code *does* (observable output, side effects), not *how* it does it. Tests should rarely need to change when internal code is refactored. Use existing fixtures (e.g. `recording_console`) instead of ad-hoc mocking.
 - **Bug Fixes**: Include a test that reproduces the bug before fixing it
-- **Pull Requests**: Keep PRs small and focused. Include a description of changes and rationale. Use conventional commit messages ("fix:" and "feat:").
+- **Pull Requests**: Keep PRs small and focused. Include a description of changes and rationale. Use conventional commit messages for PR titles. Release notes are generated from `feat:` and `fix:` titles, so choose the prefix accordingly:
+  - `feat:` — only for significant user-facing features.
+  - `fix:` — only for product bug fixes that affect users.
+  - `build:` — build system, dependencies, and packaging changes.
+  - `test:` — test additions, fixes, and CI test infrastructure.
+  - Use other conventional types (`docs:`, `refactor:`, `chore:`, `ci:`) as appropriate. Anything that is not a user-facing feature or product bug fix should avoid `feat:`/`fix:` so it is excluded from release notes.
 
 Respect existing code patterns when modifying files. Run linting before committing changes.
 


### PR DESCRIPTION
## What

1. **Test-step timeout** — add `timeout-minutes: 10` to the pytest steps in [build.yaml](.github/workflows/build.yaml) and [inspect_ai_main.yaml](.github/workflows/inspect_ai_main.yaml).
2. **PR title conventions** — document conventional-commit prefixes in [CLAUDE.md](CLAUDE.md).

## Why

A recent CI run hung for ~13 minutes inside the test step: a `uv` venv dependency install (in `test_venv.py`) stalled on a transient network blip with no output. With no step/job timeout, a hung test runs toward GitHub's **6-hour default**, silently holding a runner slot. The suite normally finishes in ~2.5 min, so a 10-minute cap fails fast with ample headroom.

The CLAUDE.md addition clarifies that release notes are generated from `feat:`/`fix:` titles, so:
- `feat:` — only significant user-facing features
- `fix:` — only product bug fixes
- `build:` / `test:` — build and test-system changes (kept out of release notes)

This PR itself uses `build:` accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)