### PR TITLE
docs: expand class-level docstrings for public Flow types

### DIFF
--- a/src/inspect_flow/_types/flow_types.py
+++ b/src/inspect_flow/_types/flow_types.py
@@ -75,7 +75,11 @@ class FlowBase(BaseModel, extra="forbid"):
 
 
 class FlowModel(FlowBase):
-    """Configuration for a Model."""
+    """Configuration for a model.
+
+    `name` is an Inspect model identifier (e.g. ``"openai/gpt-4o"``); `config`,
+    `model_args`, `base_url`, `api_key`, and `role` tune how it is created.
+    """
 
     name: str | None | NotGiven = Field(
         default=not_given,
@@ -128,7 +132,7 @@ class FlowModel(FlowBase):
 
 
 class FlowScorer(FlowBase):
-    """Configuration for a Scorer."""
+    """Configuration for a scorer: a registry `name` (or `factory`) plus its `args`."""
 
     name: str | None | NotGiven = Field(
         default=not_given,
@@ -154,7 +158,7 @@ class FlowScorer(FlowBase):
 
 
 class FlowSolver(FlowBase):
-    """Configuration for a Solver."""
+    """Configuration for a solver: a registry `name` (or `factory`) plus its `args`."""
 
     name: str | None | NotGiven = Field(
         default=not_given,
@@ -180,7 +184,7 @@ class FlowSolver(FlowBase):
 
 
 class FlowAgent(FlowBase):
-    """Configuration for an Agent."""
+    """Configuration for an agent: a registry `name` (or `factory`) plus its `args`."""
 
     name: str | None | NotGiven = Field(
         default=not_given,
@@ -328,9 +332,11 @@ class FlowFactory(BaseModel, Generic[R], arbitrary_types_allowed=True):
 
 
 class FlowTask(FlowBase, arbitrary_types_allowed=True):
-    """Configuration for an evaluation task.
+    """Configuration for a single evaluation task.
 
-    Tasks are the basis for defining and running evaluations.
+    Identifies the task (`name` or `factory`) and carries its per-task settings:
+    `model`, `solver`, `scorer`, `config` (generation config), `epochs`, `sandbox`,
+    `approval`, and the various limits. Unset fields fall back to `FlowDefaults`.
     """
 
     name: str | None | NotGiven = Field(
@@ -484,7 +490,12 @@ class FlowTask(FlowBase, arbitrary_types_allowed=True):
 
 
 class FlowOptions(FlowBase):
-    """Evaluation options."""
+    """Eval-set-wide options forwarded to Inspect's ``eval_set``.
+
+    These apply to the whole run (retries, sandbox cleanup, global limits, display,
+    scoring, the control channel, etc.) rather than to individual tasks — set per-task
+    settings on `FlowTask`. Attached to a spec via ``FlowSpec(options=...)``.
+    """
 
     retry_attempts: int | None | NotGiven = Field(
         default=not_given,
@@ -714,7 +725,11 @@ class FlowOptions(FlowBase):
 
 
 class FlowDefaults(FlowBase):
-    """Default field values for Inspect objects. Will be overriden by more specific settings."""
+    """Default `model`/`solver`/`agent`/`task` values applied to every task in the spec.
+
+    A value set on an individual `FlowTask` overrides the default here. The ``*_prefix``
+    variants apply defaults by registry-name prefix. Attached via ``FlowSpec(defaults=...)``.
+    """
 
     config: GenerateConfig | None | NotGiven = Field(
         default=not_given,
@@ -759,7 +774,12 @@ class FlowDefaults(FlowBase):
 
 
 class FlowDependencies(FlowBase):
-    """Configuration for flow dependencies to install in the venv."""
+    """Dependencies to install in the per-run virtual environment.
+
+    Only applies in venv execution mode (``execution_type="venv"``); combines an optional
+    `dependency_file`, `additional_dependencies`, and automatic detection
+    (`auto_detect_dependencies`).
+    """
 
     dependency_file: Literal["auto", "no_file"] | str | None | NotGiven = Field(
         default=not_given,
@@ -848,7 +868,14 @@ class FlowStoreConfig(FlowBase):
 
 
 class FlowSpec(FlowBase, arbitrary_types_allowed=True):
-    """Top-level flow specification."""
+    """Top-level flow specification: the tasks to run plus how to run them.
+
+    `tasks` lists what to evaluate; per-task configuration (model, solver, scorer,
+    epochs, limits) lives on each `FlowTask`. Cross-cutting settings live in dedicated
+    fields: `defaults` (`FlowDefaults`, applied to every task), `options` (`FlowOptions`,
+    eval-set-wide options forwarded to Inspect), and `dependencies` (`FlowDependencies`,
+    for venv mode). Eval parameters are not set directly at this top level.
+    """
 
     includes: Sequence[str | FlowSpec] | None | NotGiven = Field(
         default=not_given,

--- a/src/inspect_flow/_types/generated.py
+++ b/src/inspect_flow/_types/generated.py
@@ -57,7 +57,7 @@ class FlowFactoryTask(TypedDict):
 
 
 class FlowAgentDict(TypedDict, closed=True):
-    """Configuration for an Agent."""
+    """Configuration for an agent: a registry `name` (or `factory`) plus its `args`."""
 
     name: NotRequired[str | NotGiven | None]
     """Name of the agent. Used to create the agent if the factory is not provided."""
@@ -72,14 +72,19 @@ class FlowAgentDict(TypedDict, closed=True):
 
 
 class FlowAgentMatrixDict(TypedDict, closed=True):
-    """Configuration for an Agent."""
+    """Configuration for an agent: a registry `name` (or `factory`) plus its `args`."""
 
     args: NotRequired[Sequence[Mapping[str, Any] | NotGiven | None] | None]
     """Additional args to pass to agent constructor."""
 
 
 class FlowModelDict(TypedDict, closed=True):
-    """Configuration for a Model."""
+    """
+    Configuration for a model.
+
+    `name` is an Inspect model identifier (e.g. ``"openai/gpt-4o"``); `config`,
+    `model_args`, `base_url`, `api_key`, and `role` tune how it is created.
+    """
 
     name: NotRequired[str | NotGiven | None]
     """Name of the model to use. If factory is not provided, this is used to create the model."""
@@ -104,14 +109,19 @@ class FlowModelDict(TypedDict, closed=True):
 
 
 class FlowModelMatrixDict(TypedDict, closed=True):
-    """Configuration for a Model."""
+    """
+    Configuration for a model.
+
+    `name` is an Inspect model identifier (e.g. ``"openai/gpt-4o"``); `config`,
+    `model_args`, `base_url`, `api_key`, and `role` tune how it is created.
+    """
 
     config: NotRequired[Sequence[GenerateConfig | NotGiven | None] | None]
     """Configuration for model. Config values will be override settings on the `FlowTask` and `FlowSpec`."""
 
 
 class FlowSolverDict(TypedDict, closed=True):
-    """Configuration for a Solver."""
+    """Configuration for a solver: a registry `name` (or `factory`) plus its `args`."""
 
     name: NotRequired[str | NotGiven | None]
     """Name of the solver. Used to create the solver if the factory is not provided."""
@@ -124,7 +134,7 @@ class FlowSolverDict(TypedDict, closed=True):
 
 
 class FlowSolverMatrixDict(TypedDict, closed=True):
-    """Configuration for a Solver."""
+    """Configuration for a solver: a registry `name` (or `factory`) plus its `args`."""
 
     args: NotRequired[Sequence[Mapping[str, Any] | NotGiven | None] | None]
     """Additional args to pass to solver constructor."""
@@ -132,9 +142,11 @@ class FlowSolverMatrixDict(TypedDict, closed=True):
 
 class FlowTaskDict(TypedDict, closed=True):
     """
-    Configuration for an evaluation task.
+    Configuration for a single evaluation task.
 
-    Tasks are the basis for defining and running evaluations.
+    Identifies the task (`name` or `factory`) and carries its per-task settings:
+    `model`, `solver`, `scorer`, `config` (generation config), `epochs`, `sandbox`,
+    `approval`, and the various limits. Unset fields fall back to `FlowDefaults`.
     """
 
     name: NotRequired[str | NotGiven | None]
@@ -209,9 +221,11 @@ class FlowTaskDict(TypedDict, closed=True):
 
 class FlowTaskMatrixDict(TypedDict, closed=True):
     """
-    Configuration for an evaluation task.
+    Configuration for a single evaluation task.
 
-    Tasks are the basis for defining and running evaluations.
+    Identifies the task (`name` or `factory`) and carries its per-task settings:
+    `model`, `solver`, `scorer`, `config` (generation config), `epochs`, `sandbox`,
+    `approval`, and the various limits. Unset fields fall back to `FlowDefaults`.
     """
 
     args: NotRequired[Sequence[Mapping[str, Any] | NotGiven | None] | None]


### PR DESCRIPTION
## What

The public `Flow*` config types (`FlowSpec`, `FlowTask`, `FlowModel`, `FlowSolver`, `FlowScorer`, `FlowAgent`, `FlowOptions`, `FlowDefaults`, `FlowDependencies`) had one-line class docstrings. Expand them (tersely) to state each type's purpose and — importantly — **where its fields belong**.

## Why

Field-level descriptions are already good, but the class docstring is what shows up on hover / `help()` / generated reference. A one-liner gives a field list with no narrative about how the pieces relate, so it's easy (for a human or a coding agent authoring a spec) to put `model`/`epochs` on `FlowSpec` or `ctl_server` at the top level and hit a bare `extra_forbidden` error with no hint about the right home (`FlowTask` / `options=` / `defaults=`).

The new docstrings make the option grouping self-describing:
- `FlowSpec` — tasks + cross-cutting fields; eval params are **not** set at the top level.
- `FlowTask` — per-task `model`/`solver`/`scorer`/`config`/`epochs`/limits; falls back to `FlowDefaults`.
- `FlowOptions` — eval-set-wide options forwarded to `eval_set`; attached via `FlowSpec(options=...)`.
- `FlowDefaults` — defaults applied to every task, overridden per-`FlowTask`.
- building blocks (`FlowModel`/`FlowSolver`/`FlowScorer`/`FlowAgent`) — `name`/`factory` + args.

Docstring-only; `generated.py` TypedDict mirrors regenerated to match. Part of the coding-agent-friendliness work in #714.

🤖 Generated with [Claude Code](https://claude.com/claude-code)