### PR TITLE
Add @auto kickoff (auto label / @auto mention)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -54,3 +54,28 @@ jobs:
       issues: write
       id-token: write
       actions: read
+
+  # @auto kickoff (distinct from the one-shot `claude` above). An `auto` label or
+  # `@auto` mention drives the issue autonomously: the dev agent opens a PR, the
+  # PR inherits the `auto` label (so the loop in claude-auto.yml engages), and it
+  # runs to a human handoff. Same reusable dev workflow, different trigger — the
+  # action's trigger_phrase/label_trigger are single-valued, so `auto` needs its
+  # own invocation. Needs MARVIN_TOKEN (the PR must trigger CI/@review).
+  claude-auto:
+    if: |
+      contains(github.event.comment.body, '@auto') ||
+      contains(github.event.issue.body, '@auto') ||
+      contains(github.event.issue.title, '@auto') ||
+      github.event.label.name == 'auto'
+    uses: meridianlabs-ai/agents/.github/workflows/claude.yml@main
+    secrets:
+      MARVIN_TOKEN: ${{ secrets.MARVIN_TOKEN }}
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    with:
+      trigger_phrase: "@auto"
+      label_trigger: "auto"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -64,6 +64,7 @@ jobs:
   claude-auto:
     if: |
       contains(github.event.comment.body, '@auto') ||
+      contains(github.event.review.body, '@auto') ||
       contains(github.event.issue.body, '@auto') ||
       contains(github.event.issue.title, '@auto') ||
       github.event.label.name == 'auto'


### PR DESCRIPTION
Wires the `auto` label (and `@auto` mention) as an **autonomous kickoff**, distinct from the one-shot `claude`/`@claude`.

**The gap:** labeling an issue `auto` did nothing — the dev agent only triggers on `claude`/`@claude`, and `auto` was only the loop gate on PRs (e.g. #718 labeled `auto` saw no action).

**Fix:** adds a second `claude-auto` job that invokes the same reusable dev workflow with `trigger_phrase: '@auto'` / `label_trigger: 'auto'` (the action's trigger fields are single-valued, so `auto` needs its own job). The reusable's PR-open post-step now propagates the `auto` label from the issue onto the new PR, so the loop engages. `claude`/`@claude` is unchanged (one-shot, human-driven).

After merge, labeling an issue `auto` → agent opens an `auto`-labeled PR → CI-fix / review-fix loop → handoff. I'll verify on a test issue.