### PR TITLE
Add @auto CI-fix loop stub (Phase 1)

### DIFF
--- a/.github/workflows/claude-auto.yml
+++ b/.github/workflows/claude-auto.yml
@@ -1,0 +1,41 @@
+# Copy to .github/workflows/claude-auto.yml in a Meridian repo to enable the
+# @auto CI-failure -> fix loop (design/auto-agent.md, Phase 1). Independent of
+# the dev agent (claude.yml) and reviewer (claude-review.yml).
+#
+# Requires the MARVIN_TOKEN org secret scoped to this repo (same as claude.yml).
+#
+# REQUIRED EDIT: list THIS repo's CI workflow name(s) under `workflows:` below —
+# the `name:` field of each CI workflow (not its filename). workflow_run is the
+# only event that reliably fires for GitHub-Actions CI completing (check_suite
+# is suppressed for Actions-created suites), and it must name the workflows it
+# reacts to. Find them with: gh workflow list.
+
+name: Claude Auto
+
+on:
+  workflow_run:
+    # <-- replace with this repo's CI workflow name(s), e.g. ["Build"]
+    workflows: ["Build"]
+    types: [completed]
+
+jobs:
+  auto:
+    # React only to a *failed* CI run for a *same-repo* PR. Same-repo excludes
+    # external fork PRs (no secrets, untrusted) — our agent PRs are same-repo.
+    # The reusable workflow does the authoritative gate (open PR + `auto` label).
+    if: >-
+      github.event.workflow_run.conclusion == 'failure' &&
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.head_repository.full_name == github.repository
+    uses: meridianlabs-ai/agents/.github/workflows/claude-auto.yml@main
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    secrets:
+      MARVIN_TOKEN: ${{ secrets.MARVIN_TOKEN }}
+    with:
+      head_branch: ${{ github.event.workflow_run.head_branch }}
+      ci_run_id: ${{ github.event.workflow_run.id }}


### PR DESCRIPTION
Adds `.github/workflows/claude-auto.yml`, wired to the **Build** CI workflow, enabling the `@auto` Phase 1 loop (design/auto-agent.md in the agents repo).

When **Build** fails on a same-repo PR carrying the **`auto`** label, the reusable `claude-auto.yml` wakes the dev agent (as `i-am-marvin`) to read the failing logs, fix on the branch, and push — re-running CI. Bounded by a 3-attempt cap, after which it comments and removes the `auto` label (the kill-switch).

Inert for any PR without the `auto` label. Needs to be on the default branch to fire (workflow_run resolves there), hence this PR.

**After merge** I'll validate end-to-end with a deliberately CI-failing `auto`-labeled PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)