### PR TITLE
feat: signal incomplete runs/checks via exit code and avoid non-TTY hangs

### DIFF
--- a/src/inspect_flow/_api/api.py
+++ b/src/inspect_flow/_api/api.py
@@ -20,7 +20,6 @@ from inspect_flow._store.store import FlowStore, store_factory
 from inspect_flow._types.flow_types import FlowSpec, FlowTask
 from inspect_flow._util.constants import DEFAULT_LOG_LEVEL
 from inspect_flow._util.logging import init_flow_logging
-from inspect_flow._util.logs import samples_complete
 from inspect_flow._util.module_util import is_loading_spec
 
 _initialized = False
@@ -158,18 +157,14 @@ class CheckTask:
 class CheckResult:
     """Result of checking an inspect_flow evaluation against existing logs."""
 
+    is_complete: bool
+    """`True` if every task has a log with at least its expected samples."""
+
     tasks: list[CheckTask]
-    """Completeness information for each task in the spec."""
+    """Completeness information for each task in the spec. Empty for venv execution."""
 
     unrecognized: list[str]
-    """Log file paths not matching any task in the spec."""
-
-    @property
-    def is_complete(self) -> bool:
-        """`True` if every task has a log with at least its expected samples."""
-        return samples_complete(
-            (task.samples, task.total_samples) for task in self.tasks
-        )
+    """Log file paths not matching any task in the spec. Empty for venv execution."""
 
 
 def check(
@@ -177,7 +172,7 @@ def check(
     base_dir: str | None = None,
     *,
     log_dir: str | None = None,
-) -> CheckResult | None:
+) -> CheckResult:
     """Check completeness of an inspect_flow evaluation against existing logs.
 
     Args:
@@ -186,7 +181,10 @@ def check(
         log_dir: Log directory to check against. Overrides the `log_dir` in the spec.
 
     Returns:
-        A CheckResult object containing the check results when run inproc. None when run in a venv.
+        A CheckResult whose `is_complete` flag reflects whether every task has a
+        log with at least its expected samples. For venv execution the per-task
+        details live in the subprocess, so `tasks` and `unrecognized` are empty
+        and only `is_complete` is populated.
     """
     ensure_init(dotenv_base_dir=base_dir)
     base_dir = base_dir or Path().cwd().as_posix()
@@ -198,10 +196,12 @@ def check(
     if log_dir is not None:
         spec = spec.model_copy(update={"log_dir": log_dir})
     result = launch_check(spec=spec, base_dir=base_dir)
-    return _to_check_result(result.logs) if result.logs is not None else None
+    if result.logs is None:
+        return CheckResult(is_complete=result.is_complete, tasks=[], unrecognized=[])
+    return _to_check_result(result.is_complete, result.logs)
 
 
-def _to_check_result(logs_result: FindLogsResult) -> CheckResult:
+def _to_check_result(is_complete: bool, logs_result: FindLogsResult) -> CheckResult:
     tasks = []
     for info in logs_result.task_log_info.values():
         assert info.flow_task is not None
@@ -215,7 +215,11 @@ def _to_check_result(logs_result: FindLogsResult) -> CheckResult:
                 duplicate_logs=info.duplicate_logs,
             )
         )
