### PR TITLE
@auto: add PR-guard pre-filter to review-fix gate

### DIFF
--- a/.github/workflows/claude-auto.yml
+++ b/.github/workflows/claude-auto.yml
@@ -55,6 +55,7 @@ jobs:
   review-fix:
     if: >-
       github.event_name == 'issue_comment' &&
+      github.event.issue.pull_request != '' &&
       contains(github.event.comment.body, '<!-- claude-review-summary -->')
     uses: meridianlabs-ai/agents/.github/workflows/claude-auto-review.yml@main
     permissions:


### PR DESCRIPTION
Non-blocking hardening (per the inspect_ai#21 review): add `github.event.issue.pull_request != ''` to the `review-fix` gate so it only fires on PR comments, consistent with claude-review.yml. Authoritative gating (reviewer identity, same-repo, `auto` label, cap) remains in the reusable workflow.