### PR TITLE
@auto: switch review loop to issue_comment trigger

### DIFF
--- a/.github/workflows/claude-auto.yml
+++ b/.github/workflows/claude-auto.yml
@@ -18,9 +18,11 @@ on:
     # <-- replace with this repo's CI workflow name(s), e.g. ["Build"]
     workflows: ["Build"]
     types: [completed]
-  # Phase 2: react to the automated reviewer posting a review.
-  pull_request_review:
-    types: [submitted]
+  # Phase 2/3: react to the reviewer's marked summary comment. issue_comment
+  # fires from the default branch, so this works on pristine-base forks too
+  # (unlike pull_request_review).
+  issue_comment:
+    types: [created]
 
 jobs:
   # CI-failure -> fix. Only a *failed* CI run for a *same-repo* PR (same-repo
@@ -43,18 +45,19 @@ jobs:
       MARVIN_TOKEN: ${{ secrets.MARVIN_TOKEN }}
     with:
       head_branch: ${{ github.event.workflow_run.head_branch }}
+      pr_number: ${{ github.event.workflow_run.pull_requests[0].number }}
       ci_run_id: ${{ github.event.workflow_run.id }}
 
-  # Review -> fix. Same-repo only (the reusable workflow checks out and runs the
-  # PR head code, and pull_request_review runs in base-repo context with secrets
-  # even for fork PRs — so exclude forks here, matching ci-fix). Skip approvals
-  # (nothing to address); the reusable workflow gates the rest (reviewer identity
-  # + `auto` label + round cap).
+  # Review -> fix / handoff. Fire only on the reviewer's marked summary comment
+  # on a PR. Cheap gate here (it's a PR, author is the reviewer, body has the
+  # marker); the reusable workflow does the rest (same-repo, `auto` label, round
+  # cap). Adjust the reviewer login if yours differs from claude[bot].
   review-fix:
     if: >-
-      github.event_name == 'pull_request_review' &&
-      github.event.review.state != 'approved' &&
-      github.event.pull_request.head.repo.full_name == github.repository
+      github.event_name == 'issue_comment' &&
+      github.event.issue.pull_request != null &&
+      github.event.comment.user.login == 'claude[bot]' &&
+      contains(github.event.comment.body, '<!-- claude-review-summary -->')
     uses: meridianlabs-ai/agents/.github/workflows/claude-auto-review.yml@main
     permissions:
       contents: write
@@ -65,7 +68,5 @@ jobs:
     secrets:
       MARVIN_TOKEN: ${{ secrets.MARVIN_TOKEN }}
     with:
-      pr_number: ${{ github.event.pull_request.number }}
-      head_branch: ${{ github.event.pull_request.head.ref }}
-      review_id: ${{ github.event.review.id }}
-      review_author: ${{ github.event.review.user.login }}
+      pr_number: ${{ github.event.issue.number }}
+      comment_author: ${{ github.event.comment.user.login }}


### PR DESCRIPTION
Updates the `@auto` stub to match the reworked reusable workflows (meridianlabs-ai/agents): the review→fix loop now triggers on the reviewer's **marked summary comment** (`issue_comment`) instead of `pull_request_review`.

**Why:** `pull_request_review` resolves workflows from the PR base branch, so it never fires on the pristine-base inspect_ai fork. `issue_comment` resolves from the default branch and fires everywhere — one mechanism for all repos. (`@review` now always posts a marked summary comment, `<!-- claude-review-summary -->`, that @auto keys on.)

Also passes `pr_number` to `ci-fix` so CI-fix and review-fix share a per-PR concurrency group.

**Merge promptly:** the reusable `claude-auto-review.yml@main` already expects the new inputs, so the current deployed stub is mismatched until this lands (a `pull_request_review` here would error). After merge I'll re-validate the review→fix + handoff loop end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)