-    return CheckResult(tasks=tasks, unrecognized=logs_result.unexpected_logs)
+    return CheckResult(
+        is_complete=is_complete,
+        tasks=tasks,
+        unrecognized=logs_result.unexpected_logs,
+    )
 
 
 def config(

--- a/src/inspect_flow/_api/api.py
+++ b/src/inspect_flow/_api/api.py
@@ -122,13 +122,13 @@ def run(
     ensure_init(dotenv_base_dir=base_dir)
     base_dir = base_dir or Path().cwd().as_posix()
     spec = expand_spec(spec, base_dir=base_dir, options=ConfigOptions(resume=resume))
-    success, logs = launch(
+    result = launch(
         spec=spec,
         base_dir=base_dir,
         dry_run=dry_run,
     )
     assert spec.log_dir
-    return RunResult(success=success, logs=logs, log_dir=spec.log_dir)
+    return RunResult(success=result.success, logs=result.logs, log_dir=spec.log_dir)
 
 
 @dataclass
@@ -197,8 +197,8 @@ def check(
     )
     if log_dir is not None:
         spec = spec.model_copy(update={"log_dir": log_dir})
-    _, logs_result = launch_check(spec=spec, base_dir=base_dir)
-    return _to_check_result(logs_result) if logs_result is not None else None
+    result = launch_check(spec=spec, base_dir=base_dir)
+    return _to_check_result(result.logs) if result.logs is not None else None
 
 
 def _to_check_result(logs_result: FindLogsResult) -> CheckResult:

--- a/src/inspect_flow/_api/api.py
+++ b/src/inspect_flow/_api/api.py
@@ -77,7 +77,7 @@ def run(
     *,
     dry_run: bool = False,
     resume: bool = False,
-) -> None:
+) -> bool:
     """Run an inspect_flow evaluation.
 
     Args:
@@ -85,6 +85,10 @@ def run(
         base_dir: The base directory for resolving relative paths. Defaults to the current working directory.
         dry_run: If `True`, do not run eval, but show a count of tasks that would be run.
         resume: If `True`, reuse the log directory from the previous run.
+
+    Returns:
+        `True` if the eval set completed successfully (or was a dry run), `False`
+        if some tasks did not complete successfully.
 
     Raises:
         RuntimeError: If called from within a flow spec file being loaded.
@@ -98,7 +102,7 @@ def run(
     ensure_init(dotenv_base_dir=base_dir)
     base_dir = base_dir or Path().cwd().as_posix()
     spec = expand_spec(spec, base_dir=base_dir, options=ConfigOptions(resume=resume))
-    launch(
+    return launch(
         spec=spec,
         base_dir=base_dir,
         dry_run=dry_run,
@@ -119,6 +123,14 @@ class CheckTask:
 class CheckResult:
     tasks: list[CheckTask]
     unrecognized: list[str]  # log file paths not matching any task in spec
+
+    @property
+    def is_complete(self) -> bool:
+        """`True` if every task has a log with at least its expected samples."""
+        return all(
+            task.total_samples is not None and task.samples >= task.total_samples
+            for task in self.tasks
+        )
 
 
 def check(

--- a/src/inspect_flow/_api/api.py
+++ b/src/inspect_flow/_api/api.py
@@ -197,7 +197,7 @@ def check(
     )
     if log_dir is not None:
         spec = spec.model_copy(update={"log_dir": log_dir})
-    logs_result = launch_check(spec=spec, base_dir=base_dir)
+    _, logs_result = launch_check(spec=spec, base_dir=base_dir)
     return _to_check_result(logs_result) if logs_result is not None else None
 
 

--- a/src/inspect_flow/_api/api.py
+++ b/src/inspect_flow/_api/api.py
@@ -19,6 +19,7 @@ from inspect_flow._store.store import FlowStore, store_factory
 from inspect_flow._types.flow_types import FlowSpec, FlowTask
 from inspect_flow._util.constants import DEFAULT_LOG_LEVEL
 from inspect_flow._util.logging import init_flow_logging
+from inspect_flow._util.logs import samples_complete
 from inspect_flow._util.module_util import is_loading_spec
 
 _initialized = False
@@ -127,9 +128,8 @@ class CheckResult:
     @property
     def is_complete(self) -> bool:
         """`True` if every task has a log with at least its expected samples."""
-        return all(
-            task.total_samples is not None and task.samples >= task.total_samples
-            for task in self.tasks
+        return samples_complete(
+            (task.samples, task.total_samples) for task in self.tasks
         )
 
 

--- a/src/inspect_flow/_api/api.py
+++ b/src/inspect_flow/_api/api.py
@@ -196,9 +196,9 @@ def check(
     if log_dir is not None:
         spec = spec.model_copy(update={"log_dir": log_dir})
     result = launch_check(spec=spec, base_dir=base_dir)
-    if result.logs is None:
+    if result.find_result is None:
         return CheckResult(is_complete=result.is_complete, tasks=[], unrecognized=[])
-    return _to_check_result(result.is_complete, result.logs)
+    return _to_check_result(result.is_complete, result.find_result)
 
 
 def _to_check_result(is_complete: bool, logs_result: FindLogsResult) -> CheckResult:

--- a/src/inspect_flow/_cli/check.py
+++ b/src/inspect_flow/_cli/check.py
@@ -39,8 +39,6 @@ def check_command(
         display.set_title("Flow Spec:", path(config_file))
         kwargs["log_dir_create_unique"] = False
         spec = int_load_spec(config_file, options=parse_config_options(**kwargs))
-        result = launch_check(spec, base_dir=str(Path(config_file).parent))
-    # `result` is None for venv execution; in that case the child process exits
-    # with EXIT_INCOMPLETE and venv_check propagates the code via CalledProcessError.
-    if result is not None and not result.is_complete:
+        is_complete, _ = launch_check(spec, base_dir=str(Path(config_file).parent))
+    if not is_complete:
         sys.exit(EXIT_INCOMPLETE)

--- a/src/inspect_flow/_cli/check.py
+++ b/src/inspect_flow/_cli/check.py
@@ -39,6 +39,6 @@ def check_command(
         display.set_title("Flow Spec:", path(config_file))
         kwargs["log_dir_create_unique"] = False
         spec = int_load_spec(config_file, options=parse_config_options(**kwargs))
-        is_complete, _ = launch_check(spec, base_dir=str(Path(config_file).parent))
-    if not is_complete:
+        result = launch_check(spec, base_dir=str(Path(config_file).parent))
+    if not result.is_complete:
         sys.exit(EXIT_INCOMPLETE)

--- a/src/inspect_flow/_cli/check.py
+++ b/src/inspect_flow/_cli/check.py
@@ -1,3 +1,4 @@
+import sys
 from pathlib import Path
 
 import click
@@ -15,6 +16,7 @@ from inspect_flow._display.display import DisplayAction, create_display
 from inspect_flow._launcher.launch import launch_check
 from inspect_flow._runner.cli import CHECK_ACTIONS
 from inspect_flow._util.console import path
+from inspect_flow._util.constants import EXIT_INCOMPLETE
 
 _check_actions = {
     "load": DisplayAction(description="Load config"),
@@ -37,4 +39,8 @@ def check_command(
         display.set_title("Flow Spec:", path(config_file))
         kwargs["log_dir_create_unique"] = False
         spec = int_load_spec(config_file, options=parse_config_options(**kwargs))
-        launch_check(spec, base_dir=str(Path(config_file).parent))
+        result = launch_check(spec, base_dir=str(Path(config_file).parent))
+    # `result` is None for venv execution; in that case the child process exits
+    # with EXIT_INCOMPLETE and venv_check propagates the code via CalledProcessError.
+    if result is not None and not result.is_complete:
+        sys.exit(EXIT_INCOMPLETE)

--- a/src/inspect_flow/_cli/list.py
+++ b/src/inspect_flow/_cli/list.py
@@ -41,6 +41,7 @@ from inspect_flow._util.logs import (
     num_valid_samples_async,
 )
 from inspect_flow._util.path_util import apply_bundle_url_mappings, path_str
+from inspect_flow._util.terminal import stdout_is_terminal
 
 logger = getLogger(__name__)
 
@@ -598,7 +599,7 @@ def _echo_tree(
         flow_print("No logs found")
         return
     output = _format_tree(dir_entries)
-    if os.isatty(1) and output.count("\n") > Console().size.height - 1:
+    if stdout_is_terminal() and output.count("\n") > Console().size.height - 1:
         _page_string(output)
     else:
         click.echo(output, nl=False)
@@ -638,7 +639,7 @@ def _echo_logs(
     total_entries = min(
         sum(len(g) for g in dir_groups), options.max_count or float("inf")
     )
-    if options.page and os.isatty(1) and total_entries * lpe > page_size:
+    if options.page and stdout_is_terminal() and total_entries * lpe > page_size:
         _paged_output(dir_groups, page_size, options, progress=progress)
     else:
         entries = _process_groups(dir_groups, options, progress=progress)

--- a/src/inspect_flow/_cli/run.py
+++ b/src/inspect_flow/_cli/run.py
@@ -53,10 +53,10 @@ def run_command(
     with create_display(mode=mode, actions=_run_actions) as display:
         display.set_title("Flow Spec:", path(config_file))
         spec = int_load_spec(config_file, options=config_options)
-        success, _ = launch(
+        result = launch(
             spec,
             base_dir=str(Path(config_file).parent),
             dry_run=dry_run,
         )
-    if not dry_run and not success:
+    if not dry_run and not result.success:
         sys.exit(EXIT_INCOMPLETE)

--- a/src/inspect_flow/_cli/run.py
+++ b/src/inspect_flow/_cli/run.py
@@ -1,3 +1,4 @@
+import sys
 from pathlib import Path
 
 import click
@@ -15,6 +16,7 @@ from inspect_flow._display.display import DisplayAction, DisplayMode, create_dis
 from inspect_flow._launcher.launch import launch
 from inspect_flow._runner.cli import RUN_ACTIONS
 from inspect_flow._util.console import path
+from inspect_flow._util.constants import EXIT_INCOMPLETE
 
 _run_actions = {
     "load": DisplayAction(description="Load config"),
@@ -51,8 +53,10 @@ def run_command(
     with create_display(mode=mode, actions=_run_actions) as display:
         display.set_title("Flow Spec:", path(config_file))
         spec = int_load_spec(config_file, options=config_options)
-        launch(
+        complete = launch(
             spec,
             base_dir=str(Path(config_file).parent),
             dry_run=dry_run,
         )
+    if not complete:
+        sys.exit(EXIT_INCOMPLETE)

--- a/src/inspect_flow/_cli/store.py
+++ b/src/inspect_flow/_cli/store.py
@@ -1,4 +1,3 @@
-import sys
 from collections.abc import Callable
 from typing import Any, Literal, TypeVar
 
@@ -25,6 +24,7 @@ from inspect_flow._types.flow_types import LogFilter
 from inspect_flow._types.log_filter import resolve_log_filter
 from inspect_flow._util.console import console, flow_print, path, quantity
 from inspect_flow._util.logs import copy_all_logs
+from inspect_flow._util.terminal import stdin_is_interactive
 
 
 class ArgumentsHelpCommand(click.Command):
@@ -320,13 +320,6 @@ def store_info(**kwargs: Unpack[StoreOptionArgs]) -> None:
     flow_print("Version: ", flow_store.version)
 
 
-def _stdin_is_interactive() -> bool:
-    try:
-        return sys.stdin is not None and sys.stdin.isatty()
-    except (ValueError, OSError):
-        return False
-
-
 @store_command.command("delete", help="Delete the flow store")
 @store_options
 @click.option(
@@ -342,7 +335,7 @@ def store_delete(yes: bool, **kwargs: Unpack[StoreOptionArgs]) -> None:
         flow_print("Store not found at", path(store_path), format="error")
         return
     if not yes:
-        if not _stdin_is_interactive():
+        if not stdin_is_interactive():
             raise click.UsageError(
                 f"Refusing to delete the store at {store_path} without confirmation "
                 "on a non-interactive terminal. Re-run with --yes to confirm."

--- a/src/inspect_flow/_cli/store.py
+++ b/src/inspect_flow/_cli/store.py
@@ -1,3 +1,4 @@
+import sys
 from collections.abc import Callable
 from typing import Any, Literal, TypeVar
 
@@ -319,6 +320,13 @@ def store_info(**kwargs: Unpack[StoreOptionArgs]) -> None:
     flow_print("Version: ", flow_store.version)
 
 
+def _stdin_is_interactive() -> bool:
+    try:
+        return sys.stdin is not None and sys.stdin.isatty()
+    except (ValueError, OSError):
+        return False
+
+
 @store_command.command("delete", help="Delete the flow store")
 @store_options
 @click.option(
@@ -334,6 +342,11 @@ def store_delete(yes: bool, **kwargs: Unpack[StoreOptionArgs]) -> None:
         flow_print("Store not found at", path(store_path), format="error")
         return
     if not yes:
+        if not _stdin_is_interactive():
+            raise click.UsageError(
+                f"Refusing to delete the store at {store_path} without confirmation "
+                "on a non-interactive terminal. Re-run with --yes to confirm."
+            )
         click.confirm(
             f"Are you sure you want to delete the store at {store_path}?",
             abort=True,

--- a/src/inspect_flow/_launcher/inproc.py
+++ b/src/inspect_flow/_launcher/inproc.py
@@ -11,13 +11,14 @@ from inspect_flow._types.flow_types import FlowSpec
 logger = getLogger(__name__)
 
 
-def inproc_launch(spec: FlowSpec, base_dir: str, dry_run: bool) -> None:
+def inproc_launch(spec: FlowSpec, base_dir: str, dry_run: bool) -> bool:
     with RunAction("env", info="inproc"):
         if spec.env:
             os.environ.update(spec.env)
 
         write_flow_requirements(spec, cwd=".", env=os.environ.copy(), dry_run=dry_run)
-    run_eval_set(spec, base_dir=base_dir, dry_run=dry_run)
+    success, _ = run_eval_set(spec, base_dir=base_dir, dry_run=dry_run)
+    return success or dry_run
 
 
 def inproc_check(spec: FlowSpec, base_dir: str) -> FindLogsResult:

--- a/src/inspect_flow/_launcher/inproc.py
+++ b/src/inspect_flow/_launcher/inproc.py
@@ -1,21 +1,17 @@
 import os
 from logging import getLogger
 
-from inspect_ai.log import EvalLog
-
 from inspect_flow._display.run_action import RunAction
 from inspect_flow._launcher.freeze import write_flow_requirements
 from inspect_flow._runner.check import check_eval_set
 from inspect_flow._runner.logs import FindLogsResult
-from inspect_flow._runner.run import run_eval_set
+from inspect_flow._runner.run import LaunchResult, run_eval_set
 from inspect_flow._types.flow_types import FlowSpec
 
 logger = getLogger(__name__)
 
 
-def inproc_launch(
-    spec: FlowSpec, base_dir: str, dry_run: bool
-) -> tuple[bool, list[EvalLog]]:
+def inproc_launch(spec: FlowSpec, base_dir: str, dry_run: bool) -> LaunchResult:
     with RunAction("env", info="inproc"):
         if spec.env:
             os.environ.update(spec.env)

--- a/src/inspect_flow/_launcher/launch.py
+++ b/src/inspect_flow/_launcher/launch.py
@@ -10,7 +10,7 @@ from inspect_flow._util.path_util import absolute_path_relative_to
 logger = getLogger(__name__)
 
 
-def launch(spec: FlowSpec, base_dir: str, dry_run: bool = False) -> None:
+def launch(spec: FlowSpec, base_dir: str, dry_run: bool = False) -> bool:
     if not spec.log_dir:
         raise ValueError("log_dir must be set before launching the flow spec")
     spec.log_dir = absolute_path_relative_to(spec.log_dir, base_dir=base_dir)
@@ -29,9 +29,12 @@ def launch(spec: FlowSpec, base_dir: str, dry_run: bool = False) -> None:
             }
 
     if spec.execution_type == "venv":
+        # venv_launch raises CalledProcessError if the child exits non-zero,
+        # which propagates the child's exit code; reaching here means success.
         venv_launch(spec=spec, base_dir=base_dir, dry_run=dry_run)
+        return True
     else:
-        inproc_launch(spec=spec, base_dir=base_dir, dry_run=dry_run)
+        return inproc_launch(spec=spec, base_dir=base_dir, dry_run=dry_run)
 
 
 def launch_check(spec: FlowSpec, base_dir: str) -> FindLogsResult | None:

--- a/src/inspect_flow/_launcher/launch.py
+++ b/src/inspect_flow/_launcher/launch.py
@@ -35,6 +35,10 @@ def launch(spec: FlowSpec, base_dir: str, dry_run: bool = False) -> bool:
         # exit of EXIT_INCOMPLETE means the run completed but some tasks did not
         # succeed, which we surface as False to match the inproc contract. Any
         # other non-zero code is a genuine error and propagates.
+        #
+        # EXIT_INCOMPLETE (2) is also click's conventional usage-error code, so a
+        # malformed child invocation would be misread as incomplete. The child
+        # args are fully internal/controlled here, so that case does not arise.
         try:
             venv_launch(spec=spec, base_dir=base_dir, dry_run=dry_run)
             return True

--- a/src/inspect_flow/_launcher/launch.py
+++ b/src/inspect_flow/_launcher/launch.py
@@ -1,10 +1,10 @@
 from logging import getLogger
-
-from inspect_ai.log import EvalLog
+from typing import NamedTuple
 
 from inspect_flow._launcher.inproc import inproc_check, inproc_launch
 from inspect_flow._launcher.venv import venv_check, venv_launch
 from inspect_flow._runner.logs import FindLogsResult
+from inspect_flow._runner.run import LaunchResult
 from inspect_flow._types.flow_types import FlowSpec
 from inspect_flow._util.data import LAST_LOG_DIR_KEY, write_data
 from inspect_flow._util.path_util import absolute_path_relative_to
@@ -12,9 +12,12 @@ from inspect_flow._util.path_util import absolute_path_relative_to
 logger = getLogger(__name__)
 
 
-def launch(
-    spec: FlowSpec, base_dir: str, dry_run: bool = False
-) -> tuple[bool, list[EvalLog]]:
+class CheckLaunchResult(NamedTuple):
+    is_complete: bool
+    logs: FindLogsResult | None
+
+
+def launch(spec: FlowSpec, base_dir: str, dry_run: bool = False) -> LaunchResult:
     if not spec.log_dir:
         raise ValueError("log_dir must be set before launching the flow spec")
     spec.log_dir = absolute_path_relative_to(spec.log_dir, base_dir=base_dir)
@@ -38,7 +41,7 @@ def launch(
         return inproc_launch(spec=spec, base_dir=base_dir, dry_run=dry_run)
 
 
-def launch_check(spec: FlowSpec, base_dir: str) -> tuple[bool, FindLogsResult | None]:
+def launch_check(spec: FlowSpec, base_dir: str) -> CheckLaunchResult:
     if not spec.log_dir:
         raise ValueError("log_dir must be set before checking the flow spec")
     spec.log_dir = absolute_path_relative_to(spec.log_dir, base_dir=base_dir)
@@ -46,7 +49,9 @@ def launch_check(spec: FlowSpec, base_dir: str) -> tuple[bool, FindLogsResult | 
     if spec.execution_type == "venv":
         # The full result lives in the subprocess; only the completeness flag is
         # signaled back (via a per-run result file) on a clean exit.
-        return venv_check(spec=spec, base_dir=base_dir), None
+        return CheckLaunchResult(
+            is_complete=venv_check(spec=spec, base_dir=base_dir), logs=None
+        )
     else:
         result = inproc_check(spec=spec, base_dir=base_dir)
-        return result.is_complete, result
+        return CheckLaunchResult(is_complete=result.is_complete, logs=result)

--- a/src/inspect_flow/_launcher/launch.py
+++ b/src/inspect_flow/_launcher/launch.py
@@ -1,9 +1,11 @@
+import subprocess
 from logging import getLogger
 
 from inspect_flow._launcher.inproc import inproc_check, inproc_launch
 from inspect_flow._launcher.venv import venv_check, venv_launch
 from inspect_flow._runner.logs import FindLogsResult
 from inspect_flow._types.flow_types import FlowSpec
+from inspect_flow._util.constants import EXIT_INCOMPLETE
 from inspect_flow._util.data import LAST_LOG_DIR_KEY, write_data
 from inspect_flow._util.path_util import absolute_path_relative_to
 
@@ -29,10 +31,17 @@ def launch(spec: FlowSpec, base_dir: str, dry_run: bool = False) -> bool:
             }
 
     if spec.execution_type == "venv":
-        # venv_launch raises CalledProcessError if the child exits non-zero,
-        # which propagates the child's exit code; reaching here means success.
-        venv_launch(spec=spec, base_dir=base_dir, dry_run=dry_run)
-        return True
+        # venv_launch raises CalledProcessError if the child exits non-zero. An
+        # exit of EXIT_INCOMPLETE means the run completed but some tasks did not
+        # succeed, which we surface as False to match the inproc contract. Any
+        # other non-zero code is a genuine error and propagates.
+        try:
+            venv_launch(spec=spec, base_dir=base_dir, dry_run=dry_run)
+            return True
+        except subprocess.CalledProcessError as ex:
+            if ex.returncode == EXIT_INCOMPLETE:
+                return False
+            raise
     else:
         return inproc_launch(spec=spec, base_dir=base_dir, dry_run=dry_run)
 

--- a/src/inspect_flow/_launcher/launch.py
+++ b/src/inspect_flow/_launcher/launch.py
@@ -35,10 +35,6 @@ def launch(spec: FlowSpec, base_dir: str, dry_run: bool = False) -> bool:
         # exit of EXIT_INCOMPLETE means the run completed but some tasks did not
         # succeed, which we surface as False to match the inproc contract. Any
         # other non-zero code is a genuine error and propagates.
-        #
-        # EXIT_INCOMPLETE (2) is also click's conventional usage-error code, so a
-        # malformed child invocation would be misread as incomplete. The child
-        # args are fully internal/controlled here, so that case does not arise.
         try:
             venv_launch(spec=spec, base_dir=base_dir, dry_run=dry_run)
             return True

--- a/src/inspect_flow/_launcher/launch.py
+++ b/src/inspect_flow/_launcher/launch.py
@@ -38,12 +38,15 @@ def launch(
         return inproc_launch(spec=spec, base_dir=base_dir, dry_run=dry_run)
 
 
-def launch_check(spec: FlowSpec, base_dir: str) -> FindLogsResult | None:
+def launch_check(spec: FlowSpec, base_dir: str) -> tuple[bool, FindLogsResult | None]:
     if not spec.log_dir:
         raise ValueError("log_dir must be set before checking the flow spec")
     spec.log_dir = absolute_path_relative_to(spec.log_dir, base_dir=base_dir)
 
     if spec.execution_type == "venv":
-        return venv_check(spec=spec, base_dir=base_dir)
+        # The full result lives in the subprocess; only the completeness flag is
+        # signaled back (via a per-run result file) on a clean exit.
+        return venv_check(spec=spec, base_dir=base_dir), None
     else:
-        return inproc_check(spec=spec, base_dir=base_dir)
+        result = inproc_check(spec=spec, base_dir=base_dir)
+        return result.is_complete, result

--- a/src/inspect_flow/_launcher/launch.py
+++ b/src/inspect_flow/_launcher/launch.py
@@ -14,7 +14,7 @@ logger = getLogger(__name__)
 
 class CheckLaunchResult(NamedTuple):
     is_complete: bool
-    logs: FindLogsResult | None
+    find_result: FindLogsResult | None
 
 
 def launch(spec: FlowSpec, base_dir: str, dry_run: bool = False) -> LaunchResult:
@@ -50,8 +50,8 @@ def launch_check(spec: FlowSpec, base_dir: str) -> CheckLaunchResult:
         # The full result lives in the subprocess; only the completeness flag is
         # signaled back (via a per-run result file) on a clean exit.
         return CheckLaunchResult(
-            is_complete=venv_check(spec=spec, base_dir=base_dir), logs=None
+            is_complete=venv_check(spec=spec, base_dir=base_dir), find_result=None
         )
     else:
         result = inproc_check(spec=spec, base_dir=base_dir)
-        return CheckLaunchResult(is_complete=result.is_complete, logs=result)
+        return CheckLaunchResult(is_complete=result.is_complete, find_result=result)

--- a/src/inspect_flow/_launcher/venv.py
+++ b/src/inspect_flow/_launcher/venv.py
@@ -49,17 +49,14 @@ def venv_launch(
     # The eval logs live in the subprocess; only the success flag is signaled back
     # (via a per-run result file) on a clean exit. A crash raises in _venv_spawn.
     success = _venv_spawn(spec, base_dir=base_dir, subcommand="run", dry_run=dry_run)
-    assert success is not None
     return success, []
 
 
-def venv_check(spec: FlowSpec, base_dir: str) -> None:
-    _venv_spawn(spec, base_dir=base_dir, subcommand="check", dry_run=True)
+def venv_check(spec: FlowSpec, base_dir: str) -> bool:
+    return _venv_spawn(spec, base_dir=base_dir, subcommand="check", dry_run=True)
 
 
-def _venv_spawn(
-    spec: FlowSpec, base_dir: str, subcommand: str, dry_run: bool
-) -> bool | None:
+def _venv_spawn(spec: FlowSpec, base_dir: str, subcommand: str, dry_run: bool) -> bool:
     action_keys = (
         list(RUN_ACTIONS.keys()) if subcommand == "run" else list(CHECK_ACTIONS.keys())
     )
@@ -114,10 +111,11 @@ def _venv_spawn(
         env[CHILD_READY_FD_ENV] = str(child_ready_w)
         env[PARENT_ACK_FD_ENV] = str(parent_ack_r)
 
-        # Per-run path (in temp_dir) the run child writes its success flag to
+        # Per-run path (in temp_dir) the child writes its result flag to: the
+        # success flag for `run`, the completeness flag for `check`. Either way an
+        # incomplete result is data in this file, not a non-zero exit.
         result_path = Path(temp_dir) / "run_result.json"
-        if subcommand == "run":
-            env[RUN_RESULT_FILE_ENV] = str(result_path)
+        env[RUN_RESULT_FILE_ENV] = str(result_path)
 
         process = subprocess.Popen(
             [str(python_path), str(run_path), subcommand, "--file", file, *args],
@@ -147,9 +145,7 @@ def _venv_spawn(
                 cmd=process.args,
             )
 
-        if subcommand == "run":
-            return read_run_result(str(result_path))
-        return None
+        return read_run_result(str(result_path))
 
 
 def _check_spec_for_venv(spec: FlowSpec) -> None:

--- a/src/inspect_flow/_launcher/venv.py
+++ b/src/inspect_flow/_launcher/venv.py
@@ -9,7 +9,6 @@ from typing import Callable, List, Literal, Sequence
 
 from inspect_ai import Task
 from inspect_ai._util.file import absolute_file_path
-from inspect_ai.log import EvalLog
 from inspect_ai.model import Model
 from inspect_ai.scorer import Scorer
 from packaging.requirements import InvalidRequirement, Requirement
@@ -28,6 +27,7 @@ from inspect_flow._launcher.freeze import write_flow_requirements
 from inspect_flow._launcher.pip_string import get_pip_string
 from inspect_flow._launcher.python_version import resolve_python_version
 from inspect_flow._runner.cli import CHECK_ACTIONS, RUN_ACTIONS
+from inspect_flow._runner.run import LaunchResult
 from inspect_flow._types.flow_types import FlowAgent, FlowSolver, FlowSpec, FlowTask
 from inspect_flow._util.console import path
 from inspect_flow._util.logging import get_last_log_level
@@ -43,13 +43,11 @@ from inspect_flow._util.subprocess_util import (
 logger = getLogger(__name__)
 
 
-def venv_launch(
-    spec: FlowSpec, base_dir: str, dry_run: bool
-) -> tuple[bool, list[EvalLog]]:
+def venv_launch(spec: FlowSpec, base_dir: str, dry_run: bool) -> LaunchResult:
     # The eval logs live in the subprocess; only the success flag is signaled back
     # (via a per-run result file) on a clean exit. A crash raises in _venv_spawn.
     success = _venv_spawn(spec, base_dir=base_dir, subcommand="run", dry_run=dry_run)
-    return success, []
+    return LaunchResult(success=success, logs=[])
 
 
 def venv_check(spec: FlowSpec, base_dir: str) -> bool:

--- a/src/inspect_flow/_runner/cli.py
+++ b/src/inspect_flow/_runner/cli.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import sys
+
 import click
 import yaml
 
@@ -15,7 +17,7 @@ from inspect_flow._runner.check import check_eval_set
 from inspect_flow._runner.run import run_eval_set
 from inspect_flow._types.flow_types import FlowSpec
 from inspect_flow._util.console import path
-from inspect_flow._util.constants import DEFAULT_LOG_LEVEL
+from inspect_flow._util.constants import DEFAULT_LOG_LEVEL, EXIT_INCOMPLETE
 from inspect_flow._util.error import set_exception_hook
 from inspect_flow._util.logging import init_flow_logging
 from inspect_flow._util.subprocess_util import signal_ready_and_wait
@@ -100,7 +102,9 @@ def runner_run(
     mode: DisplayMode = "dry_run" if dry_run else "run"
     with create_display(mode=mode, actions=RUN_ACTIONS) as disp:
         disp.set_title("VENV Flow Spec:", path(file))
-        run_eval_set(cfg, base_dir=base_dir, dry_run=dry_run)
+        success, _ = run_eval_set(cfg, base_dir=base_dir, dry_run=dry_run)
+    if not dry_run and not success:
+        sys.exit(EXIT_INCOMPLETE)
 
 
 @runner.command("check")
@@ -118,7 +122,9 @@ def runner_check(
     cfg = _read_config(file)
     with create_display(mode="check", actions=CHECK_ACTIONS) as disp:
         disp.set_title("VENV Flow Spec:", path(file))
-        check_eval_set(cfg, base_dir=base_dir)
+        result = check_eval_set(cfg, base_dir=base_dir)
+    if not result.is_complete:
+        sys.exit(EXIT_INCOMPLETE)
 
 
 if __name__ == "__main__":

--- a/src/inspect_flow/_runner/cli.py
+++ b/src/inspect_flow/_runner/cli.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import sys
-
 import click
 import yaml
 
@@ -17,7 +15,7 @@ from inspect_flow._runner.check import check_eval_set
 from inspect_flow._runner.run import run_eval_set
 from inspect_flow._types.flow_types import FlowSpec
 from inspect_flow._util.console import path
-from inspect_flow._util.constants import DEFAULT_LOG_LEVEL, EXIT_INCOMPLETE
+from inspect_flow._util.constants import DEFAULT_LOG_LEVEL
 from inspect_flow._util.error import set_exception_hook
 from inspect_flow._util.logging import init_flow_logging
 from inspect_flow._util.subprocess_util import signal_ready_and_wait, write_run_result
@@ -122,8 +120,7 @@ def runner_check(
     with create_display(mode="check", actions=CHECK_ACTIONS) as disp:
         disp.set_title("VENV Flow Spec:", path(file))
         result = check_eval_set(cfg, base_dir=base_dir)
-    if not result.is_complete:
-        sys.exit(EXIT_INCOMPLETE)
+    write_run_result(result.is_complete)
 
 
 if __name__ == "__main__":

--- a/src/inspect_flow/_runner/cli.py
+++ b/src/inspect_flow/_runner/cli.py
@@ -100,8 +100,8 @@ def runner_run(
     mode: DisplayMode = "dry_run" if dry_run else "run"
     with create_display(mode=mode, actions=RUN_ACTIONS) as disp:
         disp.set_title("VENV Flow Spec:", path(file))
-        success, _ = run_eval_set(cfg, base_dir=base_dir, dry_run=dry_run)
-    write_run_result(success)
+        result = run_eval_set(cfg, base_dir=base_dir, dry_run=dry_run)
+    write_run_result(result.success)
 
 
 @runner.command("check")

--- a/src/inspect_flow/_runner/logs.py
+++ b/src/inspect_flow/_runner/logs.py
@@ -42,6 +42,13 @@ class FindLogsResult(NamedTuple):
     task_log_info: dict[str, TaskLogInfo]
     unexpected_logs: list[str]
 
+    @property
+    def is_complete(self) -> bool:
+        return all(
+            info.task_samples is not None and info.log_samples >= info.task_samples
+            for info in self.task_log_info.values()
+        )
+
 
 def get_task_ids_to_tasks(
     tasks: list[InstantiatedTask], spec: FlowSpec

--- a/src/inspect_flow/_runner/logs.py
+++ b/src/inspect_flow/_runner/logs.py
@@ -30,7 +30,7 @@ from inspect_flow._types.flow_types import (
     FlowTask,
 )
 from inspect_flow._util.console import quantity
-from inspect_flow._util.logs import num_valid_samples
+from inspect_flow._util.logs import num_valid_samples, samples_complete
 from inspect_flow._util.not_given import default_none
 from inspect_flow._util.path_util import path_join, path_str
 from inspect_flow._util.pydantic_util import model_dump
@@ -44,8 +44,8 @@ class FindLogsResult(NamedTuple):
 
     @property
     def is_complete(self) -> bool:
-        return all(
-            info.task_samples is not None and info.log_samples >= info.task_samples
+        return samples_complete(
+            (info.log_samples, info.task_samples)
             for info in self.task_log_info.values()
         )
 

--- a/src/inspect_flow/_runner/run.py
+++ b/src/inspect_flow/_runner/run.py
@@ -4,6 +4,7 @@ import time
 from datetime import timedelta
 from importlib.metadata import PackageNotFoundError, requires, version
 from logging import getLogger
+from typing import NamedTuple
 
 import click
 from inspect_ai import eval_set
@@ -51,15 +52,18 @@ from inspect_flow._util.path_util import apply_bundle_url_mappings, cwd_relative
 logger = getLogger(__name__)
 
 
+class LaunchResult(NamedTuple):
+    success: bool
+    logs: list[EvalLog]
+
+
 def _option_string(options: FlowOptions) -> str | None:
     if not options.model_fields_set:
         return None
     return ", ".join(f"{k}={getattr(options, k)!r}" for k in options.model_fields_set)
 
 
-def run_eval_set(
-    spec: FlowSpec, base_dir: str, dry_run: bool = False
-) -> tuple[bool, list[EvalLog]]:
+def run_eval_set(spec: FlowSpec, base_dir: str, dry_run: bool = False) -> LaunchResult:
     resolved_spec = resolve_spec(spec, base_dir=base_dir)
     # 470 - eval_resolve_tasks uses the display, which sets a global that causes it to be ignored when passed to eval_set
     # so we need to initialize the display type here first
@@ -114,7 +118,7 @@ def run_eval_set(
             action.print("Viewer:", path(print_url), copyable=True)
 
     if dry_run:
-        return False, []
+        return LaunchResult(success=False, logs=[])
 
     title = display().get_title()
     if display_type == "full":
@@ -128,8 +132,9 @@ def run_eval_set(
     eval_tasks = run_after_instantiate_hooks([t.task for t in tasks])
 
     start_time = time.time()
+    result: LaunchResult | None
     try:
-        result = eval_set(
+        success, logs = eval_set(
             tasks=eval_tasks,
             log_dir=cwd_relative_path(resolved_spec.log_dir),
             retry_attempts=default_none(options.retry_attempts),
@@ -193,6 +198,7 @@ def run_eval_set(
             retry_immediate=True,
             # kwargs= FlowSpec, FlowTask, and FlowModel allow setting the generate config
         )
+        result = LaunchResult(success=success, logs=logs)
     except (KeyboardInterrupt, click.Abort):
         flow_print(Rule("Eval Set Interrupted"))
         result = None
@@ -215,7 +221,7 @@ def run_eval_set(
                 log_dir=resolved_spec.log_dir, recursive=False, progress=progress
             )
             headers = [log.header for log in dir_logs]
-            result = False, headers
+            result = LaunchResult(success=False, logs=headers)
 
     elapsed_time = time.time() - start_time
 
@@ -224,7 +230,7 @@ def run_eval_set(
     if store and (store_config is None or store_config.write):
         # Now that the logs have been created, need to add the log_dir again to ensure all logs are indexed
         try:
-            store.add_run_logs(result[1])
+            store.add_run_logs(result.logs)
         except NoLogsError as e:
             logger.error(
                 f"No logs found in log directory: {resolved_spec.log_dir}. Cannot add to store. {e}"
@@ -235,7 +241,7 @@ def run_eval_set(
 
 def _print_result(
     spec: FlowSpec,
-    result: tuple[bool, list[EvalLog]],
+    result: LaunchResult,
     elapsed_time: float,
     task_log_info: dict[str, TaskLogInfo],
     title: list[str | Text] | None,

--- a/src/inspect_flow/_util/constants.py
+++ b/src/inspect_flow/_util/constants.py
@@ -3,3 +3,8 @@ from pathlib import Path
 PKG_NAME = Path(__file__).parent.parent.stem
 
 DEFAULT_LOG_LEVEL = "warning"
+
+# Exit code signalling that a command ran successfully but the result is
+# incomplete (e.g. some tasks errored, or `check` found missing logs). Distinct
+# from exit code 1, which is used for handled errors/exceptions.
+EXIT_INCOMPLETE = 2

--- a/src/inspect_flow/_util/constants.py
+++ b/src/inspect_flow/_util/constants.py
@@ -6,5 +6,7 @@ DEFAULT_LOG_LEVEL = "warning"
 
 # Exit code signalling that a command ran successfully but the result is
 # incomplete (e.g. some tasks errored, or `check` found missing logs). Distinct
-# from exit code 1, which is used for handled errors/exceptions.
-EXIT_INCOMPLETE = 2
+# from exit code 1 (handled errors/exceptions) and exit code 2 (click's
+# conventional usage-error code), so scripts can tell an incomplete run apart
+# from a malformed invocation.
+EXIT_INCOMPLETE = 3

--- a/src/inspect_flow/_util/logs.py
+++ b/src/inspect_flow/_util/logs.py
@@ -1,7 +1,7 @@
 """Utilities for working with Inspect logs"""
 
 import re
-from collections.abc import Collection
+from collections.abc import Collection, Iterable
 from datetime import datetime, timezone
 from logging import getLogger
 
@@ -25,6 +25,13 @@ from inspect_flow._util.path_util import path_join
 _TIMESTAMP_RE = re.compile(r"\d{4}-\d{2}-\d{2}T\d{2}[:\-]\d{2}[:\-]\d{2}")
 
 logger = getLogger(__name__)
+
+
+def samples_complete(samples_and_totals: Iterable[tuple[int, int | None]]) -> bool:
+    """`True` if every `(samples, total)` pair has a known total that is met."""
+    return all(
+        total is not None and samples >= total for samples, total in samples_and_totals
+    )
 
 
 def log_filename_ts(path: str) -> datetime | None:

--- a/src/inspect_flow/_util/subprocess_util.py
+++ b/src/inspect_flow/_util/subprocess_util.py
@@ -16,35 +16,37 @@ logger = getLogger(__name__)
 CHILD_READY_FD_ENV = "INSPECT_FLOW_CHILD_READY_FD"
 PARENT_ACK_FD_ENV = "INSPECT_FLOW_PARENT_ACK_FD"
 
-# Absolute path of a per-run file the child writes its success flag to. The
+# Absolute path of a per-run file the child writes its outcome flag to. The
 # parent creates the path and sets this before spawning the child. Using an
 # explicit per-run path (rather than a shared key) keeps concurrent runs from
 # racing and is unaffected by env changes to the child's HOME/XDG_DATA_HOME.
 RUN_RESULT_FILE_ENV = "INSPECT_FLOW_RUN_RESULT_FILE"
 
 
-def write_run_result(success: bool) -> None:
-    """Write the run success flag to the per-run result file, if one was set.
+def write_run_result(ok: bool) -> None:
+    """Write the child runner's outcome flag to the per-run result file.
 
     Called by a child runner process spawned with `RUN_RESULT_FILE_ENV`. Does
     nothing when the env var is unset (e.g. when invoked standalone).
 
     Args:
-        success: Whether the eval set completed successfully.
+        ok: The boolean outcome of the child's work — eval-set success for
+            `run`, completeness for `check`.
     """
     result_path = os.environ.get(RUN_RESULT_FILE_ENV)
     if result_path:
-        Path(result_path).write_text(json.dumps({"success": success}))
+        Path(result_path).write_text(json.dumps({"ok": ok}))
 
 
 def read_run_result(result_path: str) -> bool:
-    """Read the success flag a child runner wrote to its per-run result file.
+    """Read the outcome flag a child runner wrote to its per-run result file.
 
     Args:
         result_path: Absolute path the child was told to write to.
 
     Returns:
-        The success flag written by the child.
+        The boolean outcome written by the child (success for `run`,
+        completeness for `check`).
 
     Raises:
         RuntimeError: If the child exited without writing a result.
@@ -54,7 +56,7 @@ def read_run_result(result_path: str) -> bool:
         raise RuntimeError(
             f"venv run process exited without reporting a result at {result_path}"
         )
-    return bool(json.loads(path.read_text())["success"])
+    return bool(json.loads(path.read_text())["ok"])
 
 
 def signal_ready_and_wait() -> None:

--- a/src/inspect_flow/_util/terminal.py
+++ b/src/inspect_flow/_util/terminal.py
@@ -1,0 +1,20 @@
+"""Helpers for detecting whether the process is attached to a terminal."""
+
+import os
+import sys
+
+
+def stdin_is_interactive() -> bool:
+    """`True` if stdin is an interactive terminal we can prompt on."""
+    try:
+        return sys.stdin is not None and sys.stdin.isatty()
+    except (ValueError, OSError):
+        return False
+
+
+def stdout_is_terminal() -> bool:
+    """`True` if stdout is a terminal (e.g. safe to page output)."""
+    try:
+        return os.isatty(1)
+    except OSError:
+        return False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -336,7 +336,7 @@ def mock_venv_subprocess() -> Generator[MockVenvSubprocess, None, None]:
             env = mock_popen.call_args.kwargs.get("env") or {}
             result_path = env.get(RUN_RESULT_FILE_ENV)
             if result_path:
-                Path(result_path).write_text(json.dumps({"success": True}))
+                Path(result_path).write_text(json.dumps({"ok": True}))
 
         mock_process.wait.side_effect = write_success_result
         mock_process.returncode = 0

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -199,7 +199,7 @@ def test_check_disables_log_dir_create_unique(tmp_path: Path) -> None:
     )
 
     with patch("inspect_flow._api.api.launch_check") as mock_check:
-        mock_check.return_value = CheckLaunchResult(is_complete=True, logs=None)
+        mock_check.return_value = CheckLaunchResult(is_complete=True, find_result=None)
         check(spec=spec, base_dir="./tests/config/")
         checked_spec = mock_check.call_args.kwargs["spec"]
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -89,6 +89,7 @@ def test_resume(tmp_path: Path) -> None:
         patch("inspect_flow._launcher.inproc.run_eval_set") as mock_run_eval_set,
         patch("subprocess.run") as mock_subprocess,
     ):
