### PR TITLE
fix: return RunResult from public run()

### DIFF
--- a/src/inspect_flow/_api/api.py
+++ b/src/inspect_flow/_api/api.py
@@ -92,7 +92,7 @@ def run(
     *,
     dry_run: bool = False,
     resume: bool = False,
-) -> RunResult | None:
+) -> RunResult:
     """Run an inspect_flow evaluation.
 
     Args:
@@ -102,8 +102,10 @@ def run(
         resume: If `True`, reuse the log directory from the previous run.
 
     Returns:
-        A RunResult with the success flag, eval logs, and log directory when run
-        inproc. None when run in a venv (the result lives in the subprocess).
+        A RunResult with the success flag, eval logs, and log directory. For venv
+        execution the eval logs live in the subprocess, so `logs` is empty and
+        `success` reflects the subprocess outcome. For a dry run, the success flag
+        is always `False` and the eval logs are empty.
 
     Raises:
         RuntimeError: If called from within a flow spec file being loaded.
@@ -117,14 +119,11 @@ def run(
     ensure_init(dotenv_base_dir=base_dir)
     base_dir = base_dir or Path().cwd().as_posix()
     spec = expand_spec(spec, base_dir=base_dir, options=ConfigOptions(resume=resume))
-    result = launch(
+    success, logs = launch(
         spec=spec,
         base_dir=base_dir,
         dry_run=dry_run,
     )
-    if result is None:
-        return None
-    success, logs = result
     assert spec.log_dir
     return RunResult(success=success, logs=logs, log_dir=spec.log_dir)
 

--- a/src/inspect_flow/_api/api.py
+++ b/src/inspect_flow/_api/api.py
@@ -131,18 +131,36 @@ def run(
 
 @dataclass
 class CheckTask:
-    name: str  # resolved task name
-    task: FlowTask  # original spec input (post-expansion)
-    log_file: str | None  # path to matched log, None if no log found
-    samples: int  # completed samples in log (0 if no log)
-    total_samples: int | None  # expected samples (None if unknown)
-    duplicate_logs: list[str]  # log file paths that are duplicates of log_file
+    """Completeness status of a single task in a checked eval set."""
+
+    name: str
+    """Resolved task name."""
+
+    task: FlowTask
+    """Original spec input (post-expansion)."""
+
+    log_file: str | None
+    """Path to the matched log, or `None` if no log was found."""
+
+    samples: int
+    """Completed samples in the log (0 if no log)."""
+
+    total_samples: int | None
+    """Expected samples, or `None` if unknown."""
+
+    duplicate_logs: list[str]
+    """Log file paths that are duplicates of `log_file`."""
 
 
 @dataclass
 class CheckResult:
+    """Result of checking an inspect_flow evaluation against existing logs."""
+
     tasks: list[CheckTask]
-    unrecognized: list[str]  # log file paths not matching any task in spec
+    """Per-task completeness status for the checked spec."""
+
+    unrecognized: list[str]
+    """Log file paths not matching any task in the spec."""
 
 
 def check(

--- a/src/inspect_flow/_api/api.py
+++ b/src/inspect_flow/_api/api.py
@@ -131,22 +131,22 @@ def run(
 
 @dataclass
 class CheckTask:
-    """Completeness status of a single task in a checked eval set."""
+    """Completeness information for a single task in a checked flow spec."""
 
     name: str
-    """Resolved task name."""
+    """The resolved task name."""
 
     task: FlowTask
-    """Original spec input (post-expansion)."""
+    """The original spec input for the task (post-expansion)."""
 
     log_file: str | None
-    """Path to the matched log, or `None` if no log was found."""
+    """Path to the matched log, or None if no log was found."""
 
     samples: int
-    """Completed samples in the log (0 if no log)."""
+    """Number of completed samples in the log (0 if no log)."""
 
     total_samples: int | None
-    """Expected samples, or `None` if unknown."""
+    """Expected number of samples, or None if unknown."""
 
     duplicate_logs: list[str]
     """Log file paths that are duplicates of `log_file`."""
@@ -157,7 +157,7 @@ class CheckResult:
     """Result of checking an inspect_flow evaluation against existing logs."""
 
     tasks: list[CheckTask]
-    """Per-task completeness status for the checked spec."""
+    """Completeness information for each task in the spec."""
 
     unrecognized: list[str]
     """Log file paths not matching any task in the spec."""

--- a/src/inspect_flow/_api/api.py
+++ b/src/inspect_flow/_api/api.py
@@ -5,6 +5,7 @@ from typing import Any
 from dotenv import find_dotenv, load_dotenv
 from inspect_ai._util.file import filesystem
 from inspect_ai._util.path import chdir_python
+from inspect_ai.log import EvalLog
 
 from inspect_flow._config.load import (
     ConfigOptions,
@@ -71,13 +72,27 @@ def load_spec(
     return int_load_spec(file=file, options=ConfigOptions(args=args or {}))
 
 
+@dataclass
+class RunResult:
+    """Result of running an inspect_flow evaluation."""
+
+    success: bool
+    """Whether all tasks in the eval set completed successfully."""
+
+    logs: list[EvalLog]
+    """The eval log headers produced by the run."""
+
+    log_dir: str
+    """The log directory the run wrote to."""
+
+
 def run(
     spec: FlowSpec,
     base_dir: str | None = None,
     *,
     dry_run: bool = False,
     resume: bool = False,
-) -> None:
+) -> RunResult | None:
     """Run an inspect_flow evaluation.
 
     Args:
