### PR TITLE
Pass secrets through to the reusable Claude workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -38,12 +38,16 @@ jobs:
       contains(github.event.issue.title, '@claude') ||
       github.event.label.name == 'claude'
     uses: meridianlabs-ai/agents/.github/workflows/claude.yml@main
-    # Pass MARVIN_TOKEN (the machine-account PAT, an org secret) through to the
-    # reusable workflow so agent-opened PRs trigger CI and @review. `inherit` is
-    # harmless where the secret isn't available — the agent still runs, but
-    # issue-triggered PR creation degrades (see the reusable workflow's
+    # Pass the machine-account PAT (MARVIN_TOKEN, an org secret) through to the
+    # reusable workflow so agent-opened PRs trigger CI and @review. Passed
+    # explicitly — NOT via `secrets: inherit` — so this repo's other secrets
+    # aren't exposed to an external workflow pinned to a mutable @main ref
+    # (least privilege; the reusable workflow consumes only this one secret).
+    # An absent MARVIN_TOKEN resolves to empty: the agent still runs, just with
+    # issue-triggered PR creation degraded (see the reusable workflow's
     # secrets.MARVIN_TOKEN and design/auto-agent.md).
-    secrets: inherit
+    secrets:
+      MARVIN_TOKEN: ${{ secrets.MARVIN_TOKEN }}
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -8,6 +8,15 @@
 
 name: Claude
 
+# Trigger-resolution caveat: GitHub runs issue_comment / issues workflows from
+# the DEFAULT branch, but pull_request_review_comment / pull_request_review
+# (the pull_request family) from the PR's OWN branches. So the latter two only
+# fire where this file exists on the PR's base/head branch. On a pristine-base
+# mirror like the inspect_ai fork — where the Claude workflows live only on the
+# default branch and PRs target an upstream-mirror base that lacks them — those
+# two never fire; only top-level @claude comments (issue_comment) and the
+# `claude` label (issues) work. Drop the two review triggers in that setup so
+# the surface matches reality (the fork's deployed stub does).
 on:
   issue_comment:
     types: [created]
@@ -29,6 +38,12 @@ jobs:
       contains(github.event.issue.title, '@claude') ||
       github.event.label.name == 'claude'
     uses: meridianlabs-ai/agents/.github/workflows/claude.yml@main
+    # Pass MARVIN_TOKEN (the machine-account PAT, an org secret) through to the
+    # reusable workflow so agent-opened PRs trigger CI and @review. `inherit` is
+    # harmless where the secret isn't available — the agent still runs, but
+    # issue-triggered PR creation degrades (see the reusable workflow's
+    # secrets.MARVIN_TOKEN and design/auto-agent.md).
+    secrets: inherit
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
Adds `secrets: inherit` to the Claude dev-agent stub so `MARVIN_TOKEN` (the `marvin@meridianlabs.ai` machine-account PAT, an org secret) reaches the reusable workflow in `meridianlabs-ai/agents`.

**Why:** the reusable workflow now passes that token to claude-code-action as `github_token`, so the agent acts as the machine account. Its branch pushes and the PR it opens on issue-triggered runs then trigger CI and `@review` — which a `GITHUB_TOKEN`-opened PR cannot (GitHub's recursion guard). This is Phase 0 of the `@auto` design (`design/auto-agent.md` in the agents repo).

**Before merging:** confirm the org `MARVIN_TOKEN` secret is scoped to this repo. If it isn't, `inherit` passes nothing and the dev agent simply runs as before — no breakage either way.

**Testing after merge:** label an issue `claude` (or comment `@claude …`) and confirm it opens a PR that shows CI checks running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)