+        mock_run_eval_set.return_value = (True, [])
         mock_subprocess.return_value = subprocess.CompletedProcess(
             args=[], returncode=0, stdout=""
         )
@@ -123,6 +124,7 @@ def test_resume_ignores_log_dir_create_unique(tmp_path: Path) -> None:
         patch("inspect_flow._launcher.inproc.run_eval_set") as mock_run_eval_set,
         patch("subprocess.run") as mock_subprocess,
     ):
+        mock_run_eval_set.return_value = (True, [])
         mock_subprocess.return_value = subprocess.CompletedProcess(
             args=[], returncode=0, stdout=""
         )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -5,6 +5,8 @@ from unittest.mock import patch
 
 import pytest
 from inspect_flow._api import api as api_module
+from inspect_flow._launcher.launch import CheckLaunchResult
+from inspect_flow._runner.run import LaunchResult
 from inspect_flow._types.flow_types import FlowSpec, FlowTask, not_given
 from inspect_flow._util.data import LAST_LOG_DIR_KEY, read_data
 from inspect_flow.api import RunResult, check, config, init, load_spec, run, store_get
@@ -31,7 +33,7 @@ def test_258_run_includes() -> None:
         ],
     )
     with patch("inspect_flow._api.api.launch") as mock_launch:
-        mock_launch.return_value = (True, [])
+        mock_launch.return_value = LaunchResult(success=True, logs=[])
         run(spec=spec, base_dir="./tests/config/")
     mock_launch.assert_called_once()
     launch_spec = mock_launch.mock_calls[0].kwargs["spec"]