@@ -85,6 +100,10 @@ def run(
         base_dir: The base directory for resolving relative paths. Defaults to the current working directory.
         dry_run: If `True`, do not run eval, but show a count of tasks that would be run.
         resume: If `True`, reuse the log directory from the previous run.
+
+    Returns:
+        A RunResult with the success flag, eval logs, and log directory when run
+        inproc. None when run in a venv (the result lives in the subprocess).
 
     Raises:
         RuntimeError: If called from within a flow spec file being loaded.
@@ -98,11 +117,16 @@ def run(
     ensure_init(dotenv_base_dir=base_dir)
     base_dir = base_dir or Path().cwd().as_posix()
     spec = expand_spec(spec, base_dir=base_dir, options=ConfigOptions(resume=resume))
-    launch(
+    result = launch(
         spec=spec,
         base_dir=base_dir,
         dry_run=dry_run,
     )
+    if result is None:
+        return None
+    success, logs = result
+    assert spec.log_dir
+    return RunResult(success=success, logs=logs, log_dir=spec.log_dir)
 
 
 @dataclass

--- a/src/inspect_flow/_launcher/inproc.py
+++ b/src/inspect_flow/_launcher/inproc.py
@@ -1,6 +1,8 @@
 import os
 from logging import getLogger
 
+from inspect_ai.log import EvalLog
+
 from inspect_flow._display.run_action import RunAction
 from inspect_flow._launcher.freeze import write_flow_requirements
 from inspect_flow._runner.check import check_eval_set
@@ -11,13 +13,15 @@ from inspect_flow._types.flow_types import FlowSpec
 logger = getLogger(__name__)
 
 
-def inproc_launch(spec: FlowSpec, base_dir: str, dry_run: bool) -> None:
+def inproc_launch(
+    spec: FlowSpec, base_dir: str, dry_run: bool
+) -> tuple[bool, list[EvalLog]]:
     with RunAction("env", info="inproc"):
         if spec.env:
             os.environ.update(spec.env)
 
         write_flow_requirements(spec, cwd=".", env=os.environ.copy(), dry_run=dry_run)
-    run_eval_set(spec, base_dir=base_dir, dry_run=dry_run)
+    return run_eval_set(spec, base_dir=base_dir, dry_run=dry_run)
 
 
 def inproc_check(spec: FlowSpec, base_dir: str) -> FindLogsResult:

--- a/src/inspect_flow/_launcher/launch.py
+++ b/src/inspect_flow/_launcher/launch.py
@@ -1,5 +1,7 @@
 from logging import getLogger
 
+from inspect_ai.log import EvalLog
+
 from inspect_flow._launcher.inproc import inproc_check, inproc_launch
 from inspect_flow._launcher.venv import venv_check, venv_launch
 from inspect_flow._runner.logs import FindLogsResult
@@ -10,7 +12,9 @@ from inspect_flow._util.path_util import absolute_path_relative_to
 logger = getLogger(__name__)
 
 
-def launch(spec: FlowSpec, base_dir: str, dry_run: bool = False) -> None:
+def launch(
+    spec: FlowSpec, base_dir: str, dry_run: bool = False
+) -> tuple[bool, list[EvalLog]] | None:
     if not spec.log_dir:
         raise ValueError("log_dir must be set before launching the flow spec")
     spec.log_dir = absolute_path_relative_to(spec.log_dir, base_dir=base_dir)
@@ -30,8 +34,9 @@ def launch(spec: FlowSpec, base_dir: str, dry_run: bool = False) -> None:
 
     if spec.execution_type == "venv":
         venv_launch(spec=spec, base_dir=base_dir, dry_run=dry_run)
+        return None
     else:
-        inproc_launch(spec=spec, base_dir=base_dir, dry_run=dry_run)
+        return inproc_launch(spec=spec, base_dir=base_dir, dry_run=dry_run)
 
 
 def launch_check(spec: FlowSpec, base_dir: str) -> FindLogsResult | None:

--- a/src/inspect_flow/_launcher/launch.py
+++ b/src/inspect_flow/_launcher/launch.py
@@ -14,7 +14,7 @@ logger = getLogger(__name__)
 
 def launch(
     spec: FlowSpec, base_dir: str, dry_run: bool = False
-) -> tuple[bool, list[EvalLog]] | None:
+) -> tuple[bool, list[EvalLog]]:
     if not spec.log_dir:
         raise ValueError("log_dir must be set before launching the flow spec")
     spec.log_dir = absolute_path_relative_to(spec.log_dir, base_dir=base_dir)
@@ -33,8 +33,7 @@ def launch(
             }
 
     if spec.execution_type == "venv":
-        venv_launch(spec=spec, base_dir=base_dir, dry_run=dry_run)
-        return None
+        return venv_launch(spec=spec, base_dir=base_dir, dry_run=dry_run)
     else:
         return inproc_launch(spec=spec, base_dir=base_dir, dry_run=dry_run)
 

--- a/src/inspect_flow/_launcher/venv.py
+++ b/src/inspect_flow/_launcher/venv.py
@@ -30,12 +30,13 @@ from inspect_flow._launcher.python_version import resolve_python_version
 from inspect_flow._runner.cli import CHECK_ACTIONS, RUN_ACTIONS
 from inspect_flow._types.flow_types import FlowAgent, FlowSolver, FlowSpec, FlowTask
 from inspect_flow._util.console import path
-from inspect_flow._util.data import LAST_RUN_SUCCESS_KEY, read_data
 from inspect_flow._util.logging import get_last_log_level
 from inspect_flow._util.path_util import absolute_path_relative_to
 from inspect_flow._util.subprocess_util import (
     CHILD_READY_FD_ENV,
     PARENT_ACK_FD_ENV,
+    RUN_RESULT_FILE_ENV,
+    read_run_result,
     run_with_logging,
 )
 
@@ -45,17 +46,20 @@ logger = getLogger(__name__)
 def venv_launch(
     spec: FlowSpec, base_dir: str, dry_run: bool
 ) -> tuple[bool, list[EvalLog]]:
-    _venv_spawn(spec, base_dir=base_dir, subcommand="run", dry_run=dry_run)
     # The eval logs live in the subprocess; only the success flag is signaled back
-    # (via the data channel) on a clean exit. A crash raises in _venv_spawn.
-    return bool(read_data(LAST_RUN_SUCCESS_KEY)), []
+    # (via a per-run result file) on a clean exit. A crash raises in _venv_spawn.
+    success = _venv_spawn(spec, base_dir=base_dir, subcommand="run", dry_run=dry_run)
+    assert success is not None
+    return success, []
 
 
 def venv_check(spec: FlowSpec, base_dir: str) -> None:
     _venv_spawn(spec, base_dir=base_dir, subcommand="check", dry_run=True)
 
 
-def _venv_spawn(spec: FlowSpec, base_dir: str, subcommand: str, dry_run: bool) -> None:
+def _venv_spawn(
+    spec: FlowSpec, base_dir: str, subcommand: str, dry_run: bool
+) -> bool | None:
     action_keys = (
         list(RUN_ACTIONS.keys()) if subcommand == "run" else list(CHECK_ACTIONS.keys())
     )
@@ -110,6 +114,11 @@ def _venv_spawn(spec: FlowSpec, base_dir: str, subcommand: str, dry_run: bool) -
         env[CHILD_READY_FD_ENV] = str(child_ready_w)
         env[PARENT_ACK_FD_ENV] = str(parent_ack_r)
 
+        # Per-run path (in temp_dir) the run child writes its success flag to
+        result_path = Path(temp_dir) / "run_result.json"
+        if subcommand == "run":
+            env[RUN_RESULT_FILE_ENV] = str(result_path)
+
         process = subprocess.Popen(
             [str(python_path), str(run_path), subcommand, "--file", file, *args],
             env=env,
@@ -137,6 +146,10 @@ def _venv_spawn(spec: FlowSpec, base_dir: str, subcommand: str, dry_run: bool) -
                 returncode=process.returncode,
                 cmd=process.args,
             )
+
+        if subcommand == "run":
+            return read_run_result(str(result_path))
+        return None
 
 
 def _check_spec_for_venv(spec: FlowSpec) -> None:

--- a/src/inspect_flow/_launcher/venv.py
+++ b/src/inspect_flow/_launcher/venv.py
@@ -9,6 +9,7 @@ from typing import Callable, List, Literal, Sequence
 
 from inspect_ai import Task
 from inspect_ai._util.file import absolute_file_path
+from inspect_ai.log import EvalLog
 from inspect_ai.model import Model
 from inspect_ai.scorer import Scorer
 from packaging.requirements import InvalidRequirement, Requirement
@@ -29,6 +30,7 @@ from inspect_flow._launcher.python_version import resolve_python_version
 from inspect_flow._runner.cli import CHECK_ACTIONS, RUN_ACTIONS
 from inspect_flow._types.flow_types import FlowAgent, FlowSolver, FlowSpec, FlowTask
 from inspect_flow._util.console import path
+from inspect_flow._util.data import LAST_RUN_SUCCESS_KEY, read_data
 from inspect_flow._util.logging import get_last_log_level
 from inspect_flow._util.path_util import absolute_path_relative_to
 from inspect_flow._util.subprocess_util import (
@@ -40,8 +42,13 @@ from inspect_flow._util.subprocess_util import (
 logger = getLogger(__name__)
 
 
-def venv_launch(spec: FlowSpec, base_dir: str, dry_run: bool) -> None:
+def venv_launch(
+    spec: FlowSpec, base_dir: str, dry_run: bool
+) -> tuple[bool, list[EvalLog]]:
     _venv_spawn(spec, base_dir=base_dir, subcommand="run", dry_run=dry_run)
+    # The eval logs live in the subprocess; only the success flag is signaled back
+    # (via the data channel) on a clean exit. A crash raises in _venv_spawn.
+    return bool(read_data(LAST_RUN_SUCCESS_KEY)), []
 
 
 def venv_check(spec: FlowSpec, base_dir: str) -> None:

--- a/src/inspect_flow/_runner/cli.py
+++ b/src/inspect_flow/_runner/cli.py
@@ -16,10 +16,9 @@ from inspect_flow._runner.run import run_eval_set
 from inspect_flow._types.flow_types import FlowSpec
 from inspect_flow._util.console import path
 from inspect_flow._util.constants import DEFAULT_LOG_LEVEL
-from inspect_flow._util.data import LAST_RUN_SUCCESS_KEY, write_data
 from inspect_flow._util.error import set_exception_hook
 from inspect_flow._util.logging import init_flow_logging
-from inspect_flow._util.subprocess_util import signal_ready_and_wait
+from inspect_flow._util.subprocess_util import signal_ready_and_wait, write_run_result
 
 RUN_ACTIONS = {
     "instantiate": DisplayAction(description="Instantiate tasks"),
@@ -102,7 +101,7 @@ def runner_run(
     with create_display(mode=mode, actions=RUN_ACTIONS) as disp:
         disp.set_title("VENV Flow Spec:", path(file))
         success, _ = run_eval_set(cfg, base_dir=base_dir, dry_run=dry_run)
-    write_data(LAST_RUN_SUCCESS_KEY, success)
+    write_run_result(success)
 
 
 @runner.command("check")

--- a/src/inspect_flow/_runner/cli.py
+++ b/src/inspect_flow/_runner/cli.py
@@ -16,6 +16,7 @@ from inspect_flow._runner.run import run_eval_set
 from inspect_flow._types.flow_types import FlowSpec
 from inspect_flow._util.console import path
 from inspect_flow._util.constants import DEFAULT_LOG_LEVEL
+from inspect_flow._util.data import LAST_RUN_SUCCESS_KEY, write_data
 from inspect_flow._util.error import set_exception_hook
 from inspect_flow._util.logging import init_flow_logging
 from inspect_flow._util.subprocess_util import signal_ready_and_wait
@@ -100,7 +101,8 @@ def runner_run(
     mode: DisplayMode = "dry_run" if dry_run else "run"
     with create_display(mode=mode, actions=RUN_ACTIONS) as disp:
         disp.set_title("VENV Flow Spec:", path(file))
-        run_eval_set(cfg, base_dir=base_dir, dry_run=dry_run)
+        success, _ = run_eval_set(cfg, base_dir=base_dir, dry_run=dry_run)
+    write_data(LAST_RUN_SUCCESS_KEY, success)
 
 
 @runner.command("check")

--- a/src/inspect_flow/_util/data.py
+++ b/src/inspect_flow/_util/data.py
@@ -9,7 +9,6 @@ from inspect_flow._util.constants import PKG_NAME
 _DATA_FILE = "flow_data.json"
 
 LAST_LOG_DIR_KEY = "last_log_dir"
-LAST_RUN_SUCCESS_KEY = "last_run_success"
 
 
 def user_data_dir() -> Path:

--- a/src/inspect_flow/_util/data.py
+++ b/src/inspect_flow/_util/data.py
@@ -9,6 +9,7 @@ from inspect_flow._util.constants import PKG_NAME
 _DATA_FILE = "flow_data.json"
 
 LAST_LOG_DIR_KEY = "last_log_dir"
+LAST_RUN_SUCCESS_KEY = "last_run_success"
 
 
 def user_data_dir() -> Path:

--- a/src/inspect_flow/_util/subprocess_util.py
+++ b/src/inspect_flow/_util/subprocess_util.py
@@ -1,8 +1,10 @@
 """Utilities for running subprocesses with logging support."""
 
+import json
 import os
 import subprocess
 from logging import getLogger
+from pathlib import Path
 from typing import Any
 
 from inspect_flow._util.console import flow_print
@@ -13,6 +15,46 @@ logger = getLogger(__name__)
 # The parent sets these before spawning the child process.
 CHILD_READY_FD_ENV = "INSPECT_FLOW_CHILD_READY_FD"
 PARENT_ACK_FD_ENV = "INSPECT_FLOW_PARENT_ACK_FD"
+
+# Absolute path of a per-run file the child writes its success flag to. The
+# parent creates the path and sets this before spawning the child. Using an
+# explicit per-run path (rather than a shared key) keeps concurrent runs from
+# racing and is unaffected by env changes to the child's HOME/XDG_DATA_HOME.
+RUN_RESULT_FILE_ENV = "INSPECT_FLOW_RUN_RESULT_FILE"
+
+
+def write_run_result(success: bool) -> None:
+    """Write the run success flag to the per-run result file, if one was set.
+
+    Called by a child runner process spawned with `RUN_RESULT_FILE_ENV`. Does
+    nothing when the env var is unset (e.g. when invoked standalone).
+
+    Args:
+        success: Whether the eval set completed successfully.
+    """
+    result_path = os.environ.get(RUN_RESULT_FILE_ENV)
+    if result_path:
+        Path(result_path).write_text(json.dumps({"success": success}))
+
+
+def read_run_result(result_path: str) -> bool:
+    """Read the success flag a child runner wrote to its per-run result file.
+
+    Args:
+        result_path: Absolute path the child was told to write to.
+
+    Returns:
+        The success flag written by the child.
+
+    Raises:
+        RuntimeError: If the child exited without writing a result.
+    """
+    path = Path(result_path)
+    if not path.exists():
+        raise RuntimeError(
+            f"venv run process exited without reporting a result at {result_path}"
+        )
+    return bool(json.loads(path.read_text())["success"])
 
 
 def signal_ready_and_wait() -> None:

--- a/src/inspect_flow/api/__init__.py
+++ b/src/inspect_flow/api/__init__.py
@@ -1,6 +1,16 @@
 """inspect_flow python API."""
 
-from inspect_flow._api.api import check, config, init, load_spec, run, store_get
+from inspect_flow._api.api import (
+    CheckResult,
+    CheckTask,
+    RunResult,
+    check,
+    config,
+    init,
+    load_spec,
+    run,
+    store_get,
+)
 from inspect_flow._api.list_logs import list_logs
 from inspect_flow._display.display import DisplayType
 from inspect_flow._steps.copy import copy
@@ -12,8 +22,11 @@ from inspect_flow._store.store import FlowStore, delete_store
 from inspect_flow._util.logs import copy_all_logs
 
 __all__ = [
+    "CheckResult",
+    "CheckTask",
     "DisplayType",
     "FlowStore",
+    "RunResult",
     "StepResult",
     "check",
     "config",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ os.environ["NO_COLOR"] = "1"
 
 import importlib.util
 import inspect
+import json
 import subprocess
 from collections.abc import Generator
 from dataclasses import dataclass
@@ -20,6 +21,7 @@ from botocore.client import BaseClient
 from inspect_ai._util.logger import LogHandlerVar, _logHandler
 from inspect_flow._util.constants import DEFAULT_LOG_LEVEL
 from inspect_flow._util.logging import init_flow_logging
+from inspect_flow._util.subprocess_util import RUN_RESULT_FILE_ENV
 from rich.console import Console
 
 
@@ -325,9 +327,18 @@ def mock_venv_subprocess() -> Generator[MockVenvSubprocess, None, None]:
             args=[], returncode=0, stdout="mocked output"
         )
 
-        # Configure subprocess.Popen to return a mock process
+        # Configure subprocess.Popen to return a mock process. By default the
+        # fake child reports success by writing the per-run result file the
+        # parent told it to use, so launch() returns cleanly.
         mock_process = MagicMock()
-        mock_process.wait.return_value = None
+
+        def write_success_result() -> None:
+            env = mock_popen.call_args.kwargs.get("env") or {}
+            result_path = env.get(RUN_RESULT_FILE_ENV)
+            if result_path:
+                Path(result_path).write_text(json.dumps({"success": True}))
+
+        mock_process.wait.side_effect = write_success_result
         mock_process.returncode = 0
         mock_popen.return_value = mock_process
 

--- a/tests/expected/run_includes.yaml
+++ b/tests/expected/run_includes.yaml
@@ -1,3 +1,5 @@
+log_dir: logs
+log_dir_create_unique: false
 tasks:
 - name: local_eval/noop
 - name: local_eval/noop

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -23,13 +23,15 @@ def reset_initialized() -> None:
 def test_258_run_includes() -> None:
     spec = FlowSpec(
         includes=["defaults_flow.py"],
+        log_dir="logs",
+        log_dir_create_unique=False,
         tasks=[
             "local_eval/noop",
             FlowTask(name="local_eval/noop", model="{defaults[model][name]}"),
         ],
     )
     with patch("inspect_flow._api.api.launch") as mock_launch:
-        mock_launch.return_value = None
+        mock_launch.return_value = (True, [])
         run(spec=spec, base_dir="./tests/config/")
     mock_launch.assert_called_once()
     launch_spec = mock_launch.mock_calls[0].kwargs["spec"]
@@ -50,12 +52,12 @@ def test_config() -> None:
     assert dump == expected_dump
 
 
-def test_ensure_init_loads_dotenv_from_base_dir() -> None:
+def test_ensure_init_loads_dotenv_from_base_dir(tmp_path: Path) -> None:
     """When init() is not called explicitly, _ensure_init should load .env from base_dir."""
     os.environ.pop("TEST_ENV_VAR", None)
-    spec = FlowSpec(tasks=["local_eval/noop"])
+    spec = FlowSpec(log_dir=str(tmp_path / "logs"), tasks=["local_eval/noop"])
     with patch("inspect_flow._api.api.launch") as mock_launch:
-        mock_launch.return_value = None
+        mock_launch.return_value = (True, [])
         run(spec=spec, base_dir="./tests/config/")
     assert os.environ.get("TEST_ENV_VAR") == "test_value"
     del os.environ["TEST_ENV_VAR"]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -7,9 +7,11 @@ import pytest
 from inspect_flow._api import api as api_module
 from inspect_flow._types.flow_types import FlowSpec, FlowTask, not_given
 from inspect_flow._util.data import LAST_LOG_DIR_KEY, read_data
-from inspect_flow.api import check, config, init, load_spec, run, store_get
+from inspect_flow.api import RunResult, check, config, init, load_spec, run, store_get
 
 from tests.test_helpers.config_helpers import validate_config
+
+_TASK = "tests/local_eval/src/local_eval/noop.py@noop"
 
 
 @pytest.fixture(autouse=True)
@@ -27,6 +29,7 @@ def test_258_run_includes() -> None:
         ],
     )
     with patch("inspect_flow._api.api.launch") as mock_launch:
+        mock_launch.return_value = None
         run(spec=spec, base_dir="./tests/config/")
     mock_launch.assert_called_once()
     launch_spec = mock_launch.mock_calls[0].kwargs["spec"]
@@ -51,7 +54,8 @@ def test_ensure_init_loads_dotenv_from_base_dir() -> None:
     """When init() is not called explicitly, _ensure_init should load .env from base_dir."""
     os.environ.pop("TEST_ENV_VAR", None)
     spec = FlowSpec(tasks=["local_eval/noop"])
-    with patch("inspect_flow._api.api.launch"):
+    with patch("inspect_flow._api.api.launch") as mock_launch:
+        mock_launch.return_value = None
         run(spec=spec, base_dir="./tests/config/")
     assert os.environ.get("TEST_ENV_VAR") == "test_value"
     del os.environ["TEST_ENV_VAR"]
@@ -89,6 +93,7 @@ def test_resume(tmp_path: Path) -> None:
         patch("inspect_flow._launcher.inproc.run_eval_set") as mock_run_eval_set,
         patch("subprocess.run") as mock_subprocess,
     ):
+        mock_run_eval_set.return_value = (True, [])
         mock_subprocess.return_value = subprocess.CompletedProcess(
             args=[], returncode=0, stdout=""
         )
@@ -123,6 +128,7 @@ def test_resume_ignores_log_dir_create_unique(tmp_path: Path) -> None:
         patch("inspect_flow._launcher.inproc.run_eval_set") as mock_run_eval_set,
         patch("subprocess.run") as mock_subprocess,
     ):
+        mock_run_eval_set.return_value = (True, [])
         mock_subprocess.return_value = subprocess.CompletedProcess(
             args=[], returncode=0, stdout=""
         )
@@ -143,6 +149,41 @@ def test_resume_ignores_log_dir_create_unique(tmp_path: Path) -> None:
         resumed_log_dir = mock_run_eval_set.call_args.args[0].log_dir
 
     assert resumed_log_dir == first_log_dir
+
+
+def test_run_returns_result(tmp_path: Path) -> None:
+    log_dir = str(tmp_path / "logs")
+    spec = FlowSpec(
+        log_dir=log_dir,
+        store="none",
+        tasks=[FlowTask(name=_TASK, model="mockllm/mock-llm")],
+    )
+
+    result = run(spec=spec, base_dir=".")
+
+    assert isinstance(result, RunResult)
+    assert result.success
+    assert len(result.logs) == 1
+    assert result.logs[0].status == "success"
+    assert Path(result.log_dir).is_absolute()
+    assert Path(result.log_dir).name == "logs"
+
+
+def test_run_dry_run_returns_result(tmp_path: Path) -> None:
+    log_dir = str(tmp_path / "logs")
+    spec = FlowSpec(
+        log_dir=log_dir,
+        store="none",
+        tasks=[FlowTask(name=_TASK, model="mockllm/mock-llm")],
+    )
+
+    result = run(spec=spec, base_dir=".", dry_run=True)
+
+    assert isinstance(result, RunResult)
+    assert not result.success
+    assert result.logs == []
+    assert Path(result.log_dir).is_absolute()
+    assert Path(result.log_dir).name == "logs"
 
 
 def test_check_disables_log_dir_create_unique(tmp_path: Path) -> None:

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -5,21 +5,27 @@ from unittest.mock import patch
 
 import pytest
 from botocore.client import BaseClient
+from click.testing import CliRunner
 from inspect_ai import Task
 from inspect_ai.model import get_model
 from inspect_flow import FlowSpec
 from inspect_flow._api.api import init, load_spec, run
 from inspect_flow._config.load import ConfigOptions, int_load_spec
+from inspect_flow._config.write import write_config_file
 from inspect_flow._display.display import DEFAULT_DISPLAY_TYPE
 from inspect_flow._launcher.launch import launch
 from inspect_flow._launcher.venv import _check_spec_for_venv, _create_venv
+from inspect_flow._runner.cli import runner
 from inspect_flow._types.flow_types import FlowSolver, FlowTask
 from inspect_flow._util.constants import DEFAULT_LOG_LEVEL
+from inspect_flow._util.data import LAST_RUN_SUCCESS_KEY, read_data, write_data
 
 from tests.config.inspect_objects_flow import a_agent, a_scorer, a_solver
 from tests.conftest import MockVenvSubprocess, mock_call_arg
 
 CREATE_VENV_RUN_CALLS = 4
+
+_TASK = "tests/local_eval/src/local_eval/noop.py@noop"
 
 
 def test_launch_inproc() -> None:
@@ -68,6 +74,48 @@ def test_launch_venv(mock_venv_subprocess: MockVenvSubprocess) -> None:
     assert args[8] == DEFAULT_LOG_LEVEL
     assert args[9] == "--display"
     assert args[10] == DEFAULT_DISPLAY_TYPE
+
+
+@pytest.mark.parametrize("child_success", [True, False])
+def test_launch_venv_returns_subprocess_success(
+    mock_venv_subprocess: MockVenvSubprocess, child_success: bool
+) -> None:
+    # The child signals its success flag over the data channel before exiting; the
+    # parent reads it back and returns it (with empty logs, which live in the child).
+    mock_venv_subprocess.popen.return_value.wait.side_effect = lambda: write_data(
+        LAST_RUN_SUCCESS_KEY, child_success
+    )
+
+    success, logs = launch(
+        spec=FlowSpec(execution_type="venv", log_dir="logs", tasks=["task_name"]),
+        base_dir=".",
+    )
+
+    assert success is child_success
+    assert logs == []
+
+
+@pytest.mark.parametrize("eval_set_success", [True, False])
+def test_runner_run_writes_success(tmp_path: Path, eval_set_success: bool) -> None:
+    spec = FlowSpec(
+        log_dir=str(tmp_path / "logs"),
+        store="none",
+        tasks=[FlowTask(name=_TASK, model="mockllm/mock-llm")],
+    )
+    config_file = write_config_file(spec)
+
+    with patch(
+        "inspect_flow._runner.cli.run_eval_set",
+        return_value=(eval_set_success, []),
+    ):
+        result = CliRunner().invoke(
+            runner,
+            ["run", "--file", config_file, "--base-dir", "."],
+            catch_exceptions=False,
+        )
+
+    assert result.exit_code == 0
+    assert read_data(LAST_RUN_SUCCESS_KEY) is eval_set_success
 
 
 def test_env(

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -1,3 +1,4 @@
+import json
 import os
 import subprocess
 from pathlib import Path
@@ -18,7 +19,7 @@ from inspect_flow._launcher.venv import _check_spec_for_venv, _create_venv
 from inspect_flow._runner.cli import runner
 from inspect_flow._types.flow_types import FlowSolver, FlowTask
 from inspect_flow._util.constants import DEFAULT_LOG_LEVEL
-from inspect_flow._util.data import LAST_RUN_SUCCESS_KEY, read_data, write_data
+from inspect_flow._util.subprocess_util import RUN_RESULT_FILE_ENV, read_run_result
 
 from tests.config.inspect_objects_flow import a_agent, a_scorer, a_solver
 from tests.conftest import MockVenvSubprocess, mock_call_arg
@@ -80,11 +81,15 @@ def test_launch_venv(mock_venv_subprocess: MockVenvSubprocess) -> None:
 def test_launch_venv_returns_subprocess_success(
     mock_venv_subprocess: MockVenvSubprocess, child_success: bool
 ) -> None:
-    # The child signals its success flag over the data channel before exiting; the
-    # parent reads it back and returns it (with empty logs, which live in the child).
-    mock_venv_subprocess.popen.return_value.wait.side_effect = lambda: write_data(
-        LAST_RUN_SUCCESS_KEY, child_success
-    )
+    # The child writes its success flag to the per-run result file before exiting;
+    # the parent reads it back and returns it (with empty logs, in the child).
+    def write_result() -> None:
+        env = mock_venv_subprocess.popen.call_args.kwargs["env"]
+        Path(env[RUN_RESULT_FILE_ENV]).write_text(
+            json.dumps({"success": child_success})
+        )
+
+    mock_venv_subprocess.popen.return_value.wait.side_effect = write_result
 
     success, logs = launch(
         spec=FlowSpec(execution_type="venv", log_dir="logs", tasks=["task_name"]),
@@ -95,14 +100,31 @@ def test_launch_venv_returns_subprocess_success(
     assert logs == []
 
 
+def test_launch_venv_missing_result_raises(
+    mock_venv_subprocess: MockVenvSubprocess,
+) -> None:
+    # Child exits cleanly but never writes a result; the parent must not silently
+    # report success or failure.
+    mock_venv_subprocess.popen.return_value.wait.side_effect = None
+    with pytest.raises(RuntimeError, match="without reporting a result"):
+        launch(
+            spec=FlowSpec(execution_type="venv", log_dir="logs", tasks=["task_name"]),
+            base_dir=".",
+        )
+
+
 @pytest.mark.parametrize("eval_set_success", [True, False])
-def test_runner_run_writes_success(tmp_path: Path, eval_set_success: bool) -> None:
+def test_runner_run_writes_success(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, eval_set_success: bool
+) -> None:
     spec = FlowSpec(
         log_dir=str(tmp_path / "logs"),
         store="none",
         tasks=[FlowTask(name=_TASK, model="mockllm/mock-llm")],
     )
     config_file = write_config_file(spec)
+    result_path = tmp_path / "run_result.json"
+    monkeypatch.setenv(RUN_RESULT_FILE_ENV, str(result_path))
 
     with patch(
         "inspect_flow._runner.cli.run_eval_set",
@@ -115,7 +137,7 @@ def test_runner_run_writes_success(tmp_path: Path, eval_set_success: bool) -> No
         )
 
     assert result.exit_code == 0
-    assert read_data(LAST_RUN_SUCCESS_KEY) is eval_set_success
+    assert read_run_result(str(result_path)) is eval_set_success
 
 
 def test_env(


### PR DESCRIPTION
Fixes #718

The public `run()` previously discarded the `(success, logs)` tuple produced
by `eval_set`, forcing callers to scrape disk for results. Thread the
`eval_set` return value up through `launch()`/`inproc_launch()` and return a
`RunResult` with `success`, `logs`, and `log_dir`. Mirrors `check()`'s
`CheckResult`.

For venv execution the eval logs live in the subprocess, so the runner signals
its `success` flag back to the parent over the data channel; `run()` returns a
`RunResult` with that `success` and an empty `logs` list. A nonzero subprocess
exit still raises, so a crash is never reported as success.

For a dry run, `success` is always `False` and `logs` is empty.

Co-authored-by: Ransom Richardson <ransomr@users.noreply.github.com>