### PR TITLE
Add claude-setup action so the Claude agents can run tests

### DIFF
--- a/.github/actions/claude-setup/action.yaml
+++ b/.github/actions/claude-setup/action.yaml
@@ -1,0 +1,15 @@
+name: Claude agent environment
+description: >-
+  Provision the project so Claude Code agents (dev + reviewer) can actually run
+  pytest/ruff/pyright instead of falling back to static checks. Invoked by the
+  reusable agent workflows in meridianlabs-ai/agents when present. Delegates to
+  the existing CI setup so the install logic and uv cache are shared, not
+  duplicated.
+
+runs:
+  using: composite
+  steps:
+    - uses: ./.github/actions/setup
+      with:
+        # CI runs a 3.10/3.11 matrix; the agent only needs one interpreter.
+        python-version: "3.11"


### PR DESCRIPTION
## What

Adds `.github/actions/claude-setup`, a one-step composite action that delegates to the existing `.github/actions/setup` (uv + cache + `uv sync --dev`).

## Why

The reusable Claude dev/review workflows ([`meridianlabs-ai/agents@main`](https://github.com/meridianlabs-ai/agents)) now look for `.github/actions/claude-setup` and run it between checkout and the agent (guarded by `hashFiles`, so it's a no-op for repos that don't define it). Until a repo adds this shim, the agents run against a bare runner with no dependencies installed, so they can only verify with `py_compile` and reasoning.

That's exactly what happened on #715's review: the reviewer reported *"env not provisioned: no pytest/inspect_flow"* and LGTM'd on static checks alone ([comment](https://github.com/meridianlabs-ai/inspect_flow/pull/726#issuecomment-4745118694)). With this action present, both the dev agent and the reviewer get a real `.venv` and can run `uv run pytest`/`ruff`/`pyright`.

No install logic is duplicated — the shim delegates to the existing CI setup action, so it rides the same uv cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)