### PR TITLE
fix: let explicit dependencies override auto-detected host pins

### DIFF
--- a/src/inspect_flow/_launcher/auto_dependencies.py
+++ b/src/inspect_flow/_launcher/auto_dependencies.py
@@ -64,8 +64,9 @@ def collect_auto_dependencies(
     for task in spec.tasks or []:
         _collect_task_dependencies(task, result)
 
-    # Explicit dependencies (and their requirements) take precedence over the
-    # auto-detected host versions, so drop any package the user pinned directly.
+    # An explicit pin must win over the auto-detected host version of the same
+    # package, so drop any package the user named directly. Its version
+    # requirement (and whatever uv resolves from it) then governs instead.
     exclude = {canonicalize_name(p) for p in exclude_packages}
 
     # inspect_ai is already included by inspect-flow

--- a/src/inspect_flow/_launcher/auto_dependencies.py
+++ b/src/inspect_flow/_launcher/auto_dependencies.py
@@ -1,6 +1,6 @@
 import os
 from logging import getLogger
-from typing import Sequence
+from typing import Collection, Sequence
 
 from inspect_ai import Task
 from inspect_ai._util.registry import (
@@ -14,6 +14,7 @@ from inspect_ai.scorer import Scorer
 from inspect_ai.solver import Solver
 from inspect_ai.util import SandboxEnvironmentType
 from inspect_ai.util._sandbox.registry import registry_match_sandboxenv
+from packaging.utils import canonicalize_name
 
 from inspect_flow._launcher.pip_string import get_pip_string
 from inspect_flow._types.flow_types import (
@@ -55,14 +56,26 @@ _MODEL_PROVIDERS: dict[str, list[str]] = {
 }
 
 
-def collect_auto_dependencies(spec: FlowSpec) -> list[str]:
+def collect_auto_dependencies(
+    spec: FlowSpec, exclude_packages: Collection[str] = ()
+) -> list[str]:
     result = set()
 
     for task in spec.tasks or []:
         _collect_task_dependencies(task, result)
 
+    # Explicit dependencies (and their requirements) take precedence over the
+    # auto-detected host versions, so drop any package the user pinned directly.
+    exclude = {canonicalize_name(p) for p in exclude_packages}
+
     # inspect_ai is already included by inspect-flow
-    return sorted({get_pip_string(dep) for dep in result if dep != "inspect_ai"})
+    return sorted(
+        {
+            get_pip_string(dep)
+            for dep in result
+            if dep != "inspect_ai" and canonicalize_name(dep) not in exclude
+        }
+    )
 
 
 def _collect_task_dependencies(

--- a/src/inspect_flow/_launcher/venv.py
+++ b/src/inspect_flow/_launcher/venv.py
@@ -175,22 +175,27 @@ def _create_venv(
 
     create_venv_func()
 
-    dependencies: List[str] = []
+    explicit_dependencies: List[str] = []
     if spec.dependencies and spec.dependencies.additional_dependencies:
         if isinstance(spec.dependencies.additional_dependencies, str):
-            dependencies.append(spec.dependencies.additional_dependencies)
+            explicit_dependencies.append(spec.dependencies.additional_dependencies)
         else:
-            dependencies.extend(spec.dependencies.additional_dependencies)
-        dependencies = [
-            _resolve_dependency(dep, base_dir=base_dir) for dep in dependencies
-        ]
+            explicit_dependencies.extend(spec.dependencies.additional_dependencies)
+
+    dependencies: List[str] = [
+        _resolve_dependency(dep, base_dir=base_dir) for dep in explicit_dependencies
+    ]
 
     auto_detect_dependencies = True
     if spec.dependencies and spec.dependencies.auto_detect_dependencies is False:
         auto_detect_dependencies = False
 
     if auto_detect_dependencies:
-        dependencies.extend(collect_auto_dependencies(spec))
+        dependencies.extend(
+            collect_auto_dependencies(
+                spec, exclude_packages=_explicit_dependency_names(explicit_dependencies)
+            )
+        )
     dependencies.append(get_pip_string("inspect-flow"))
     if not any(
         _spec_is_inspect_ai(d) for d in dependencies
@@ -209,6 +214,17 @@ def _resolve_dependency(dependency: str, base_dir: str) -> str:
     if "/" in dependency:
         return absolute_path_relative_to(dependency, base_dir=base_dir)
     return dependency
+
+
+def _explicit_dependency_names(dependencies: List[str]) -> set[str]:
+    names: set[str] = set()
+    for dependency in dependencies:
+        try:
+            names.add(canonicalize_name(Requirement(dependency).name))
+        except InvalidRequirement:
+            # Paths, URLs, and VCS specs have no parseable package name to match.
+            continue
+    return names
 
 
 def _spec_is_inspect_ai(requirement: str) -> bool:

--- a/tests/test_venv.py
+++ b/tests/test_venv.py
@@ -231,6 +231,65 @@ def test_auto_dependency() -> None:
             ]
 
 
+def test_715_explicit_dependency_overrides_auto_pin() -> None:
+    with tempfile.TemporaryDirectory() as temp_dir:
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=[], returncode=0, stdout="mocked output"
+            )
+            spec = FlowSpec(
+                dependencies=FlowDependencies(
+                    additional_dependencies=["openai>=2.40.0"],
+                ),
+                tasks=[
+                    FlowTask(
+                        name="inspect_evals/task_name",
+                        model="openai/gpt-4o-mini",
+                    ),
+                ],
+            )
+
+            _create_venv(
+                spec=spec,
+                base_dir=".",
+                temp_dir=temp_dir,
+                env=os.environ.copy(),
+                dry_run=False,
+                action=_test_action,
+            )
+
+            assert mock_run.call_count == 2
+            args = mock_run.call_args.args[0]
+            flow_path = str((Path(__file__).parents[1]).resolve())
+            # The explicit "openai>=2.40.0" pin must win; the auto-detected
+            # "openai==<host version>" must be excluded to avoid a conflict.
+            assert args[:6] == [
+                "uv",
+                "pip",
+                "install",
+                "openai>=2.40.0",
+                "inspect_evals",
+                f"-e {flow_path}",
+            ]
+            assert not any(arg.startswith("openai==") for arg in args)
+
+
+def test_715_collect_auto_dependencies_exclude_packages() -> None:
+    spec = FlowSpec(
+        tasks=[
+            FlowTask(name="inspect_evals/task_name", model="openai/gpt-4o-mini"),
+        ]
+    )
+
+    dependencies = collect_auto_dependencies(spec)
+    assert any(dep.startswith("openai") for dep in dependencies)
+
+    # Canonicalization should match regardless of name normalization.
+    excluded = collect_auto_dependencies(spec, exclude_packages=["OpenAI"])
+    assert not any(dep.startswith("openai") for dep in excluded)
+    assert "inspect_evals" in excluded
+
+
 def test_no_auto_dependency() -> None:
     with tempfile.TemporaryDirectory() as temp_dir:
         with patch("subprocess.run") as mock_run:


### PR DESCRIPTION
Fixes Bug B of #715.

## Problem

In venv mode, `collect_auto_dependencies` pins every auto-detected package to the **exact installed host version** via `get_pip_string` (e.g. a task using an `openai/*` model auto-detects and freezes `openai==2.37.0`). When the user also explicitly pins that same package in `additional_dependencies`, both specifiers land on the `uv pip install` command line:

```
uv pip install inspect-ai>=0.3.240 openai>=2.40.0 ... openai==2.37.0 ...
                                    ^^^^^^^^^^^^^ explicit   ^^^^^^^^^^^^^^ auto-detected host freeze
```

uv intersects repeated requirements, so `openai>=2.40.0` ∧ `openai==2.37.0` is empty and resolution fails. The only way to avoid the collision was to disable auto-detection entirely (`auto_detect_dependencies=False`), which is a blunt instrument — it also drops detection of every other package (task packages, solvers, sandboxes).

## Fix

Auto-detection now **excludes any package the user named in `additional_dependencies`** (compared via `packaging.utils.canonicalize_name`, so `OpenAI` matches `openai`). The explicit pin — and the transitive requirements uv resolves from it — takes precedence over the host freeze, with no duplicate specifier to collide.

This means the workaround in the issue collapses from:

```python
FlowDependencies(
    auto_detect_dependencies=False,
    additional_dependencies=["inspect-ai>=0.3.240", "openai>=2.40.0"],
)
```

down to just keeping auto-detection on:

```python
FlowDependencies(
    additional_dependencies=["inspect-ai>=0.3.240", "openai>=2.40.0"],
)
```

## Scope / boundary

This fixes conflicts between an explicit pin and the auto-frozen host version **of the same package**. The issue's narrowest repro — pinning only `inspect-ai` and letting `openai` stay auto-detected — is not auto-resolved, because inspect-ai enforces its `openai>=2.40.0` minimum as a **runtime check, not package metadata**, so uv can't see the constraint to resolve around it. The user must still name `openai` explicitly in that case; this PR ensures doing so no longer requires turning auto-detection off.

## Changes

- `src/inspect_flow/_launcher/auto_dependencies.py` — `collect_auto_dependencies(spec, exclude_packages=())` skips canonicalized excluded names.
- `src/inspect_flow/_launcher/venv.py` — `_create_venv` parses the names from explicit `additional_dependencies` (new `_explicit_dependency_names` helper, which ignores paths/URLs/VCS specs that have no parseable name) and passes them as `exclude_packages`.

## Tests (`tests/test_venv.py`)

- `test_715_explicit_dependency_overrides_auto_pin` — explicit `openai>=2.40.0` with an openai-model task; asserts the explicit pin is installed and no `openai==<host>` pin is added.
- `test_715_collect_auto_dependencies_exclude_packages` — asserts exclusion works and is canonicalization-aware.

Generated with [Claude Code](https://claude.ai/code)
