### PR TITLE
fix: add hint when eval_set fails due to stale inspect-ai version

### DIFF
--- a/src/inspect_flow/_runner/run.py
+++ b/src/inspect_flow/_runner/run.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import time
 from datetime import timedelta
+from importlib.metadata import PackageNotFoundError, version
 from logging import getLogger
 
 import click
@@ -197,6 +198,8 @@ def run_eval_set(
             _fix_prerequisite_error_message(e)
         if error_string := str(e):
             flow_print(error_string, format="error")
+        if hint := _stale_inspect_ai_hint(e):
+            flow_print(hint, format="warning")
         flow_print(Rule("Eval Set Failed with Exception"))
         if error_string:
             raise FlowHandledError from e
@@ -328,6 +331,31 @@ def _fix_prerequisite_error_message(e: PrerequisiteError) -> None:
     modified_message = original_message.replace("'overwrite'", "'bundle_overwrite'")
     if original_message != modified_message:
         e.args = (modified_message, *e.args[1:])
+
+
+# eval_set params added in inspect-ai 0.3.240. Against an older inspect-ai they
+# fall through to GenerateConfig and surface as an opaque validation error that
+# never mentions inspect-ai or its version.
+_MIN_INSPECT_AI_VERSION = "0.3.240"
+_VERSION_GATED_EVAL_SET_PARAMS = ("acp_server", "ctl_server", "notification")
+
+
+def _stale_inspect_ai_hint(e: Exception) -> str | None:
+    message = str(e)
+    if "Unknown GenerateConfig field(s)" not in message:
+        return None
+    if not any(param in message for param in _VERSION_GATED_EVAL_SET_PARAMS):
+        return None
+    try:
+        installed = version("inspect-ai")
+    except PackageNotFoundError:
+        installed = "unknown"
+    return (
+        f"This likely means the installed inspect-ai ({installed}) predates the "
+        f"control-channel and notification eval_set options, which require "
+        f"inspect-ai >= {_MIN_INSPECT_AI_VERSION}. Run `uv sync` (or otherwise "
+        f"upgrade inspect-ai to >= {_MIN_INSPECT_AI_VERSION}) and retry."
+    )
 
 
 def _ensure_trailing_slash(url: str) -> str:

--- a/src/inspect_flow/_runner/run.py
+++ b/src/inspect_flow/_runner/run.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import time
 from datetime import timedelta
-from importlib.metadata import PackageNotFoundError, version
+from importlib.metadata import PackageNotFoundError, requires, version
 from logging import getLogger
 
 import click
@@ -12,6 +12,9 @@ from inspect_ai._eval.evalset import list_all_eval_logs, task_identifier
 from inspect_ai._util.error import PrerequisiteError
 from inspect_ai.log import EvalLog
 from inspect_ai.util._display import init_display_type
+from packaging.requirements import Requirement
+from packaging.utils import canonicalize_name
+from packaging.version import Version
 from rich.console import Group
 from rich.panel import Panel
 from rich.rule import Rule
@@ -198,7 +201,7 @@ def run_eval_set(
             _fix_prerequisite_error_message(e)
         if error_string := str(e):
             flow_print(error_string, format="error")
-        if hint := _stale_inspect_ai_hint(e):
+        if hint := _stale_inspect_ai_hint():
             flow_print(hint, format="warning")
         flow_print(Rule("Eval Set Failed with Exception"))
         if error_string:
@@ -333,28 +336,30 @@ def _fix_prerequisite_error_message(e: PrerequisiteError) -> None:
         e.args = (modified_message, *e.args[1:])
 
 
-# eval_set params added in inspect-ai 0.3.240. Against an older inspect-ai they
-# fall through to GenerateConfig and surface as an opaque validation error that
-# never mentions inspect-ai or its version.
-_MIN_INSPECT_AI_VERSION = "0.3.240"
-_VERSION_GATED_EVAL_SET_PARAMS = ("acp_server", "ctl_server", "notification")
+def _min_inspect_ai_version() -> str | None:
+    for req in requires("inspect_flow") or ():
+        requirement = Requirement(req)
+        if canonicalize_name(requirement.name) == "inspect-ai":
+            for spec in requirement.specifier:
+                if spec.operator in (">=", "=="):
+                    return spec.version
+    return None
 
 
-def _stale_inspect_ai_hint(e: Exception) -> str | None:
-    message = str(e)
-    if "Unknown GenerateConfig field(s)" not in message:
-        return None
-    if not any(param in message for param in _VERSION_GATED_EVAL_SET_PARAMS):
+def _stale_inspect_ai_hint() -> str | None:
+    required = _min_inspect_ai_version()
+    if required is None:
         return None
     try:
         installed = version("inspect-ai")
     except PackageNotFoundError:
-        installed = "unknown"
+        return None
+    if Version(installed) >= Version(required):
+        return None
     return (
-        f"This likely means the installed inspect-ai ({installed}) predates the "
-        f"control-channel and notification eval_set options, which require "
-        f"inspect-ai >= {_MIN_INSPECT_AI_VERSION}. Run `uv sync` (or otherwise "
-        f"upgrade inspect-ai to >= {_MIN_INSPECT_AI_VERSION}) and retry."
+        f"The installed inspect-ai ({installed}) is older than the required "
+        f"inspect-ai >= {required}, which may be the cause of the error above. "
+        f"Run `uv sync` (or otherwise upgrade inspect-ai to >= {required}) and retry."
     )
 
 

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -1510,6 +1510,45 @@ def test_eval_set_error(mock_eval_set: MagicMock) -> None:
     assert "Test error from eval_set" in str(e.value.__cause__)
 
 
+def test_eval_set_stale_inspect_ai_hint(
+    mock_eval_set: MagicMock, recording_console: Console
+) -> None:
+    log_dir = init_test_logs()
+    spec = FlowSpec(
+        log_dir=log_dir,
+        tasks=[task_file + "@noop"],
+    )
+    mock_eval_set.side_effect = ValueError(
+        "1 validation error for GenerateConfig\n"
+        "Value error, Unknown GenerateConfig field(s): "
+        "acp_server, ctl_server, notification.\n"
+        "Use extra_body for provider-specific options."
+    )
+
+    with pytest.raises(FlowHandledError):
+        run_eval_set(spec=spec, base_dir=".")
+
+    out = recording_console.export_text()
+    assert "inspect-ai >= 0.3.240" in out
+
+
+def test_eval_set_error_no_stale_hint(
+    mock_eval_set: MagicMock, recording_console: Console
+) -> None:
+    log_dir = init_test_logs()
+    spec = FlowSpec(
+        log_dir=log_dir,
+        tasks=[task_file + "@noop"],
+    )
+    mock_eval_set.side_effect = ValueError("Some unrelated error")
+
+    with pytest.raises(FlowHandledError):
+        run_eval_set(spec=spec, base_dir=".")
+
+    out = recording_console.export_text()
+    assert "inspect-ai >= 0.3.240" not in out
+
+
 def test_store_write_on_keyboard_interrupt() -> None:
     log_dir = init_test_logs()
     store_dir = init_test_store()

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -30,7 +30,7 @@ from inspect_flow import (
     tasks_matrix,
 )
 from inspect_flow._config.write import config_to_yaml
-from inspect_flow._runner.run import run_eval_set
+from inspect_flow._runner.run import _min_inspect_ai_version, run_eval_set
 from inspect_flow._store.store import store_factory
 from inspect_flow._types.flow_types import FlowScorer, not_given
 from inspect_flow._util.error import FlowHandledError
@@ -39,6 +39,7 @@ from inspect_flow._util.logging import (
     init_flow_logging,
     update_log_level,
 )
+from packaging.version import Version
 from rich.console import Console
 
 from .test_helpers.log_helpers import init_test_logs, init_test_store, verify_test_logs
@@ -1518,18 +1519,14 @@ def test_eval_set_stale_inspect_ai_hint(
         log_dir=log_dir,
         tasks=[task_file + "@noop"],
     )
-    mock_eval_set.side_effect = ValueError(
-        "1 validation error for GenerateConfig\n"
-        "Value error, Unknown GenerateConfig field(s): "
-        "acp_server, ctl_server, notification.\n"
-        "Use extra_body for provider-specific options."
-    )
+    mock_eval_set.side_effect = ValueError("Some unrelated error")
 
-    with pytest.raises(FlowHandledError):
-        run_eval_set(spec=spec, base_dir=".")
+    with patch("inspect_flow._runner.run.version", return_value="0.0.1"):
+        with pytest.raises(FlowHandledError):
+            run_eval_set(spec=spec, base_dir=".")
 
     out = recording_console.export_text()
-    assert "inspect-ai >= 0.3.240" in out
+    assert f"inspect-ai >= {_min_inspect_ai_version()}" in out
 
 
 def test_eval_set_error_no_stale_hint(
@@ -1542,11 +1539,18 @@ def test_eval_set_error_no_stale_hint(
     )
     mock_eval_set.side_effect = ValueError("Some unrelated error")
 
-    with pytest.raises(FlowHandledError):
-        run_eval_set(spec=spec, base_dir=".")
+    with patch("inspect_flow._runner.run.version", return_value="999.0.0"):
+        with pytest.raises(FlowHandledError):
+            run_eval_set(spec=spec, base_dir=".")
 
     out = recording_console.export_text()
-    assert "inspect-ai >= 0.3.240" not in out
+    assert "older than the required" not in out
+
+
+def test_min_inspect_ai_version_derived_from_metadata() -> None:
+    required = _min_inspect_ai_version()
+    assert required is not None
+    Version(required)
 
 
 def test_store_write_on_keyboard_interrupt() -> None:


### PR DESCRIPTION
Fixes Bug A of #715. When the resolved inspect-ai predates the `acp_server`/`ctl_server`/`notification` eval_set params, they fall through to `GenerateConfig` and produce an opaque validation error. This detects that error and prints a hint naming the required inspect-ai version and how to fix it.

Generated with [Claude Code](https://claude.ai/code)