### PR TITLE
Test @auto Phase 2: review->fix loop (planted clamp bug)

### DIFF
--- a/tests/test_auto_review_DELETEME.py
+++ b/tests/test_auto_review_DELETEME.py
@@ -3,9 +3,14 @@ def clamp(value: int, low: int, high: int) -> int:
 
     Returns low if value < low, high if value > high, otherwise value.
     """
-    return max(low, value)
+    return min(high, max(low, value))
 
 
 def test_clamp_lower_bound() -> None:
     assert clamp(-5, 0, 10) == 0
     assert clamp(3, 0, 10) == 3
+
+
+def test_clamp_upper_bound() -> None:
+    assert clamp(15, 0, 10) == 10
+    assert clamp(10, 0, 10) == 10

--- a/tests/test_auto_review_DELETEME.py
+++ b/tests/test_auto_review_DELETEME.py
@@ -1,0 +1,11 @@
+def clamp(value: int, low: int, high: int) -> int:
+    """Clamp value to the inclusive range [low, high].
+
+    Returns low if value < low, high if value > high, otherwise value.
+    """
+    return max(low, value)
+
+
+def test_clamp_lower_bound() -> None:
+    assert clamp(-5, 0, 10) == 0
+    assert clamp(3, 0, 10) == 3


### PR DESCRIPTION
Smoke test of the @auto review->fix loop (Phase 2). `clamp()`'s docstring promises an upper bound, but the body (`max(low, value)`) ignores `high`; the test only covers the lower bound, so CI passes. @review should flag the upper-bound bug, and @auto should fix it and re-request review. Throwaway — will be closed.