### PR TITLE
claude-setup: put the project venv on PATH for the agent

### DIFF
--- a/.github/actions/claude-setup/action.yaml
+++ b/.github/actions/claude-setup/action.yaml
@@ -13,3 +13,12 @@ runs:
       with:
         # CI runs a 3.10/3.11 matrix; the agent only needs one interpreter.
         python-version: "3.11"
+    # Put the uv-managed project venv on PATH so the agent's allow-listed bare
+    # `pytest`/`ruff`/`pyright` resolve. Without this they aren't on PATH, so the
+    # agent falls back to `.venv/bin/...` / `make check` — neither allow-listed —
+    # and the verify loop is blocked (it then ships unverified, noting it could
+    # not run the tools). Plain `run:` step (no post phase) so it's safe on the
+    # fork dev agent too.
+    - name: Put the project venv on PATH for the agent
+      shell: bash
+      run: echo "$GITHUB_WORKSPACE/.venv/bin" >> "$GITHUB_PATH"


### PR DESCRIPTION
Fixes the @auto verify loop being blocked (seen on #718 → #742: the agent shipped with *"unable to run pytest, ruff, or pyright… every invocation of the venv binaries required interactive approval"*).

**Cause:** `claude-setup` runs `uv sync` but doesn't put `.venv/bin` on `PATH`. So the agent's allow-listed bare `pytest`/`ruff`/`pyright` don't resolve; it falls back to `.venv/bin/pytest`, `make check`, etc. — none allow-listed — and the verify loop is denied.

**Fix:** append `$GITHUB_WORKSPACE/.venv/bin` to `GITHUB_PATH` after setup, so bare tools resolve. Pairs with adding `Bash(pyright:*)` to the agent allow-lists (meridianlabs-ai/agents@main). Plain `run:` step (no post phase), safe on the fork dev agent.