### PR TITLE
@auto: make review-fix gate fire (router stub + authoritative reusable gate)

### DIFF
--- a/.github/workflows/claude-auto.yml
+++ b/.github/workflows/claude-auto.yml
@@ -55,7 +55,7 @@ jobs:
   review-fix:
     if: >-
       github.event_name == 'issue_comment' &&
-      github.event.issue.pull_request != null &&
+      github.event.issue.pull_request != '' &&
       github.event.comment.user.login == 'claude[bot]' &&
       contains(github.event.comment.body, '<!-- claude-review-summary -->')
     uses: meridianlabs-ai/agents/.github/workflows/claude-auto-review.yml@main

--- a/.github/workflows/claude-auto.yml
+++ b/.github/workflows/claude-auto.yml
@@ -55,8 +55,6 @@ jobs:
   review-fix:
     if: >-
       github.event_name == 'issue_comment' &&
-      github.event.issue.pull_request != '' &&
-      github.event.comment.user.login == 'claude[bot]' &&
       contains(github.event.comment.body, '<!-- claude-review-summary -->')
     uses: meridianlabs-ai/agents/.github/workflows/claude-auto-review.yml@main
     permissions:


### PR DESCRIPTION
The unified `issue_comment` review loop wasn't firing: `review-fix` was being skipped. A reviewer correctly pointed out my first attempt (`!= null` → `!= ''`) was a no-op (the two coerce identically), so this replaces it with the right fix + instrumentation:

- The stub `review-fix` `if` is now a **cheap router** — `issue_comment` + the `<!-- claude-review-summary -->` marker.
- **Authoritative gating moves into the reusable** `claude-auto-review.yml@main` (comment author == reviewer, same-repo, `auto` label, round cap), which now **logs the actual `comment_author`** on entry. The marker is forgeable, but the reusable's bot-login check remains the security gate.

This makes `review-fix` actually run and surfaces exactly which condition was failing. Merge and I'll re-validate the loop end-to-end on the open test PR (#738).