@@ -57,7 +59,7 @@ def test_ensure_init_loads_dotenv_from_base_dir(tmp_path: Path) -> None:
     os.environ.pop("TEST_ENV_VAR", None)
     spec = FlowSpec(log_dir=str(tmp_path / "logs"), tasks=["local_eval/noop"])
     with patch("inspect_flow._api.api.launch") as mock_launch:
-        mock_launch.return_value = (True, [])
+        mock_launch.return_value = LaunchResult(success=True, logs=[])
         run(spec=spec, base_dir="./tests/config/")
     assert os.environ.get("TEST_ENV_VAR") == "test_value"
     del os.environ["TEST_ENV_VAR"]
@@ -95,7 +97,7 @@ def test_resume(tmp_path: Path) -> None:
         patch("inspect_flow._launcher.inproc.run_eval_set") as mock_run_eval_set,
         patch("subprocess.run") as mock_subprocess,
     ):
-        mock_run_eval_set.return_value = (True, [])
+        mock_run_eval_set.return_value = LaunchResult(success=True, logs=[])
         mock_subprocess.return_value = subprocess.CompletedProcess(
             args=[], returncode=0, stdout=""
         )
@@ -130,7 +132,7 @@ def test_resume_ignores_log_dir_create_unique(tmp_path: Path) -> None:
         patch("inspect_flow._launcher.inproc.run_eval_set") as mock_run_eval_set,
         patch("subprocess.run") as mock_subprocess,
     ):
