### PR TITLE
Add @auto review->fix trigger (Phase 2)

### DIFF
--- a/.github/workflows/claude-auto.yml
+++ b/.github/workflows/claude-auto.yml
@@ -45,12 +45,16 @@ jobs:
       head_branch: ${{ github.event.workflow_run.head_branch }}
       ci_run_id: ${{ github.event.workflow_run.id }}
 
-  # Review -> fix. Skip approvals here (nothing to address); the reusable
-  # workflow gates the rest (reviewer identity + `auto` label + round cap).
+  # Review -> fix. Same-repo only (the reusable workflow checks out and runs the
+  # PR head code, and pull_request_review runs in base-repo context with secrets
+  # even for fork PRs — so exclude forks here, matching ci-fix). Skip approvals
+  # (nothing to address); the reusable workflow gates the rest (reviewer identity
+  # + `auto` label + round cap).
   review-fix:
     if: >-
       github.event_name == 'pull_request_review' &&
-      github.event.review.state != 'approved'
+      github.event.review.state != 'approved' &&
+      github.event.pull_request.head.repo.full_name == github.repository
     uses: meridianlabs-ai/agents/.github/workflows/claude-auto-review.yml@main
     permissions:
       contents: write

--- a/.github/workflows/claude-auto.yml
+++ b/.github/workflows/claude-auto.yml
@@ -1,29 +1,34 @@
 # Copy to .github/workflows/claude-auto.yml in a Meridian repo to enable the
-# @auto CI-failure -> fix loop (design/auto-agent.md, Phase 1). Independent of
-# the dev agent (claude.yml) and reviewer (claude-review.yml).
+# @auto autonomous loop (design/auto-agent.md). Independent of the dev agent
+# (claude.yml) and reviewer (claude-review.yml).
 #
 # Requires the MARVIN_TOKEN org secret scoped to this repo (same as claude.yml).
 #
-# REQUIRED EDIT: list THIS repo's CI workflow name(s) under `workflows:` below —
-# the `name:` field of each CI workflow (not its filename). workflow_run is the
-# only event that reliably fires for GitHub-Actions CI completing (check_suite
-# is suppressed for Actions-created suites), and it must name the workflows it
-# reacts to. Find them with: gh workflow list.
+# REQUIRED EDIT: under `workflows:` list THIS repo's CI workflow name(s) — the
+# `name:` field of each CI workflow (not its filename). workflow_run is the only
+# event that reliably fires for GitHub-Actions CI completing (check_suite is
+# suppressed for Actions-created suites), and it must name what it reacts to.
+# Find names with: gh workflow list.
 
 name: Claude Auto
 
 on:
+  # Phase 1: react to CI completing (so we can fix failures).
   workflow_run:
     # <-- replace with this repo's CI workflow name(s), e.g. ["Build"]
     workflows: ["Build"]
     types: [completed]
+  # Phase 2: react to the automated reviewer posting a review.
+  pull_request_review:
+    types: [submitted]
 
 jobs:
-  auto:
-    # React only to a *failed* CI run for a *same-repo* PR. Same-repo excludes
-    # external fork PRs (no secrets, untrusted) — our agent PRs are same-repo.
-    # The reusable workflow does the authoritative gate (open PR + `auto` label).
+  # CI-failure -> fix. Only a *failed* CI run for a *same-repo* PR (same-repo
+  # excludes untrusted fork PRs). The reusable workflow does the authoritative
+  # gate (open PR + `auto` label + attempt cap).
+  ci-fix:
     if: >-
+      github.event_name == 'workflow_run' &&
       github.event.workflow_run.conclusion == 'failure' &&
       github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.head_repository.full_name == github.repository
@@ -39,3 +44,24 @@ jobs:
     with:
       head_branch: ${{ github.event.workflow_run.head_branch }}
       ci_run_id: ${{ github.event.workflow_run.id }}
+
+  # Review -> fix. Skip approvals here (nothing to address); the reusable
+  # workflow gates the rest (reviewer identity + `auto` label + round cap).
+  review-fix:
+    if: >-
+      github.event_name == 'pull_request_review' &&
+      github.event.review.state != 'approved'
+    uses: meridianlabs-ai/agents/.github/workflows/claude-auto-review.yml@main
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    secrets:
+      MARVIN_TOKEN: ${{ secrets.MARVIN_TOKEN }}
+    with:
+      pr_number: ${{ github.event.pull_request.number }}
+      head_branch: ${{ github.event.pull_request.head.ref }}
+      review_id: ${{ github.event.review.id }}
+      review_author: ${{ github.event.review.user.login }}


### PR DESCRIPTION
Extends `.github/workflows/claude-auto.yml` with the **Phase 2** review→fix loop: a `pull_request_review` trigger + `review-fix` job calling the new reusable `claude-auto-review.yml` (in meridianlabs-ai/agents).

When the automated reviewer (`claude[bot]`) posts a review on an **`auto`**-labeled PR, the dev agent (as `i-am-marvin`) addresses the feedback, pushes, and re-requests `@review` — closing the loop. Bounded by a 3-round cap; at the cap it comments and removes the `auto` label.

Must be on the default branch to fire (`pull_request_review` resolves there), hence this PR. Inert without the `auto` label.

**After merge** I'll validate end-to-end with an `auto`-labeled PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)