-        mock_run_eval_set.return_value = (True, [])
+        mock_run_eval_set.return_value = LaunchResult(success=True, logs=[])
         mock_subprocess.return_value = subprocess.CompletedProcess(
             args=[], returncode=0, stdout=""
         )
@@ -197,7 +199,7 @@ def test_check_disables_log_dir_create_unique(tmp_path: Path) -> None:
     )
 
     with patch("inspect_flow._api.api.launch_check") as mock_check:
-        mock_check.return_value = (True, None)
+        mock_check.return_value = CheckLaunchResult(is_complete=True, logs=None)
         check(spec=spec, base_dir="./tests/config/")
         checked_spec = mock_check.call_args.kwargs["spec"]
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -197,6 +197,7 @@ def test_check_disables_log_dir_create_unique(tmp_path: Path) -> None:
     )
 
     with patch("inspect_flow._api.api.launch_check") as mock_check:
+        mock_check.return_value = (True, None)
         check(spec=spec, base_dir="./tests/config/")
         checked_spec = mock_check.call_args.kwargs["spec"]
 

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -88,6 +88,21 @@ def test_check_result_task_has_duplicate_logs(tmp_path: Path) -> None:
     assert len(result.tasks[0].duplicate_logs) == 1
 
 
+def test_check_result_is_complete(tmp_path: Path) -> None:
+    log_dir = str(tmp_path / "logs")
+    flow_task = FlowTask(name=_TASK, model="mockllm/mock-llm")
+    spec = FlowSpec(log_dir=log_dir, tasks=[flow_task])
+
+    incomplete = check(spec=spec, base_dir=".")
+    assert incomplete is not None
+    assert not incomplete.is_complete
+
+    run_eval_set(spec=spec, base_dir=".")
+    complete = check(spec=spec, base_dir=".")
+    assert complete is not None
+    assert complete.is_complete
+
+
 def test_check_result_has_unrecognized_logs(tmp_path: Path) -> None:
     log_dir = str(tmp_path / "logs")
     spec = FlowSpec(

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -36,7 +36,6 @@ def test_check_returns_result_with_no_existing_logs(tmp_path: Path) -> None:
 
     result = check(spec=spec, base_dir=".")
 
-    assert result is not None
     assert len(result.tasks) == 1
     assert result.unrecognized == []
 
@@ -57,7 +56,6 @@ def test_check_returns_result_with_completed_log(tmp_path: Path) -> None:
     run_eval_set(spec=spec, base_dir=".")
     result = check(spec=spec, base_dir=".")
 
-    assert result is not None
     assert len(result.tasks) == 1
     assert result.unrecognized == []
 
@@ -84,7 +82,6 @@ def test_check_result_task_has_duplicate_logs(tmp_path: Path) -> None:
 
     result = check(spec=spec, base_dir=".")
 
-    assert result is not None
     assert len(result.tasks[0].duplicate_logs) == 1
 
 
@@ -94,12 +91,10 @@ def test_check_result_is_complete(tmp_path: Path) -> None:
     spec = FlowSpec(log_dir=log_dir, tasks=[flow_task])
 
     incomplete = check(spec=spec, base_dir=".")
-    assert incomplete is not None
     assert not incomplete.is_complete
 
     run_eval_set(spec=spec, base_dir=".")
     complete = check(spec=spec, base_dir=".")
-    assert complete is not None
     assert complete.is_complete
 
 
@@ -116,6 +111,5 @@ def test_check_result_has_unrecognized_logs(tmp_path: Path) -> None:
     empty_spec = FlowSpec(log_dir=log_dir, tasks=[])
     result = check(spec=empty_spec, base_dir=".")
 
-    assert result is not None
     assert len(result.unrecognized) == 1
     assert result.tasks == []

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -1,6 +1,8 @@
 import shutil
 from pathlib import Path
+from unittest.mock import patch
 
+import pytest
 from inspect_flow import FlowSpec, FlowTask
 from inspect_flow._runner.run import run_eval_set
 from inspect_flow.api import check
@@ -96,6 +98,26 @@ def test_check_result_is_complete(tmp_path: Path) -> None:
     run_eval_set(spec=spec, base_dir=".")
     complete = check(spec=spec, base_dir=".")
     assert complete.is_complete
+
+
+@pytest.mark.parametrize("is_complete", [True, False])
+def test_check_venv_returns_is_complete(tmp_path: Path, is_complete: bool) -> None:
+    spec = FlowSpec(
+        execution_type="venv",
+        log_dir=str(tmp_path / "logs"),
+        tasks=[FlowTask(name=_TASK, model="mockllm/mock-llm")],
+    )
+
+    with patch(
+        "inspect_flow._launcher.launch.venv_check", return_value=is_complete
+    ) as mock_venv_check:
+        result = check(spec=spec, base_dir=".")
+
+    mock_venv_check.assert_called_once()
+    # The per-task details live in the subprocess; only is_complete comes back.
+    assert result.is_complete is is_complete
+    assert result.tasks == []
+    assert result.unrecognized == []
 
 
 def test_check_result_has_unrecognized_logs(tmp_path: Path) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,6 +10,8 @@ from inspect_flow._cli.options import _options_to_overrides
 from inspect_flow._cli.run import run_command
 from inspect_flow._cli.store import store_command
 from inspect_flow._config.load import ConfigOptions, _apply_overrides
+from inspect_flow._launcher.launch import CheckLaunchResult
+from inspect_flow._runner.run import LaunchResult
 from inspect_flow._types.flow_types import FlowSpec
 from inspect_flow._version import __version__
 
@@ -47,7 +49,10 @@ def test_flow_version() -> None:
 def test_run_command_overrides() -> None:
     runner = CliRunner()
     with (
-        patch("inspect_flow._cli.run.launch", return_value=(True, [])) as mock_run,
+        patch(
+            "inspect_flow._cli.run.launch",
+            return_value=LaunchResult(success=True, logs=[]),
+        ) as mock_run,
         patch("inspect_flow._cli.run.int_load_spec") as mock_config,
     ):
         # Mock the config object
@@ -96,7 +101,10 @@ def test_run_command_overrides() -> None:
 def test_run_command_log_dir_create_unique() -> None:
     runner = CliRunner()
     with (
-        patch("inspect_flow._cli.run.launch", return_value=(True, [])) as mock_run,
+        patch(
+            "inspect_flow._cli.run.launch",
+            return_value=LaunchResult(success=True, logs=[]),
+        ) as mock_run,
         patch("inspect_flow._cli.run.int_load_spec") as mock_config,
     ):
         # Mock the config object
@@ -142,7 +150,7 @@ def test_no_log_dir_create_unique_overrides_spec() -> None:
 def test_check_command_disables_log_dir_create_unique() -> None:
     runner = CliRunner()
     with patch("inspect_flow._cli.check.launch_check") as mock_check:
-        mock_check.return_value = (True, None)
+        mock_check.return_value = CheckLaunchResult(is_complete=True, logs=None)
         result = runner.invoke(
             check_command,
             [CONFIG_FILE, "--set", "log_dir_create_unique=True"],
@@ -225,7 +233,10 @@ def test_config_command_overrides_envvars(monkeypatch: pytest.MonkeyPatch) -> No
 def test_run_command_dry_run() -> None:
     runner = CliRunner()
     with (
-        patch("inspect_flow._cli.run.launch", return_value=(True, [])) as mock_run,
+        patch(
+            "inspect_flow._cli.run.launch",
+            return_value=LaunchResult(success=True, logs=[]),
+        ) as mock_run,
         patch("inspect_flow._cli.run.int_load_spec") as mock_config,
     ):
         mock_config_obj = MagicMock()
@@ -249,7 +260,10 @@ def test_run_command_dry_run() -> None:
 def test_run_command_args() -> None:
     runner = CliRunner()
     with (
-        patch("inspect_flow._cli.run.launch", return_value=(True, [])) as mock_run,
+        patch(
+            "inspect_flow._cli.run.launch",
+            return_value=LaunchResult(success=True, logs=[]),
+        ) as mock_run,
         patch("inspect_flow._cli.run.int_load_spec") as mock_config,
     ):
         mock_config_obj = MagicMock()
@@ -279,7 +293,10 @@ def test_run_command_args() -> None:
 def test_run_command_venv() -> None:
     runner = CliRunner()
     with (
-        patch("inspect_flow._cli.run.launch", return_value=(True, [])) as mock_run,
+        patch(
+            "inspect_flow._cli.run.launch",
+            return_value=LaunchResult(success=True, logs=[]),
+        ) as mock_run,
         patch("inspect_flow._cli.run.int_load_spec") as mock_config,
     ):
         mock_config_obj = MagicMock()
@@ -306,7 +323,10 @@ def test_run_command_venv() -> None:
 def test_run_command_allow_dirty() -> None:
     runner = CliRunner()
     with (
-        patch("inspect_flow._cli.run.launch", return_value=(True, [])) as mock_run,
+        patch(
+            "inspect_flow._cli.run.launch",
+            return_value=LaunchResult(success=True, logs=[]),
+        ) as mock_run,
         patch("inspect_flow._cli.run.int_load_spec") as mock_config,
     ):
         mock_config_obj = MagicMock()
@@ -562,7 +582,10 @@ def test_run_display_passed_to_eval_set(mock_eval_set: MagicMock) -> None:
 def test_run_command_resume() -> None:
     runner = CliRunner()
     with (
-        patch("inspect_flow._cli.run.launch", return_value=(True, [])),
+        patch(
+            "inspect_flow._cli.run.launch",
+            return_value=LaunchResult(success=True, logs=[]),
+        ),
         patch("inspect_flow._cli.run.int_load_spec") as mock_config,
     ):
         mock_config_obj = MagicMock()
@@ -599,7 +622,10 @@ def test_run_command_resume_and_log_dir_mutually_exclusive() -> None:
 def test_run_command_multiple_store_filters() -> None:
     runner = CliRunner()
     with (
-        patch("inspect_flow._cli.run.launch", return_value=(True, [])),
+        patch(
+            "inspect_flow._cli.run.launch",
+            return_value=LaunchResult(success=True, logs=[]),
+        ),
         patch("inspect_flow._cli.run.int_load_spec") as mock_config,
     ):
         mock_config_obj = MagicMock()
@@ -637,7 +663,10 @@ def test_no_duplicate_short_flags() -> None:
 
     runner = CliRunner()
     with (
-        patch("inspect_flow._cli.run.launch", return_value=(True, [])),
+        patch(
+            "inspect_flow._cli.run.launch",
+            return_value=LaunchResult(success=True, logs=[]),
+        ),
         patch("inspect_flow._cli.run.int_load_spec") as mock_config,
         warnings.catch_warnings(record=True) as caught,
     ):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -150,7 +150,7 @@ def test_no_log_dir_create_unique_overrides_spec() -> None:
 def test_check_command_disables_log_dir_create_unique() -> None:
     runner = CliRunner()
     with patch("inspect_flow._cli.check.launch_check") as mock_check:
-        mock_check.return_value = CheckLaunchResult(is_complete=True, logs=None)
+        mock_check.return_value = CheckLaunchResult(is_complete=True, find_result=None)
         result = runner.invoke(
             check_command,
             [CONFIG_FILE, "--set", "log_dir_create_unique=True"],
@@ -444,6 +444,23 @@ def test_check_command_exit_code_complete(tmp_path: Path) -> None:
     assert check_result.exit_code == 0
 
 
+@pytest.mark.parametrize("is_complete,expected_code", [(True, 0), (False, 3)])
+def test_check_command_venv_exit_code(
+    tmp_path: Path, is_complete: bool, expected_code: int
+) -> None:
+    runner = CliRunner()
+    with patch(
+        "inspect_flow._launcher.launch.venv_check", return_value=is_complete
+    ) as mock_venv_check:
+        result = runner.invoke(
+            check_command,
+            [CONFIG_FILE, "--log-dir", str(tmp_path), "--set", "execution_type=venv"],
+            catch_exceptions=False,
+        )
+    mock_venv_check.assert_called_once()
+    assert result.exit_code == expected_code
+
+
 def test_store_commands() -> None:
     log_dir = "tests/test_logs/logs1"
     runner = CliRunner()
@@ -486,7 +503,7 @@ def test_store_delete() -> None:
     log_dir = "tests/test_logs/logs1"
     runner = CliRunner()
     runner.invoke(store_command, ["import", log_dir, "--log-level", "error"])
-    with patch("inspect_flow._cli.store._stdin_is_interactive", return_value=True):
+    with patch("inspect_flow._cli.store.stdin_is_interactive", return_value=True):
         result = runner.invoke(
             store_command, ["delete", "--log-level", "error"], input="y\n"
         )
@@ -509,7 +526,7 @@ def test_store_delete_abort() -> None:
     log_dir = "tests/test_logs/logs1"
     runner = CliRunner()
     runner.invoke(store_command, ["import", log_dir, "--log-level", "error"])
-    with patch("inspect_flow._cli.store._stdin_is_interactive", return_value=True):
+    with patch("inspect_flow._cli.store.stdin_is_interactive", return_value=True):
         result = runner.invoke(
             store_command, ["delete", "--log-level", "error"], input="n\n"
         )
@@ -522,7 +539,7 @@ def test_store_delete_non_tty_requires_yes() -> None:
     log_dir = "tests/test_logs/logs1"
     runner = CliRunner()
     runner.invoke(store_command, ["import", log_dir, "--log-level", "error"])
-    with patch("inspect_flow._cli.store._stdin_is_interactive", return_value=False):
+    with patch("inspect_flow._cli.store.stdin_is_interactive", return_value=False):
         result = runner.invoke(store_command, ["delete", "--log-level", "error"])
     assert result.exit_code != 0
     assert "--yes" in result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -395,7 +395,7 @@ def test_run_command_exit_code_incomplete(tmp_path: Path) -> None:
     runner = CliRunner()
     with patch("inspect_flow._runner.run.eval_set", return_value=(False, [])):
         result = runner.invoke(run_command, [CONFIG_FILE, "--log-dir", str(tmp_path)])
-    assert result.exit_code == 2
+    assert result.exit_code == 3
 
 
 def test_run_command_exit_code_success(tmp_path: Path) -> None:
@@ -408,7 +408,7 @@ def test_run_command_exit_code_success(tmp_path: Path) -> None:
 def test_check_command_exit_code_incomplete(tmp_path: Path) -> None:
     runner = CliRunner()
     result = runner.invoke(check_command, [CONFIG_FILE, "--log-dir", str(tmp_path)])
-    assert result.exit_code == 2
+    assert result.exit_code == 3
 
 
 def test_check_command_exit_code_complete(tmp_path: Path) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -142,6 +142,7 @@ def test_no_log_dir_create_unique_overrides_spec() -> None:
 def test_check_command_disables_log_dir_create_unique() -> None:
     runner = CliRunner()
     with patch("inspect_flow._cli.check.launch_check") as mock_check:
+        mock_check.return_value = (True, None)
         result = runner.invoke(
             check_command,
             [CONFIG_FILE, "--set", "log_dir_create_unique=True"],

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -391,6 +391,38 @@ def test_417_invalid_run() -> None:
     )
 
 
+def test_run_command_exit_code_incomplete(tmp_path: Path) -> None:
+    runner = CliRunner()
+    with patch("inspect_flow._runner.run.eval_set", return_value=(False, [])):
+        result = runner.invoke(run_command, [CONFIG_FILE, "--log-dir", str(tmp_path)])
+    assert result.exit_code == 2
+
+
+def test_run_command_exit_code_success(tmp_path: Path) -> None:
+    runner = CliRunner()
+    with patch("inspect_flow._runner.run.eval_set", return_value=(True, [])):
+        result = runner.invoke(run_command, [CONFIG_FILE, "--log-dir", str(tmp_path)])
+    assert result.exit_code == 0
+
+
+def test_check_command_exit_code_incomplete(tmp_path: Path) -> None:
+    runner = CliRunner()
+    result = runner.invoke(check_command, [CONFIG_FILE, "--log-dir", str(tmp_path)])
+    assert result.exit_code == 2
+
+
+def test_check_command_exit_code_complete(tmp_path: Path) -> None:
+    runner = CliRunner()
+    run_result = runner.invoke(
+        run_command, [CONFIG_FILE, "--log-dir", str(tmp_path)], catch_exceptions=False
+    )
+    assert run_result.exit_code == 0
+    check_result = runner.invoke(
+        check_command, [CONFIG_FILE, "--log-dir", str(tmp_path)], catch_exceptions=False
+    )
+    assert check_result.exit_code == 0
+
+
 def test_store_commands() -> None:
     log_dir = "tests/test_logs/logs1"
     runner = CliRunner()
@@ -433,9 +465,10 @@ def test_store_delete() -> None:
     log_dir = "tests/test_logs/logs1"
     runner = CliRunner()
     runner.invoke(store_command, ["import", log_dir, "--log-level", "error"])
-    result = runner.invoke(
-        store_command, ["delete", "--log-level", "error"], input="y\n"
-    )
+    with patch("inspect_flow._cli.store._stdin_is_interactive", return_value=True):
+        result = runner.invoke(
+            store_command, ["delete", "--log-level", "error"], input="y\n"
+        )
     assert result.exit_code == 0
     assert "Deleted store" in result.output
     result = runner.invoke(store_command, ["info", "--log-level", "error"])
@@ -455,10 +488,24 @@ def test_store_delete_abort() -> None:
     log_dir = "tests/test_logs/logs1"
     runner = CliRunner()
     runner.invoke(store_command, ["import", log_dir, "--log-level", "error"])
-    result = runner.invoke(
-        store_command, ["delete", "--log-level", "error"], input="n\n"
-    )
+    with patch("inspect_flow._cli.store._stdin_is_interactive", return_value=True):
+        result = runner.invoke(
+            store_command, ["delete", "--log-level", "error"], input="n\n"
+        )
     assert result.exit_code != 0
+    result = runner.invoke(store_command, ["info", "--log-level", "error"])
+    assert "2 logs" in result.output
+
+
+def test_store_delete_non_tty_requires_yes() -> None:
+    log_dir = "tests/test_logs/logs1"
+    runner = CliRunner()
+    runner.invoke(store_command, ["import", log_dir, "--log-level", "error"])
+    with patch("inspect_flow._cli.store._stdin_is_interactive", return_value=False):
+        result = runner.invoke(store_command, ["delete", "--log-level", "error"])
+    assert result.exit_code != 0
+    assert "--yes" in result.output
+    # The store must be left intact when confirmation is refused.
     result = runner.invoke(store_command, ["info", "--log-level", "error"])
     assert "2 logs" in result.output
 

--- a/tests/test_inspect_objects.py
+++ b/tests/test_inspect_objects.py
@@ -281,7 +281,7 @@ def test_559_factory_name() -> None:
         ],
     )
     result = run_eval_set(spec=(spec), base_dir=".")
-    logs = result[1]
+    logs = result.logs
     assert len(logs) == 1
     assert logs[0].eval.task == "custom_task_name"
     verify_test_logs(spec, log_dir)
@@ -302,7 +302,7 @@ def test_559_factory_name_after_dump() -> None:
     dump = model_dump(spec)
     spec = FlowSpec.model_validate(dump)
     result = run_eval_set(spec=(spec), base_dir=".")
-    logs = result[1]
+    logs = result.logs
     assert len(logs) == 1
     assert logs[0].eval.task == "custom_task_name"
     verify_test_logs(spec, log_dir)

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -2,7 +2,7 @@ import json
 import os
 import subprocess
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from botocore.client import BaseClient
@@ -87,9 +87,7 @@ def test_launch_venv_returns_subprocess_success(
     # the parent reads it back and returns it (with empty logs, in the child).
     def write_result() -> None:
         env = mock_venv_subprocess.popen.call_args.kwargs["env"]
-        Path(env[RUN_RESULT_FILE_ENV]).write_text(
-            json.dumps({"success": child_success})
-        )
+        Path(env[RUN_RESULT_FILE_ENV]).write_text(json.dumps({"ok": child_success}))
 
     mock_venv_subprocess.popen.return_value.wait.side_effect = write_result
 
@@ -140,6 +138,33 @@ def test_runner_run_writes_success(
 
     assert result.exit_code == 0
     assert read_run_result(str(result_path)) is eval_set_success
+
+
+@pytest.mark.parametrize("is_complete", [True, False])
+def test_runner_check_writes_is_complete(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, is_complete: bool
+) -> None:
+    spec = FlowSpec(
+        log_dir=str(tmp_path / "logs"),
+        store="none",
+        tasks=[FlowTask(name=_TASK, model="mockllm/mock-llm")],
+    )
+    config_file = write_config_file(spec)
+    result_path = tmp_path / "run_result.json"
+    monkeypatch.setenv(RUN_RESULT_FILE_ENV, str(result_path))
+
+    with patch(
+        "inspect_flow._runner.cli.check_eval_set",
+        return_value=MagicMock(is_complete=is_complete),
+    ):
+        result = CliRunner().invoke(
+            runner,
+            ["check", "--file", config_file, "--base-dir", "."],
+            catch_exceptions=False,
+        )
+
+    assert result.exit_code == 0
+    assert read_run_result(str(result_path)) is is_complete
 
 
 def test_env(

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -14,7 +14,7 @@ from inspect_flow._display.display import DEFAULT_DISPLAY_TYPE
 from inspect_flow._launcher.launch import launch
 from inspect_flow._launcher.venv import _check_spec_for_venv, _create_venv
 from inspect_flow._types.flow_types import FlowSolver, FlowTask
-from inspect_flow._util.constants import DEFAULT_LOG_LEVEL
+from inspect_flow._util.constants import DEFAULT_LOG_LEVEL, EXIT_INCOMPLETE
 
 from tests.config.inspect_objects_flow import a_agent, a_scorer, a_solver
 from tests.conftest import MockVenvSubprocess, mock_call_arg
@@ -313,3 +313,22 @@ def test_flow_process_error(mock_venv_subprocess: MockVenvSubprocess) -> None:
         launch(spec=spec, base_dir="./tests/config/")
     mock_create_venv.assert_called_once()
     assert e.value.returncode == 123
+
+
+def test_flow_process_incomplete_returns_false(
+    mock_venv_subprocess: MockVenvSubprocess,
+) -> None:
+    spec = FlowSpec(
+        execution_type="venv",
+        log_dir="logs",
+        tasks=[
+            "local_eval/noop",
+        ],
+    )
+
+    mock_venv_subprocess.popen.return_value.returncode = EXIT_INCOMPLETE
+
+    with patch("inspect_flow._launcher.venv._create_venv") as mock_create_venv:
+        complete = launch(spec=spec, base_dir="./tests/config/")
+    mock_create_venv.assert_called_once()
+    assert complete is False

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -17,6 +17,7 @@ from inspect_flow._display.display import DEFAULT_DISPLAY_TYPE
 from inspect_flow._launcher.launch import launch
 from inspect_flow._launcher.venv import _check_spec_for_venv, _create_venv
 from inspect_flow._runner.cli import runner
+from inspect_flow._runner.run import LaunchResult
 from inspect_flow._types.flow_types import FlowSolver, FlowTask
 from inspect_flow._util.constants import DEFAULT_LOG_LEVEL
 from inspect_flow._util.subprocess_util import RUN_RESULT_FILE_ENV, read_run_result
@@ -34,7 +35,7 @@ def test_launch_inproc() -> None:
         patch("inspect_flow._launcher.inproc.run_eval_set") as mock_run_eval_set,
         patch("subprocess.run") as mock_run,
     ):
-        mock_run_eval_set.return_value = (True, [])
+        mock_run_eval_set.return_value = LaunchResult(success=True, logs=[])
         mock_run.return_value = subprocess.CompletedProcess(
             args=[], returncode=0, stdout="mocked output"
         )
@@ -129,7 +130,7 @@ def test_runner_run_writes_success(
 
     with patch(
         "inspect_flow._runner.cli.run_eval_set",
-        return_value=(eval_set_success, []),
+        return_value=LaunchResult(success=eval_set_success, logs=[]),
     ):
         result = CliRunner().invoke(
             runner,
@@ -169,7 +170,10 @@ def test_env_inproc(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("myenv1", raising=False)
     monkeypatch.delenv("myenv2", raising=False)
 
-    with patch("inspect_flow._launcher.inproc.run_eval_set", return_value=(True, [])):
+    with patch(
+        "inspect_flow._launcher.inproc.run_eval_set",
+        return_value=LaunchResult(success=True, logs=[]),
+    ):
         launch(
             spec=FlowSpec(
                 execution_type="inproc",

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -27,6 +27,7 @@ def test_launch_inproc() -> None:
         patch("inspect_flow._launcher.inproc.run_eval_set") as mock_run_eval_set,
         patch("subprocess.run") as mock_run,
     ):
+        mock_run_eval_set.return_value = (True, [])
         mock_run.return_value = subprocess.CompletedProcess(
             args=[], returncode=0, stdout="mocked output"
         )
@@ -98,7 +99,7 @@ def test_env_inproc(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("myenv1", raising=False)
     monkeypatch.delenv("myenv2", raising=False)
 
-    with patch("inspect_flow._launcher.inproc.run_eval_set"):
+    with patch("inspect_flow._launcher.inproc.run_eval_set", return_value=(True, [])):
         launch(
             spec=FlowSpec(
                 execution_type="inproc",

--- a/tests/test_list_cli.py
+++ b/tests/test_list_cli.py
@@ -28,6 +28,19 @@ def test_list_log(recording_console: Console) -> None:
     assert "Date " in result.output
 
 
+def test_list_log_no_page_when_not_tty() -> None:
+    runner = CliRunner()
+    _import_logs(runner)
+    with (
+        patch("inspect_flow._cli.list.os.isatty", return_value=False),
+        patch("inspect_flow._cli.list._paged_output") as paged,
+    ):
+        result = runner.invoke(list_command, ["log"], catch_exceptions=False)
+    assert result.exit_code == 0
+    paged.assert_not_called()
+    assert "gpqa_diamond" in result.output
+
+
 def test_list_log_oneline(recording_console: Console) -> None:
     runner = CliRunner()
     _import_logs(runner)

--- a/tests/test_list_cli.py
+++ b/tests/test_list_cli.py
@@ -32,7 +32,7 @@ def test_list_log_no_page_when_not_tty() -> None:
     runner = CliRunner()
     _import_logs(runner)
     with (
-        patch("inspect_flow._cli.list.os.isatty", return_value=False),
+        patch("inspect_flow._cli.list.stdout_is_terminal", return_value=False),
         patch("inspect_flow._cli.list._paged_output") as paged,
     ):
         result = runner.invoke(list_command, ["log"], catch_exceptions=False)

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -1046,7 +1046,7 @@ def test_task_failure() -> None:
         tasks=[FlowTask(name=task_file + "@noop", solver="fail_solver")],
     )
     result = run_eval_set(spec=spec, base_dir=".")
-    assert result[0] is False
+    assert result.success is False
 
 
 def test_eval_set_args(mock_eval_set: MagicMock) -> None:

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -20,6 +20,7 @@ from inspect_flow._runner.logs import (
 )
 from inspect_flow._runner.resolve import resolve_spec
 from inspect_flow._runner.run import (
+    LaunchResult,
     _bundle_url_output,
     _fix_prerequisite_error_message,
     _option_string,
@@ -472,7 +473,7 @@ class TestFlowRunCli:
         mock_signal: MagicMock,
         tmp_path: pytest.TempPathFactory,
     ) -> None:
-        mock_run.return_value = (True, [])
+        mock_run.return_value = LaunchResult(success=True, logs=[])
         config_data = {"tasks": ["my_task"], "log_dir": "./logs"}
         config_file = tmp_path / "flow.yaml"  # type: ignore[operator]
         config_file.write_text(yaml.dump(config_data))


### PR DESCRIPTION
Fixes #724

- `flow run` and `flow check` now exit with code 3 ("incomplete") when the
  eval set does not fully succeed or the spec is missing logs, distinct from
  exit code 1 (handled errors) and exit code 2 (click's usage errors). Works
  for both inproc and venv execution.
- `flow store delete` refuses with a clear error (instead of hanging) when
  stdin is not a TTY and `--yes` was not passed.
- `flow list log` already skips paging on non-TTY stdout; locked in with a test.

### API behavior changes

- **`check()` now always returns a `CheckResult` (previously `CheckResult | None`).**
  It no longer returns `None` for venv execution. For venv the per-task details
  live in the subprocess, so `tasks` and `unrecognized` are empty, but the new
  `is_complete` flag is always populated. Any `if check(...) is None:` branch is
  now dead code.
- **`CheckResult.is_complete` is now a stored field, not a computed property**,
  and is the first field on the dataclass. Code that constructs `CheckResult`
  positionally must be updated (it is normally a received type, not constructed).
  This mirrors `RunResult.success`: completeness is reported uniformly for both
  inproc and venv.
- `run()`'s `RunResult.success` is now documented as `True` only when every task
  in the eval set completed successfully.

Co-authored-by: Ransom Richardson <ransomr@users.noreply.github.com>
