### PR TITLE
feat: add --json output to read-only CLI commands

### DIFF
--- a/src/inspect_flow/_cli/check.py
+++ b/src/inspect_flow/_cli/check.py
@@ -5,12 +5,7 @@ import click
 from inspect_ai._util.file import absolute_file_path
 from typing_extensions import Unpack
 
-from inspect_flow._cli.json_output import (
-    emit_json,
-    ensure_json_supported,
-    find_logs_result_to_json,
-    quiet_output,
-)
+from inspect_flow._cli.json_output import emit_json, quiet_output
 from inspect_flow._cli.options import (
     ConfigOptionArgs,
     check_options,
@@ -49,11 +44,9 @@ def check_command(
     if output_json:
         with quiet_output():
             spec = int_load_spec(config_file, options=parse_config_options(**kwargs))
-            ensure_json_supported(spec)
-            result = launch_check(spec, base_dir=base_dir)
-        assert spec.log_dir
-        assert result.find_result is not None
-        emit_json(find_logs_result_to_json(result.find_result, spec.log_dir))
+            result = launch_check(spec, base_dir=base_dir, output_json=True)
+        assert result.json_result is not None
+        emit_json(result.json_result)
         if not result.is_complete:
             sys.exit(EXIT_INCOMPLETE)
         return

--- a/src/inspect_flow/_cli/check.py
+++ b/src/inspect_flow/_cli/check.py
@@ -6,6 +6,7 @@ from typing_extensions import Unpack
 
 from inspect_flow._cli.json_output import (
     emit_json,
+    ensure_json_supported,
     find_logs_result_to_json,
     quiet_output,
 )
@@ -46,13 +47,11 @@ def check_command(
     if output_json:
         with quiet_output():
             spec = int_load_spec(config_file, options=parse_config_options(**kwargs))
+            ensure_json_supported(spec)
             result = launch_check(spec, base_dir=base_dir)
         assert spec.log_dir
-        emit_json(
-            find_logs_result_to_json(result, spec.log_dir)
-            if result is not None
-            else None
-        )
+        assert result is not None
+        emit_json(find_logs_result_to_json(result, spec.log_dir))
         return
     with create_display(mode="check", actions=_check_actions) as display:
         display.set_title("Flow Spec:", path(config_file))

--- a/src/inspect_flow/_cli/check.py
+++ b/src/inspect_flow/_cli/check.py
@@ -5,10 +5,16 @@ import click
 from inspect_ai._util.file import absolute_file_path
 from typing_extensions import Unpack
 
+from inspect_flow._cli.json_output import (
+    emit_json,
+    find_logs_result_to_json,
+    quiet_output,
+)
 from inspect_flow._cli.options import (
     ConfigOptionArgs,
     check_options,
     init_output,
+    json_option,
     parse_config_options,
 )
 from inspect_flow._config.load import int_load_spec
@@ -28,17 +34,33 @@ _check_actions = {
     "check",
     help="Check a spec against existing logs (searches log directory recursively)",
 )
+@json_option
 @check_options
 def check_command(
     config_file: str,
+    output_json: bool,
     **kwargs: Unpack[ConfigOptionArgs],
 ) -> None:
     init_output(**kwargs)
     config_file = absolute_file_path(config_file)
+    kwargs["log_dir_create_unique"] = False
+    base_dir = str(Path(config_file).parent)
+    if output_json:
+        with quiet_output():
+            spec = int_load_spec(config_file, options=parse_config_options(**kwargs))
+            result = launch_check(spec, base_dir=base_dir)
+        assert spec.log_dir
+        emit_json(
+            find_logs_result_to_json(result.find_result, spec.log_dir)
+            if result.find_result is not None
+            else None
+        )
+        if not result.is_complete:
+            sys.exit(EXIT_INCOMPLETE)
+        return
     with create_display(mode="check", actions=_check_actions) as display:
         display.set_title("Flow Spec:", path(config_file))
-        kwargs["log_dir_create_unique"] = False
         spec = int_load_spec(config_file, options=parse_config_options(**kwargs))
-        result = launch_check(spec, base_dir=str(Path(config_file).parent))
+        result = launch_check(spec, base_dir=base_dir)
     if not result.is_complete:
         sys.exit(EXIT_INCOMPLETE)

--- a/src/inspect_flow/_cli/check.py
+++ b/src/inspect_flow/_cli/check.py
@@ -7,6 +7,7 @@ from typing_extensions import Unpack
 
 from inspect_flow._cli.json_output import (
     emit_json,
+    ensure_json_supported,
     find_logs_result_to_json,
     quiet_output,
 )
@@ -48,13 +49,11 @@ def check_command(
     if output_json:
         with quiet_output():
             spec = int_load_spec(config_file, options=parse_config_options(**kwargs))
+            ensure_json_supported(spec)
             result = launch_check(spec, base_dir=base_dir)
         assert spec.log_dir
-        emit_json(
-            find_logs_result_to_json(result.find_result, spec.log_dir)
-            if result.find_result is not None
-            else None
-        )
+        assert result.find_result is not None
+        emit_json(find_logs_result_to_json(result.find_result, spec.log_dir))
         if not result.is_complete:
             sys.exit(EXIT_INCOMPLETE)
         return

--- a/src/inspect_flow/_cli/check.py
+++ b/src/inspect_flow/_cli/check.py
@@ -4,10 +4,16 @@ import click
 from inspect_ai._util.file import absolute_file_path
 from typing_extensions import Unpack
 
+from inspect_flow._cli.json_output import (
+    emit_json,
+    find_logs_result_to_json,
+    quiet_output,
+)
 from inspect_flow._cli.options import (
     ConfigOptionArgs,
     check_options,
     init_output,
+    json_option,
     parse_config_options,
 )
 from inspect_flow._config.load import int_load_spec
@@ -26,15 +32,29 @@ _check_actions = {
     "check",
     help="Check a spec against existing logs (searches log directory recursively)",
 )
+@json_option
 @check_options
 def check_command(
     config_file: str,
+    output_json: bool,
     **kwargs: Unpack[ConfigOptionArgs],
 ) -> None:
     init_output(**kwargs)
     config_file = absolute_file_path(config_file)
+    kwargs["log_dir_create_unique"] = False
+    base_dir = str(Path(config_file).parent)
+    if output_json:
+        with quiet_output():
+            spec = int_load_spec(config_file, options=parse_config_options(**kwargs))
+            result = launch_check(spec, base_dir=base_dir)
+        assert spec.log_dir
+        emit_json(
+            find_logs_result_to_json(result, spec.log_dir)
+            if result is not None
+            else None
+        )
+        return
     with create_display(mode="check", actions=_check_actions) as display:
         display.set_title("Flow Spec:", path(config_file))
-        kwargs["log_dir_create_unique"] = False
         spec = int_load_spec(config_file, options=parse_config_options(**kwargs))
-        launch_check(spec, base_dir=str(Path(config_file).parent))
+        launch_check(spec, base_dir=base_dir)

--- a/src/inspect_flow/_cli/check.py
+++ b/src/inspect_flow/_cli/check.py
@@ -5,7 +5,7 @@ import click
 from inspect_ai._util.file import absolute_file_path
 from typing_extensions import Unpack
 
-from inspect_flow._cli.json_output import emit_json, quiet_output
+from inspect_flow._cli.json_output import emit_json, output_context
 from inspect_flow._cli.options import (
     ConfigOptionArgs,
     check_options,
@@ -14,10 +14,9 @@ from inspect_flow._cli.options import (
     parse_config_options,
 )
 from inspect_flow._config.load import int_load_spec
-from inspect_flow._display.display import DisplayAction, create_display
+from inspect_flow._display.display import DisplayAction
 from inspect_flow._launcher.launch import launch_check
 from inspect_flow._runner.cli import CHECK_ACTIONS
-from inspect_flow._util.console import path
 from inspect_flow._util.constants import EXIT_INCOMPLETE
 
 _check_actions = {
@@ -41,18 +40,13 @@ def check_command(
     config_file = absolute_file_path(config_file)
     kwargs["log_dir_create_unique"] = False
     base_dir = str(Path(config_file).parent)
+    with output_context(
+        output_json, mode="check", actions=_check_actions, config_file=config_file
+    ):
+        spec = int_load_spec(config_file, options=parse_config_options(**kwargs))
+        result = launch_check(spec, base_dir=base_dir, output_json=output_json)
     if output_json:
-        with quiet_output():
-            spec = int_load_spec(config_file, options=parse_config_options(**kwargs))
-            result = launch_check(spec, base_dir=base_dir, output_json=True)
         assert result.json_result is not None
         emit_json(result.json_result)
-        if not result.is_complete:
-            sys.exit(EXIT_INCOMPLETE)
-        return
-    with create_display(mode="check", actions=_check_actions) as display:
-        display.set_title("Flow Spec:", path(config_file))
-        spec = int_load_spec(config_file, options=parse_config_options(**kwargs))
-        result = launch_check(spec, base_dir=base_dir)
     if not result.is_complete:
         sys.exit(EXIT_INCOMPLETE)

--- a/src/inspect_flow/_cli/config.py
+++ b/src/inspect_flow/_cli/config.py
@@ -2,25 +2,35 @@ import click
 from inspect_ai._util.file import absolute_file_path
 from typing_extensions import Unpack
 
+from inspect_flow._cli.json_output import emit_json, quiet_output
 from inspect_flow._cli.options import (
     ConfigOptionArgs,
     config_options,
     init_output,
+    json_option,
     parse_config_options,
 )
 from inspect_flow._config.load import int_load_spec
 from inspect_flow._config.write import print_config_yaml
+from inspect_flow._util.pydantic_util import model_dump
 
 
 @click.command("config", help="Output config")
+@json_option
 @config_options
 def config_command(
     config_file: str,
+    output_json: bool,
     **kwargs: Unpack[ConfigOptionArgs],
 ) -> None:
     """CLI command to output config."""
     init_output(**kwargs)
     config_options = parse_config_options(**kwargs)
     config_file = absolute_file_path(config_file)
+    if output_json:
+        with quiet_output():
+            fconfig = int_load_spec(config_file, options=config_options)
+        emit_json(model_dump(fconfig))
+        return
     fconfig = int_load_spec(config_file, options=config_options)
     print_config_yaml(fconfig, resolved=False)

--- a/src/inspect_flow/_cli/config.py
+++ b/src/inspect_flow/_cli/config.py
@@ -2,7 +2,7 @@ import click
 from inspect_ai._util.file import absolute_file_path
 from typing_extensions import Unpack
 
-from inspect_flow._cli.json_output import emit_json, quiet_output
+from inspect_flow._cli.json_output import emit_json, output_context
 from inspect_flow._cli.options import (
     ConfigOptionArgs,
     config_options,
@@ -27,10 +27,9 @@ def config_command(
     init_output(**kwargs)
     config_options = parse_config_options(**kwargs)
     config_file = absolute_file_path(config_file)
+    with output_context(output_json):
+        fconfig = int_load_spec(config_file, options=config_options)
     if output_json:
-        with quiet_output():
-            fconfig = int_load_spec(config_file, options=config_options)
         emit_json(model_dump(fconfig))
-        return
-    fconfig = int_load_spec(config_file, options=config_options)
-    print_config_yaml(fconfig, resolved=False)
+    else:
+        print_config_yaml(fconfig, resolved=False)

--- a/src/inspect_flow/_cli/json_output.py
+++ b/src/inspect_flow/_cli/json_output.py
@@ -20,7 +20,6 @@ from inspect_flow._util.console import console
 
 @contextmanager
 def quiet_output() -> Iterator[None]:
-    """Suppress Rich/display output so only JSON is written to stdout."""
     prev_display_type = get_display_type()
     prev_display = get_display()
     prev_quiet = console.quiet

--- a/src/inspect_flow/_cli/json_output.py
+++ b/src/inspect_flow/_cli/json_output.py
@@ -8,6 +8,7 @@ import click
 from inspect_flow._display.display import get_display_type, set_display_type
 from inspect_flow._runner.logs import FindLogsResult
 from inspect_flow._runner.task_log import TaskLogInfo
+from inspect_flow._types.flow_types import FlowSpec
 from inspect_flow._util.console import console
 
 
@@ -23,6 +24,16 @@ def quiet_output() -> Iterator[None]:
     finally:
         console.quiet = prev_quiet
         set_display_type(prev_display)
+
+
+def ensure_json_supported(spec: FlowSpec) -> None:
+    """Raise if --json output is requested for an unsupported execution type."""
+    if spec.execution_type == "venv":
+        raise click.UsageError(
+            "--json is not supported with venv execution because results are "
+            "produced in a subprocess. Use the default inproc execution type "
+            "(omit --venv), or drop --json."
+        )
 
 
 def emit_json(data: Any) -> None:

--- a/src/inspect_flow/_cli/json_output.py
+++ b/src/inspect_flow/_cli/json_output.py
@@ -1,6 +1,7 @@
 import json
+import sys
 from collections.abc import Iterator
-from contextlib import contextmanager
+from contextlib import contextmanager, redirect_stdout
 from typing import Any
 
 import click
@@ -26,7 +27,8 @@ def quiet_output() -> Iterator[None]:
     set_display_type("plain")
     console.quiet = True
     try:
-        yield
+        with redirect_stdout(sys.stderr):
+            yield
     finally:
         console.quiet = prev_quiet
         set_display_type(prev_display_type)

--- a/src/inspect_flow/_cli/json_output.py
+++ b/src/inspect_flow/_cli/json_output.py
@@ -12,9 +12,6 @@ from inspect_flow._display.display import (
     set_display,
     set_display_type,
 )
-from inspect_flow._runner.logs import FindLogsResult
-from inspect_flow._runner.task_log import TaskLogInfo
-from inspect_flow._types.flow_types import FlowSpec
 from inspect_flow._util.console import console
 
 
@@ -34,42 +31,5 @@ def quiet_output() -> Iterator[None]:
         set_display(prev_display)
 
 
-def ensure_json_supported(spec: FlowSpec) -> None:
-    """Raise if --json output is requested for an unsupported execution type."""
-    if spec.execution_type == "venv":
-        raise click.UsageError(
-            "--json is not supported with venv execution because results are "
-            "produced in a subprocess. Use the default inproc execution type "
-            "(omit --venv), or drop --json."
-        )
-
-
 def emit_json(data: Any) -> None:
     click.echo(json.dumps(data, indent=2, default=str))
-
-
-def _task_to_json(info: TaskLogInfo) -> dict[str, Any]:
-    complete = info.task_samples is not None and info.log_samples >= info.task_samples
-    return {
-        "name": info.task.name,
-        "log_file": info.eval_log.location if info.eval_log else None,
-        "samples": info.log_samples,
-        "total_samples": info.task_samples,
-        "complete": complete,
-        "duplicate_logs": list(info.duplicate_logs),
-    }
-
-
-def find_logs_result_to_json(result: FindLogsResult, log_dir: str) -> dict[str, Any]:
-    tasks = [_task_to_json(info) for info in result.task_log_info.values()]
-    complete = sum(1 for task in tasks if task["complete"])
-    return {
-        "log_dir": log_dir,
-        "tasks": tasks,
-        "unrecognized": list(result.unexpected_logs),
-        "summary": {
-            "total": len(tasks),
-            "complete": complete,
-            "incomplete": len(tasks) - complete,
-        },
-    }

--- a/src/inspect_flow/_cli/json_output.py
+++ b/src/inspect_flow/_cli/json_output.py
@@ -7,12 +7,15 @@ from typing import Any
 import click
 
 from inspect_flow._display.display import (
+    DisplayAction,
+    DisplayMode,
+    create_display,
     get_display,
     get_display_type,
     set_display,
     set_display_type,
 )
-from inspect_flow._util.console import console
+from inspect_flow._util.console import console, path
 
 
 @contextmanager
@@ -29,6 +32,37 @@ def quiet_output() -> Iterator[None]:
         console.quiet = prev_quiet
         set_display_type(prev_display_type)
         set_display(prev_display)
+
+
+@contextmanager
+def output_context(
+    output_json: bool,
+    *,
+    mode: DisplayMode | None = None,
+    actions: dict[str, DisplayAction] | None = None,
+    config_file: str | None = None,
+) -> Iterator[None]:
+    """Select the output context for a command based on ``--json``.
+
+    Suppresses display for JSON output; otherwise shows the interactive display
+    for ``mode`` (when given) or leaves output untouched.
+
+    Args:
+        output_json: Whether the command is emitting JSON.
+        mode: Display mode for the interactive (non-JSON) display.
+        actions: Display actions for the interactive display.
+        config_file: Spec path shown in the interactive display title.
+    """
+    if output_json:
+        with quiet_output():
+            yield
+    elif mode is not None:
+        with create_display(mode=mode, actions=actions or {}) as display:
+            if config_file is not None:
+                display.set_title("Flow Spec:", path(config_file))
+            yield
+    else:
+        yield
 
 
 def emit_json(data: Any) -> None:

--- a/src/inspect_flow/_cli/json_output.py
+++ b/src/inspect_flow/_cli/json_output.py
@@ -5,7 +5,12 @@ from typing import Any
 
 import click
 
-from inspect_flow._display.display import get_display_type, set_display_type
+from inspect_flow._display.display import (
+    get_display,
+    get_display_type,
+    set_display,
+    set_display_type,
+)
 from inspect_flow._runner.logs import FindLogsResult
 from inspect_flow._runner.task_log import TaskLogInfo
 from inspect_flow._types.flow_types import FlowSpec
@@ -15,7 +20,8 @@ from inspect_flow._util.console import console
 @contextmanager
 def quiet_output() -> Iterator[None]:
     """Suppress Rich/display output so only JSON is written to stdout."""
-    prev_display = get_display_type()
+    prev_display_type = get_display_type()
+    prev_display = get_display()
     prev_quiet = console.quiet
     set_display_type("plain")
     console.quiet = True
@@ -23,7 +29,8 @@ def quiet_output() -> Iterator[None]:
         yield
     finally:
         console.quiet = prev_quiet
-        set_display_type(prev_display)
+        set_display_type(prev_display_type)
+        set_display(prev_display)
 
 
 def ensure_json_supported(spec: FlowSpec) -> None:

--- a/src/inspect_flow/_cli/json_output.py
+++ b/src/inspect_flow/_cli/json_output.py
@@ -1,0 +1,56 @@
+import json
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Any
+
+import click
+
+from inspect_flow._display.display import get_display_type, set_display_type
+from inspect_flow._runner.logs import FindLogsResult
+from inspect_flow._runner.task_log import TaskLogInfo
+from inspect_flow._util.console import console
+
+
+@contextmanager
+def quiet_output() -> Iterator[None]:
+    """Suppress Rich/display output so only JSON is written to stdout."""
+    prev_display = get_display_type()
+    prev_quiet = console.quiet
+    set_display_type("plain")
+    console.quiet = True
+    try:
+        yield
+    finally:
+        console.quiet = prev_quiet
+        set_display_type(prev_display)
+
+
+def emit_json(data: Any) -> None:
+    click.echo(json.dumps(data, indent=2, default=str))
+
+
+def _task_to_json(info: TaskLogInfo) -> dict[str, Any]:
+    complete = info.task_samples is not None and info.log_samples >= info.task_samples
+    return {
+        "name": info.task.name,
+        "log_file": info.eval_log.location if info.eval_log else None,
+        "samples": info.log_samples,
+        "total_samples": info.task_samples,
+        "complete": complete,
+        "duplicate_logs": list(info.duplicate_logs),
+    }
+
+
+def find_logs_result_to_json(result: FindLogsResult, log_dir: str) -> dict[str, Any]:
+    tasks = [_task_to_json(info) for info in result.task_log_info.values()]
+    complete = sum(1 for task in tasks if task["complete"])
+    return {
+        "log_dir": log_dir,
+        "tasks": tasks,
+        "unrecognized": list(result.unexpected_logs),
+        "summary": {
+            "total": len(tasks),
+            "complete": complete,
+            "incomplete": len(tasks) - complete,
+        },
+    }

--- a/src/inspect_flow/_cli/list.py
+++ b/src/inspect_flow/_cli/list.py
@@ -628,6 +628,10 @@ def _process_groups(
     return entries
 
 
+def _truncate(entries: list[LogEntry], max_count: int | None) -> list[LogEntry]:
+    return entries if max_count is None else entries[:max_count]
+
+
 def _lines_per_entry(oneline: bool) -> int:
     return 1 if oneline else 6
 
@@ -649,9 +653,9 @@ def _echo_logs(
     if options.page and stdout_is_terminal() and total_entries * lpe > page_size:
         _paged_output(dir_groups, page_size, options, progress=progress)
     else:
-        entries = _process_groups(dir_groups, options, progress=progress)
-        if options.max_count is not None:
-            entries = entries[: options.max_count]
+        entries = _truncate(
+            _process_groups(dir_groups, options, progress=progress), options.max_count
+        )
         if progress:
             progress.stop()
         if not entries:
@@ -766,9 +770,7 @@ def _compute_renderable(
             return Text("No logs found")
         return _build_tree(dir_entries, console.size.width, max_lines=page_lines)
 
-    entries = _process_groups(dir_groups, options)
-    if options.max_count is not None:
-        entries = entries[: options.max_count]
+    entries = _truncate(_process_groups(dir_groups, options), options.max_count)
     if not entries:
         return Text("No logs found")
     return _entries_renderable(
@@ -999,9 +1001,10 @@ def list_log(
                 path_str(p)
                 for p in list_logs(log_dir=path, store=store, since=since, until=until)
             ]
-            entries = _process_groups(group_logs_by_dir(log_paths), options)
-            if options.max_count is not None:
-                entries = entries[: options.max_count]
+            entries = _truncate(
+                _process_groups(group_logs_by_dir(log_paths), options),
+                options.max_count,
+            )
         emit_json({"logs": [_log_entry_to_json(e) for e in entries]})
         return
     if live_interval is not None:

--- a/src/inspect_flow/_cli/list.py
+++ b/src/inspect_flow/_cli/list.py
@@ -851,7 +851,7 @@ class _MaxCountCommand(click.Command):
 @list_command.command(
     "log",
     cls=_MaxCountCommand,
-    help="List logs, sorted by timestamp extracted from log file name. If PATH is not provided, falls back to the default store (--store auto).",
+    help="List logs, sorted by timestamp extracted from log file name. If PATH is not provided, falls back to the default store (--store auto). With --json, display-only options (--format, --oneline, --provenance, --live, --no-page) are ignored.",
 )
 @json_option
 @store_options

--- a/src/inspect_flow/_cli/list.py
+++ b/src/inspect_flow/_cli/list.py
@@ -850,7 +850,7 @@ class _MaxCountCommand(click.Command):
 @list_command.command(
     "log",
     cls=_MaxCountCommand,
-    help="List logs, sorted by timestamp extracted from log file name. If PATH is not provided, falls back to the default store (--store auto).",
+    help="List logs, sorted by timestamp extracted from log file name. If PATH is not provided, falls back to the default store (--store auto). With --json, display-only options (--format, --oneline, --provenance, --live, --no-page) are ignored.",
 )
 @json_option
 @store_options

--- a/src/inspect_flow/_cli/list.py
+++ b/src/inspect_flow/_cli/list.py
@@ -188,20 +188,17 @@ def _date_str(header_result: _HeaderResult) -> str:
     return dt.strftime("%Y-%m-%d %H:%M:%S %z")
 
 
-def _samples_str(header_result: _HeaderResult) -> str:
-    valid_samples = header_result.num_valid_samples
-    header = header_result.header
-    if header.results:
-        return f"{valid_samples}/{header.results.total_samples}"
-    total = (header.eval.dataset.samples or 0) * (header.eval.config.epochs or 1)
-    return f"{valid_samples}/{total}" if total else ""
-
-
 def _total_samples(header: EvalLog) -> int | None:
     if header.results:
         return header.results.total_samples
     total = (header.eval.dataset.samples or 0) * (header.eval.config.epochs or 1)
     return total or None
+
+
+def _samples_str(header_result: _HeaderResult) -> str:
+    valid_samples = header_result.num_valid_samples
+    total = _total_samples(header_result.header)
+    return f"{valid_samples}/{total}" if total else ""
 
 
 @dataclass

--- a/src/inspect_flow/_cli/list.py
+++ b/src/inspect_flow/_cli/list.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from functools import partial
 from logging import getLogger
+from typing import Any
 
 import click
 import yaml
@@ -27,6 +28,8 @@ from rich.tree import Tree
 from typing_extensions import Unpack
 
 from inspect_flow._api.list_logs import list_logs
+from inspect_flow._cli.json_output import emit_json, quiet_output
+from inspect_flow._cli.options import json_option
 from inspect_flow._cli.store import (
     StoreOptionArgs,
     _resolve_cli_filter,
@@ -192,6 +195,13 @@ def _samples_str(header_result: _HeaderResult) -> str:
         return f"{valid_samples}/{header.results.total_samples}"
     total = (header.eval.dataset.samples or 0) * (header.eval.config.epochs or 1)
     return f"{valid_samples}/{total}" if total else ""
+
+
+def _total_samples(header: EvalLog) -> int | None:
+    if header.results:
+        return header.results.total_samples
+    total = (header.eval.dataset.samples or 0) * (header.eval.config.epochs or 1)
+    return total or None
 
 
 @dataclass
@@ -803,6 +813,22 @@ def _chain(base: LogFilter | None, new: LogFilter) -> LogFilter:
     return combined
 
 
+def _log_entry_to_json(entry: LogEntry) -> dict[str, Any]:
+    header = entry.header
+    return {
+        "task": entry.task,
+        "log_file": entry.log_path,
+        "status": header.status,
+        "model": header.eval.model,
+        "samples": entry.header_result.num_valid_samples,
+        "total_samples": _total_samples(header),
+        "started_at": header.stats.started_at,
+        "completed_at": header.stats.completed_at,
+        "tags": list(header.tags) if header.tags else [],
+        "viewer_url": entry.viewer_url,
+    }
+
+
 @click.group("list")
 def list_command() -> None:
     """CLI command to list flow entities."""
@@ -827,6 +853,7 @@ class _MaxCountCommand(click.Command):
     cls=_MaxCountCommand,
     help="List logs, sorted by timestamp extracted from log file name. If PATH is not provided, falls back to the default store (--store auto).",
 )
+@json_option
 @store_options
 @filter_options
 @click.option(
@@ -919,6 +946,7 @@ class _MaxCountCommand(click.Command):
 @click.argument("path", required=False, default=None)
 def list_log(
     path: str | None,
+    output_json: bool,
     output_format: str,
     oneline: bool,
     provenance: bool,
@@ -968,6 +996,17 @@ def list_log(
         provenance=provenance,
     )
     store = kwargs.get("store") or "auto"
+    if output_json:
+        with quiet_output():
+            log_paths = [
+                path_str(p)
+                for p in list_logs(log_dir=path, store=store, since=since, until=until)
+            ]
+            entries = _process_groups(group_logs_by_dir(log_paths), options)
+            if options.max_count is not None:
+                entries = entries[: options.max_count]
+        emit_json({"logs": [_log_entry_to_json(e) for e in entries]})
+        return
     if live_interval is not None:
         _live_output(path, store, since, until, options, live_interval)
         return

--- a/src/inspect_flow/_cli/list.py
+++ b/src/inspect_flow/_cli/list.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from functools import partial
 from logging import getLogger
+from typing import Any
 
 import click
 import yaml
@@ -27,6 +28,8 @@ from rich.tree import Tree
 from typing_extensions import Unpack
 
 from inspect_flow._api.list_logs import list_logs
+from inspect_flow._cli.json_output import emit_json, quiet_output
+from inspect_flow._cli.options import json_option
 from inspect_flow._cli.store import (
     StoreOptionArgs,
     _resolve_cli_filter,
@@ -191,6 +194,13 @@ def _samples_str(header_result: _HeaderResult) -> str:
         return f"{valid_samples}/{header.results.total_samples}"
     total = (header.eval.dataset.samples or 0) * (header.eval.config.epochs or 1)
     return f"{valid_samples}/{total}" if total else ""
+
+
+def _total_samples(header: EvalLog) -> int | None:
+    if header.results:
+        return header.results.total_samples
+    total = (header.eval.dataset.samples or 0) * (header.eval.config.epochs or 1)
+    return total or None
 
 
 @dataclass
@@ -802,6 +812,22 @@ def _chain(base: LogFilter | None, new: LogFilter) -> LogFilter:
     return combined
 
 
+def _log_entry_to_json(entry: LogEntry) -> dict[str, Any]:
+    header = entry.header
+    return {
+        "task": entry.task,
+        "log_file": entry.log_path,
+        "status": header.status,
+        "model": header.eval.model,
+        "samples": entry.header_result.num_valid_samples,
+        "total_samples": _total_samples(header),
+        "started_at": header.stats.started_at,
+        "completed_at": header.stats.completed_at,
+        "tags": list(header.tags) if header.tags else [],
+        "viewer_url": entry.viewer_url,
+    }
+
+
 @click.group("list")
 def list_command() -> None:
     """CLI command to list flow entities."""
@@ -826,6 +852,7 @@ class _MaxCountCommand(click.Command):
     cls=_MaxCountCommand,
     help="List logs, sorted by timestamp extracted from log file name. If PATH is not provided, falls back to the default store (--store auto).",
 )
+@json_option
 @store_options
 @filter_options
 @click.option(
@@ -918,6 +945,7 @@ class _MaxCountCommand(click.Command):
 @click.argument("path", required=False, default=None)
 def list_log(
     path: str | None,
+    output_json: bool,
     output_format: str,
     oneline: bool,
     provenance: bool,
@@ -967,6 +995,17 @@ def list_log(
         provenance=provenance,
     )
     store = kwargs.get("store") or "auto"
+    if output_json:
+        with quiet_output():
+            log_paths = [
+                path_str(p)
+                for p in list_logs(log_dir=path, store=store, since=since, until=until)
+            ]
+            entries = _process_groups(group_logs_by_dir(log_paths), options)
+            if options.max_count is not None:
+                entries = entries[: options.max_count]
+        emit_json({"logs": [_log_entry_to_json(e) for e in entries]})
+        return
     if live_interval is not None:
         _live_output(path, store, since, until, options, live_interval)
         return

--- a/src/inspect_flow/_cli/list.py
+++ b/src/inspect_flow/_cli/list.py
@@ -187,20 +187,17 @@ def _date_str(header_result: _HeaderResult) -> str:
     return dt.strftime("%Y-%m-%d %H:%M:%S %z")
 
 
-def _samples_str(header_result: _HeaderResult) -> str:
-    valid_samples = header_result.num_valid_samples
-    header = header_result.header
-    if header.results:
-        return f"{valid_samples}/{header.results.total_samples}"
-    total = (header.eval.dataset.samples or 0) * (header.eval.config.epochs or 1)
-    return f"{valid_samples}/{total}" if total else ""
-
-
 def _total_samples(header: EvalLog) -> int | None:
     if header.results:
         return header.results.total_samples
     total = (header.eval.dataset.samples or 0) * (header.eval.config.epochs or 1)
     return total or None
+
+
+def _samples_str(header_result: _HeaderResult) -> str:
+    valid_samples = header_result.num_valid_samples
+    total = _total_samples(header_result.header)
+    return f"{valid_samples}/{total}" if total is not None else ""
 
 
 @dataclass

--- a/src/inspect_flow/_cli/options.py
+++ b/src/inspect_flow/_cli/options.py
@@ -63,6 +63,17 @@ def output_options(f: F) -> F:
     return f
 
 
+def json_option(f: F) -> F:
+    """Decorator that adds a ``--json`` flag for machine-readable output."""
+    return click.option(
+        "--json",
+        "output_json",
+        is_flag=True,
+        default=False,
+        help="Output results as JSON.",
+    )(f)
+
+
 def base_config_options(f: F) -> F:
     """Shared options for commands that load a flow config."""
     f = output_options(f)

--- a/src/inspect_flow/_cli/run.py
+++ b/src/inspect_flow/_cli/run.py
@@ -5,7 +5,7 @@ import click
 from inspect_ai._util.file import absolute_file_path
 from typing_extensions import Unpack
 
-from inspect_flow._cli.json_output import emit_json, quiet_output
+from inspect_flow._cli.json_output import emit_json, output_context
 from inspect_flow._cli.options import (
     ConfigOptionArgs,
     config_options,
@@ -14,10 +14,9 @@ from inspect_flow._cli.options import (
     parse_config_options,
 )
 from inspect_flow._config.load import int_load_spec
-from inspect_flow._display.display import DisplayAction, DisplayMode, create_display
+from inspect_flow._display.display import DisplayAction, DisplayMode
 from inspect_flow._launcher.launch import launch, launch_dry_run
 from inspect_flow._runner.cli import RUN_ACTIONS
-from inspect_flow._util.console import path
 from inspect_flow._util.constants import EXIT_INCOMPLETE
 
 _run_actions = {
@@ -54,23 +53,21 @@ def run_command(
     config_options = parse_config_options(**kwargs)
     config_file = absolute_file_path(config_file)
     base_dir = str(Path(config_file).parent)
-    if output_json:
-        if not dry_run:
-            raise click.UsageError("--json is only supported with --dry-run.")
-        with quiet_output():
-            spec = int_load_spec(config_file, options=config_options)
-            result = launch_dry_run(spec, base_dir=base_dir)
-        assert result is not None
-        emit_json(result)
-        return
+    if output_json and not dry_run:
+        raise click.UsageError("--json is only supported with --dry-run.")
     mode: DisplayMode = "dry_run" if dry_run else "run"
-    with create_display(mode=mode, actions=_run_actions) as display:
-        display.set_title("Flow Spec:", path(config_file))
+    with output_context(
+        output_json, mode=mode, actions=_run_actions, config_file=config_file
+    ):
         spec = int_load_spec(config_file, options=config_options)
-        result = launch(
-            spec,
-            base_dir=base_dir,
-            dry_run=dry_run,
+        json_result = launch_dry_run(spec, base_dir=base_dir) if output_json else None
+        result = (
+            None if output_json else launch(spec, base_dir=base_dir, dry_run=dry_run)
         )
+    if output_json:
+        assert json_result is not None
+        emit_json(json_result)
+        return
+    assert result is not None
     if not dry_run and not result.success:
         sys.exit(EXIT_INCOMPLETE)

--- a/src/inspect_flow/_cli/run.py
+++ b/src/inspect_flow/_cli/run.py
@@ -5,12 +5,7 @@ import click
 from inspect_ai._util.file import absolute_file_path
 from typing_extensions import Unpack
 
-from inspect_flow._cli.json_output import (
-    emit_json,
-    ensure_json_supported,
-    find_logs_result_to_json,
-    quiet_output,
-)
+from inspect_flow._cli.json_output import emit_json, quiet_output
 from inspect_flow._cli.options import (
     ConfigOptionArgs,
     config_options,
@@ -64,11 +59,9 @@ def run_command(
             raise click.UsageError("--json is only supported with --dry-run.")
         with quiet_output():
             spec = int_load_spec(config_file, options=config_options)
-            ensure_json_supported(spec)
             result = launch_dry_run(spec, base_dir=base_dir)
-        assert spec.log_dir
         assert result is not None
-        emit_json(find_logs_result_to_json(result, spec.log_dir))
+        emit_json(result)
         return
     mode: DisplayMode = "dry_run" if dry_run else "run"
     with create_display(mode=mode, actions=_run_actions) as display:

--- a/src/inspect_flow/_cli/run.py
+++ b/src/inspect_flow/_cli/run.py
@@ -6,6 +6,7 @@ from typing_extensions import Unpack
 
 from inspect_flow._cli.json_output import (
     emit_json,
+    ensure_json_supported,
     find_logs_result_to_json,
     quiet_output,
 )
@@ -61,13 +62,11 @@ def run_command(
             raise click.UsageError("--json is only supported with --dry-run.")
         with quiet_output():
             spec = int_load_spec(config_file, options=config_options)
+            ensure_json_supported(spec)
             result = launch_dry_run(spec, base_dir=base_dir)
         assert spec.log_dir
-        emit_json(
-            find_logs_result_to_json(result, spec.log_dir)
-            if result is not None
-            else None
-        )
+        assert result is not None
+        emit_json(find_logs_result_to_json(result, spec.log_dir))
         return
     mode: DisplayMode = "dry_run" if dry_run else "run"
     with create_display(mode=mode, actions=_run_actions) as display:

--- a/src/inspect_flow/_cli/run.py
+++ b/src/inspect_flow/_cli/run.py
@@ -4,15 +4,21 @@ import click
 from inspect_ai._util.file import absolute_file_path
 from typing_extensions import Unpack
 
+from inspect_flow._cli.json_output import (
+    emit_json,
+    find_logs_result_to_json,
+    quiet_output,
+)
 from inspect_flow._cli.options import (
     ConfigOptionArgs,
     config_options,
     init_output,
+    json_option,
     parse_config_options,
 )
 from inspect_flow._config.load import int_load_spec
 from inspect_flow._display.display import DisplayAction, DisplayMode, create_display
-from inspect_flow._launcher.launch import launch
+from inspect_flow._launcher.launch import launch, launch_dry_run
 from inspect_flow._runner.cli import RUN_ACTIONS
 from inspect_flow._util.console import path
 
@@ -23,6 +29,7 @@ _run_actions = {
 
 
 @click.command("run", help="Run a spec")
+@json_option
 @click.option(
     "--dry-run",
     type=bool,
@@ -40,6 +47,7 @@ _run_actions = {
 @config_options
 def run_command(
     config_file: str,
+    output_json: bool,
     dry_run: bool,
     **kwargs: Unpack[ConfigOptionArgs],
 ) -> None:
@@ -47,12 +55,26 @@ def run_command(
     init_output(**kwargs)
     config_options = parse_config_options(**kwargs)
     config_file = absolute_file_path(config_file)
+    base_dir = str(Path(config_file).parent)
+    if output_json:
+        if not dry_run:
+            raise click.UsageError("--json is only supported with --dry-run.")
+        with quiet_output():
+            spec = int_load_spec(config_file, options=config_options)
+            result = launch_dry_run(spec, base_dir=base_dir)
+        assert spec.log_dir
+        emit_json(
+            find_logs_result_to_json(result, spec.log_dir)
+            if result is not None
+            else None
+        )
+        return
     mode: DisplayMode = "dry_run" if dry_run else "run"
     with create_display(mode=mode, actions=_run_actions) as display:
         display.set_title("Flow Spec:", path(config_file))
         spec = int_load_spec(config_file, options=config_options)
         launch(
             spec,
-            base_dir=str(Path(config_file).parent),
+            base_dir=base_dir,
             dry_run=dry_run,
         )

--- a/src/inspect_flow/_cli/run.py
+++ b/src/inspect_flow/_cli/run.py
@@ -5,15 +5,21 @@ import click
 from inspect_ai._util.file import absolute_file_path
 from typing_extensions import Unpack
 
+from inspect_flow._cli.json_output import (
+    emit_json,
+    find_logs_result_to_json,
+    quiet_output,
+)
 from inspect_flow._cli.options import (
     ConfigOptionArgs,
     config_options,
     init_output,
+    json_option,
     parse_config_options,
 )
 from inspect_flow._config.load import int_load_spec
 from inspect_flow._display.display import DisplayAction, DisplayMode, create_display
-from inspect_flow._launcher.launch import launch
+from inspect_flow._launcher.launch import launch, launch_dry_run
 from inspect_flow._runner.cli import RUN_ACTIONS
 from inspect_flow._util.console import path
 from inspect_flow._util.constants import EXIT_INCOMPLETE
@@ -25,6 +31,7 @@ _run_actions = {
 
 
 @click.command("run", help="Run a spec")
+@json_option
 @click.option(
     "--dry-run",
     type=bool,
@@ -42,6 +49,7 @@ _run_actions = {
 @config_options
 def run_command(
     config_file: str,
+    output_json: bool,
     dry_run: bool,
     **kwargs: Unpack[ConfigOptionArgs],
 ) -> None:
@@ -49,13 +57,27 @@ def run_command(
     init_output(**kwargs)
     config_options = parse_config_options(**kwargs)
     config_file = absolute_file_path(config_file)
+    base_dir = str(Path(config_file).parent)
+    if output_json:
+        if not dry_run:
+            raise click.UsageError("--json is only supported with --dry-run.")
+        with quiet_output():
+            spec = int_load_spec(config_file, options=config_options)
+            result = launch_dry_run(spec, base_dir=base_dir)
+        assert spec.log_dir
+        emit_json(
+            find_logs_result_to_json(result, spec.log_dir)
+            if result is not None
+            else None
+        )
+        return
     mode: DisplayMode = "dry_run" if dry_run else "run"
     with create_display(mode=mode, actions=_run_actions) as display:
         display.set_title("Flow Spec:", path(config_file))
         spec = int_load_spec(config_file, options=config_options)
         result = launch(
             spec,
-            base_dir=str(Path(config_file).parent),
+            base_dir=base_dir,
             dry_run=dry_run,
         )
     if not dry_run and not result.success:

--- a/src/inspect_flow/_cli/run.py
+++ b/src/inspect_flow/_cli/run.py
@@ -7,6 +7,7 @@ from typing_extensions import Unpack
 
 from inspect_flow._cli.json_output import (
     emit_json,
+    ensure_json_supported,
     find_logs_result_to_json,
     quiet_output,
 )
@@ -63,13 +64,11 @@ def run_command(
             raise click.UsageError("--json is only supported with --dry-run.")
         with quiet_output():
             spec = int_load_spec(config_file, options=config_options)
+            ensure_json_supported(spec)
             result = launch_dry_run(spec, base_dir=base_dir)
         assert spec.log_dir
-        emit_json(
-            find_logs_result_to_json(result, spec.log_dir)
-            if result is not None
-            else None
-        )
+        assert result is not None
+        emit_json(find_logs_result_to_json(result, spec.log_dir))
         return
     mode: DisplayMode = "dry_run" if dry_run else "run"
     with create_display(mode=mode, actions=_run_actions) as display:

--- a/src/inspect_flow/_cli/store.py
+++ b/src/inspect_flow/_cli/store.py
@@ -3,6 +3,7 @@ from typing import Any, Literal, TypeVar
 
 import click
 from click import Context, HelpFormatter
+from inspect_ai._util.file import dirname
 from rich.text import Text
 from rich.tree import Tree
 from typing_extensions import Unpack
@@ -320,7 +321,7 @@ def store_info(output_json: bool, **kwargs: Unpack[StoreOptionArgs]) -> None:
             {
                 "path": flow_store.store_path,
                 "logs": len(logs),
-                "log_dirs": len({log.rsplit("/", 1)[0] for log in logs}),
+                "log_dirs": len({dirname(log) for log in logs}),
                 "version": flow_store.version,
             }
             if flow_store
@@ -331,7 +332,7 @@ def store_info(output_json: bool, **kwargs: Unpack[StoreOptionArgs]) -> None:
     if not flow_store:
         return
     logs = flow_store.get_logs()
-    log_dirs = {log.rsplit("/", 1)[0] for log in logs}
+    log_dirs = {dirname(log) for log in logs}
     flow_print("Path:    ", path(flow_store.store_path))
     flow_print("Logs:    ", quantity(len(logs), "log"))
     flow_print("Log dirs:", quantity(len(log_dirs), "log dir"))

--- a/src/inspect_flow/_cli/store.py
+++ b/src/inspect_flow/_cli/store.py
@@ -1,5 +1,4 @@
 from collections.abc import Callable
-from contextlib import nullcontext
 from typing import Any, Literal, TypeVar
 
 import click
@@ -9,7 +8,7 @@ from rich.text import Text
 from rich.tree import Tree
 from typing_extensions import Unpack
 
-from inspect_flow._cli.json_output import emit_json, quiet_output
+from inspect_flow._cli.json_output import emit_json, output_context, quiet_output
 from inspect_flow._cli.options import (
     OutputOptionArgs,
     init_output,
@@ -314,7 +313,7 @@ def _echo_logs_tree(log_files: list[str]) -> None:
 @json_option
 @store_options
 def store_info(output_json: bool, **kwargs: Unpack[StoreOptionArgs]) -> None:
-    with quiet_output() if output_json else nullcontext():
+    with output_context(output_json):
         flow_store = init_store(quiet=True, **kwargs)
         logs = flow_store.get_logs() if flow_store else set()
     log_dirs = {dirname(log) for log in logs}

--- a/src/inspect_flow/_cli/store.py
+++ b/src/inspect_flow/_cli/store.py
@@ -7,9 +7,11 @@ from rich.text import Text
 from rich.tree import Tree
 from typing_extensions import Unpack
 
+from inspect_flow._cli.json_output import emit_json, quiet_output
 from inspect_flow._cli.options import (
     OutputOptionArgs,
     init_output,
+    json_option,
     output_options,
     store_option,
 )
@@ -307,8 +309,24 @@ def _echo_logs_tree(log_files: list[str]) -> None:
 
 
 @store_command.command("info", help="Print store information")
+@json_option
 @store_options
-def store_info(**kwargs: Unpack[StoreOptionArgs]) -> None:
+def store_info(output_json: bool, **kwargs: Unpack[StoreOptionArgs]) -> None:
+    if output_json:
+        with quiet_output():
+            flow_store = init_store(quiet=True, **kwargs)
+            logs = flow_store.get_logs() if flow_store else set()
+        emit_json(
+            {
+                "path": flow_store.store_path,
+                "logs": len(logs),
+                "log_dirs": len({log.rsplit("/", 1)[0] for log in logs}),
+                "version": flow_store.version,
+            }
+            if flow_store
+            else None
+        )
+        return
     flow_store = init_store(quiet=True, **kwargs)
     if not flow_store:
         return
@@ -349,6 +367,7 @@ def store_delete(yes: bool, **kwargs: Unpack[StoreOptionArgs]) -> None:
 
 
 @store_command.command("list", help="List logs and log directories in the store")
+@json_option
 @store_options
 @filter_options
 @click.option(
@@ -361,12 +380,19 @@ def store_delete(yes: bool, **kwargs: Unpack[StoreOptionArgs]) -> None:
 )
 def store_list(
     format: str,
+    output_json: bool,
     filter_name: tuple[str, ...],
     exclude_name: str | None,
     **kwargs: Unpack[StoreOptionArgs],
 ) -> None:
     assert format in ("flat", "tree")
     log_filter = _resolve_cli_filter(filter_name, exclude_name)
+    if output_json:
+        with quiet_output():
+            flow_store = init_store(quiet=True, **kwargs)
+            logs = flow_store.get_logs(filter=log_filter) if flow_store else None
+        emit_json({"logs": sorted(logs)} if logs is not None else None)
+        return
     quiet = kwargs.get("display") == "plain"
     flow_store = init_store(quiet=quiet, **kwargs)
     if flow_store:

--- a/src/inspect_flow/_cli/store.py
+++ b/src/inspect_flow/_cli/store.py
@@ -1,4 +1,5 @@
 from collections.abc import Callable
+from contextlib import nullcontext
 from typing import Any, Literal, TypeVar
 
 import click
@@ -313,26 +314,24 @@ def _echo_logs_tree(log_files: list[str]) -> None:
 @json_option
 @store_options
 def store_info(output_json: bool, **kwargs: Unpack[StoreOptionArgs]) -> None:
+    with quiet_output() if output_json else nullcontext():
+        flow_store = init_store(quiet=True, **kwargs)
+        logs = flow_store.get_logs() if flow_store else set()
+    log_dirs = {dirname(log) for log in logs}
     if output_json:
-        with quiet_output():
-            flow_store = init_store(quiet=True, **kwargs)
-            logs = flow_store.get_logs() if flow_store else set()
         emit_json(
             {
                 "path": flow_store.store_path,
                 "logs": len(logs),
-                "log_dirs": len({dirname(log) for log in logs}),
+                "log_dirs": len(log_dirs),
                 "version": flow_store.version,
             }
             if flow_store
             else None
         )
         return
-    flow_store = init_store(quiet=True, **kwargs)
     if not flow_store:
         return
-    logs = flow_store.get_logs()
-    log_dirs = {dirname(log) for log in logs}
     flow_print("Path:    ", path(flow_store.store_path))
     flow_print("Logs:    ", quantity(len(logs), "log"))
     flow_print("Log dirs:", quantity(len(log_dirs), "log dir"))

--- a/src/inspect_flow/_cli/store.py
+++ b/src/inspect_flow/_cli/store.py
@@ -360,7 +360,10 @@ def store_delete(yes: bool, **kwargs: Unpack[StoreOptionArgs]) -> None:
     flow_print("Deleted store at", path(store_path), format="success")
 
 
-@store_command.command("list", help="List logs and log directories in the store")
+@store_command.command(
+    "list",
+    help="List logs and log directories in the store. With --json, the display-only --format option is ignored.",
+)
 @json_option
 @store_options
 @filter_options

--- a/src/inspect_flow/_cli/store.py
+++ b/src/inspect_flow/_cli/store.py
@@ -7,9 +7,11 @@ from rich.text import Text
 from rich.tree import Tree
 from typing_extensions import Unpack
 
+from inspect_flow._cli.json_output import emit_json, quiet_output
 from inspect_flow._cli.options import (
     OutputOptionArgs,
     init_output,
+    json_option,
     output_options,
     store_option,
 )
@@ -306,8 +308,24 @@ def _echo_logs_tree(log_files: list[str]) -> None:
 
 
 @store_command.command("info", help="Print store information")
+@json_option
 @store_options
-def store_info(**kwargs: Unpack[StoreOptionArgs]) -> None:
+def store_info(output_json: bool, **kwargs: Unpack[StoreOptionArgs]) -> None:
+    if output_json:
+        with quiet_output():
+            flow_store = init_store(quiet=True, **kwargs)
+            logs = flow_store.get_logs() if flow_store else set()
+        emit_json(
+            {
+                "path": flow_store.store_path,
+                "logs": len(logs),
+                "log_dirs": len({log.rsplit("/", 1)[0] for log in logs}),
+                "version": flow_store.version,
+            }
+            if flow_store
+            else None
+        )
+        return
     flow_store = init_store(quiet=True, **kwargs)
     if not flow_store:
         return
@@ -343,6 +361,7 @@ def store_delete(yes: bool, **kwargs: Unpack[StoreOptionArgs]) -> None:
 
 
 @store_command.command("list", help="List logs and log directories in the store")
+@json_option
 @store_options
 @filter_options
 @click.option(
@@ -355,12 +374,19 @@ def store_delete(yes: bool, **kwargs: Unpack[StoreOptionArgs]) -> None:
 )
 def store_list(
     format: str,
+    output_json: bool,
     filter_name: tuple[str, ...],
     exclude_name: str | None,
     **kwargs: Unpack[StoreOptionArgs],
 ) -> None:
     assert format in ("flat", "tree")
     log_filter = _resolve_cli_filter(filter_name, exclude_name)
+    if output_json:
+        with quiet_output():
+            flow_store = init_store(quiet=True, **kwargs)
+            logs = flow_store.get_logs(filter=log_filter) if flow_store else None
+        emit_json({"logs": sorted(logs)} if logs is not None else None)
+        return
     quiet = kwargs.get("display") == "plain"
     flow_store = init_store(quiet=quiet, **kwargs)
     if flow_store:

--- a/src/inspect_flow/_display/display.py
+++ b/src/inspect_flow/_display/display.py
@@ -57,6 +57,10 @@ def display() -> Display:
     return _display
 
 
+def get_display() -> Display | None:
+    return _display
+
+
 def set_display(d: Display | None) -> None:
     global _display
     _display = d

--- a/src/inspect_flow/_launcher/inproc.py
+++ b/src/inspect_flow/_launcher/inproc.py
@@ -7,7 +7,7 @@ from inspect_flow._display.run_action import RunAction
 from inspect_flow._launcher.freeze import write_flow_requirements
 from inspect_flow._runner.check import check_eval_set
 from inspect_flow._runner.logs import FindLogsResult
-from inspect_flow._runner.run import run_eval_set
+from inspect_flow._runner.run import dry_run_eval_set, run_eval_set
 from inspect_flow._types.flow_types import FlowSpec
 
 logger = getLogger(__name__)
@@ -29,3 +29,10 @@ def inproc_check(spec: FlowSpec, base_dir: str) -> FindLogsResult:
         if spec.env:
             os.environ.update(spec.env)
     return check_eval_set(spec, base_dir=base_dir)
+
+
+def inproc_dry_run(spec: FlowSpec, base_dir: str) -> FindLogsResult:
+    with RunAction("env", info="inproc"):
+        if spec.env:
+            os.environ.update(spec.env)
+    return dry_run_eval_set(spec, base_dir=base_dir)

--- a/src/inspect_flow/_launcher/inproc.py
+++ b/src/inspect_flow/_launcher/inproc.py
@@ -5,7 +5,7 @@ from inspect_flow._display.run_action import RunAction
 from inspect_flow._launcher.freeze import write_flow_requirements
 from inspect_flow._runner.check import check_eval_set
 from inspect_flow._runner.logs import FindLogsResult
-from inspect_flow._runner.run import LaunchResult, run_eval_set
+from inspect_flow._runner.run import LaunchResult, dry_run_eval_set, run_eval_set
 from inspect_flow._types.flow_types import FlowSpec
 
 logger = getLogger(__name__)
@@ -25,3 +25,10 @@ def inproc_check(spec: FlowSpec, base_dir: str) -> FindLogsResult:
         if spec.env:
             os.environ.update(spec.env)
     return check_eval_set(spec, base_dir=base_dir)
+
+
+def inproc_dry_run(spec: FlowSpec, base_dir: str) -> FindLogsResult:
+    with RunAction("env", info="inproc"):
+        if spec.env:
+            os.environ.update(spec.env)
+    return dry_run_eval_set(spec, base_dir=base_dir)

--- a/src/inspect_flow/_launcher/launch.py
+++ b/src/inspect_flow/_launcher/launch.py
@@ -1,7 +1,11 @@
 from logging import getLogger
 from typing import NamedTuple
 
-from inspect_flow._launcher.inproc import inproc_check, inproc_launch
+from inspect_flow._launcher.inproc import (
+    inproc_check,
+    inproc_dry_run,
+    inproc_launch,
+)
 from inspect_flow._launcher.venv import venv_check, venv_launch
 from inspect_flow._runner.logs import FindLogsResult
 from inspect_flow._runner.run import LaunchResult
@@ -17,7 +21,7 @@ class CheckLaunchResult(NamedTuple):
     find_result: FindLogsResult | None
 
 
-def launch(spec: FlowSpec, base_dir: str, dry_run: bool = False) -> LaunchResult:
+def _prepare_launch_spec(spec: FlowSpec, base_dir: str) -> None:
     if not spec.log_dir:
         raise ValueError("log_dir must be set before launching the flow spec")
     spec.log_dir = absolute_path_relative_to(spec.log_dir, base_dir=base_dir)
@@ -35,10 +39,20 @@ def launch(spec: FlowSpec, base_dir: str, dry_run: bool = False) -> LaunchResult
                 for k, v in spec.options.bundle_url_mappings.items()
             }
 
+
+def launch(spec: FlowSpec, base_dir: str, dry_run: bool = False) -> LaunchResult:
+    _prepare_launch_spec(spec, base_dir=base_dir)
     if spec.execution_type == "venv":
         return venv_launch(spec=spec, base_dir=base_dir, dry_run=dry_run)
     else:
         return inproc_launch(spec=spec, base_dir=base_dir, dry_run=dry_run)
+
+
+def launch_dry_run(spec: FlowSpec, base_dir: str) -> FindLogsResult | None:
+    _prepare_launch_spec(spec, base_dir=base_dir)
+    if spec.execution_type == "venv":
+        return None
+    return inproc_dry_run(spec=spec, base_dir=base_dir)
 
 
 def launch_check(spec: FlowSpec, base_dir: str) -> CheckLaunchResult:

--- a/src/inspect_flow/_launcher/launch.py
+++ b/src/inspect_flow/_launcher/launch.py
@@ -1,13 +1,13 @@
 from logging import getLogger
-from typing import NamedTuple
+from typing import Any, NamedTuple
 
 from inspect_flow._launcher.inproc import (
     inproc_check,
     inproc_dry_run,
     inproc_launch,
 )
-from inspect_flow._launcher.venv import venv_check, venv_launch
-from inspect_flow._runner.logs import FindLogsResult
+from inspect_flow._launcher.venv import venv_check, venv_dry_run_json, venv_launch
+from inspect_flow._runner.logs import FindLogsResult, find_logs_result_to_json
 from inspect_flow._runner.run import LaunchResult
 from inspect_flow._types.flow_types import FlowSpec
 from inspect_flow._util.data import LAST_LOG_DIR_KEY, write_data
@@ -19,6 +19,7 @@ logger = getLogger(__name__)
 class CheckLaunchResult(NamedTuple):
     is_complete: bool
     find_result: FindLogsResult | None
+    json_result: dict[str, Any] | None = None
 
 
 def _prepare_launch_spec(spec: FlowSpec, base_dir: str) -> None:
@@ -48,24 +49,37 @@ def launch(spec: FlowSpec, base_dir: str, dry_run: bool = False) -> LaunchResult
         return inproc_launch(spec=spec, base_dir=base_dir, dry_run=dry_run)
 
 
-def launch_dry_run(spec: FlowSpec, base_dir: str) -> FindLogsResult | None:
+def launch_dry_run(spec: FlowSpec, base_dir: str) -> dict[str, Any] | None:
     _prepare_launch_spec(spec, base_dir=base_dir)
+    assert spec.log_dir
     if spec.execution_type == "venv":
-        return None
-    return inproc_dry_run(spec=spec, base_dir=base_dir)
+        return venv_dry_run_json(spec=spec, base_dir=base_dir)
+    return find_logs_result_to_json(
+        inproc_dry_run(spec=spec, base_dir=base_dir), spec.log_dir
+    )
 
 
-def launch_check(spec: FlowSpec, base_dir: str) -> CheckLaunchResult:
+def launch_check(
+    spec: FlowSpec, base_dir: str, output_json: bool = False
+) -> CheckLaunchResult:
     if not spec.log_dir:
         raise ValueError("log_dir must be set before checking the flow spec")
     spec.log_dir = absolute_path_relative_to(spec.log_dir, base_dir=base_dir)
 
     if spec.execution_type == "venv":
-        # The full result lives in the subprocess; only the completeness flag is
-        # signaled back (via a per-run result file) on a clean exit.
+        # The full result lives in the subprocess; the completeness flag (and the
+        # JSON result under --json) are signaled back via a per-run result file.
+        result = venv_check(spec=spec, base_dir=base_dir, output_json=output_json)
         return CheckLaunchResult(
-            is_complete=venv_check(spec=spec, base_dir=base_dir), find_result=None
+            is_complete=result.ok, find_result=None, json_result=result.json_result
         )
     else:
         result = inproc_check(spec=spec, base_dir=base_dir)
-        return CheckLaunchResult(is_complete=result.is_complete, find_result=result)
+        json_result = (
+            find_logs_result_to_json(result, spec.log_dir) if output_json else None
+        )
+        return CheckLaunchResult(
+            is_complete=result.is_complete,
+            find_result=result,
+            json_result=json_result,
+        )

--- a/src/inspect_flow/_launcher/launch.py
+++ b/src/inspect_flow/_launcher/launch.py
@@ -2,7 +2,11 @@ from logging import getLogger
 
 from inspect_ai.log import EvalLog
 
-from inspect_flow._launcher.inproc import inproc_check, inproc_launch
+from inspect_flow._launcher.inproc import (
+    inproc_check,
+    inproc_dry_run,
+    inproc_launch,
+)
 from inspect_flow._launcher.venv import venv_check, venv_launch
 from inspect_flow._runner.logs import FindLogsResult
 from inspect_flow._types.flow_types import FlowSpec
@@ -12,9 +16,7 @@ from inspect_flow._util.path_util import absolute_path_relative_to
 logger = getLogger(__name__)
 
 
-def launch(
-    spec: FlowSpec, base_dir: str, dry_run: bool = False
-) -> tuple[bool, list[EvalLog]]:
+def _prepare_launch_spec(spec: FlowSpec, base_dir: str) -> None:
     if not spec.log_dir:
         raise ValueError("log_dir must be set before launching the flow spec")
     spec.log_dir = absolute_path_relative_to(spec.log_dir, base_dir=base_dir)
@@ -32,10 +34,22 @@ def launch(
                 for k, v in spec.options.bundle_url_mappings.items()
             }
 
+
+def launch(
+    spec: FlowSpec, base_dir: str, dry_run: bool = False
+) -> tuple[bool, list[EvalLog]]:
+    _prepare_launch_spec(spec, base_dir=base_dir)
     if spec.execution_type == "venv":
         return venv_launch(spec=spec, base_dir=base_dir, dry_run=dry_run)
     else:
         return inproc_launch(spec=spec, base_dir=base_dir, dry_run=dry_run)
+
+
+def launch_dry_run(spec: FlowSpec, base_dir: str) -> FindLogsResult | None:
+    _prepare_launch_spec(spec, base_dir=base_dir)
+    if spec.execution_type == "venv":
+        return None
+    return inproc_dry_run(spec=spec, base_dir=base_dir)
 
 
 def launch_check(spec: FlowSpec, base_dir: str) -> FindLogsResult | None:

--- a/src/inspect_flow/_launcher/venv.py
+++ b/src/inspect_flow/_launcher/venv.py
@@ -5,7 +5,7 @@ import sys
 import tempfile
 from logging import getLogger
 from pathlib import Path
-from typing import Callable, List, Literal, Sequence
+from typing import Any, Callable, List, Literal, Sequence
 
 from inspect_ai import Task
 from inspect_ai._util.file import absolute_file_path
@@ -36,6 +36,7 @@ from inspect_flow._util.subprocess_util import (
     CHILD_READY_FD_ENV,
     PARENT_ACK_FD_ENV,
     RUN_RESULT_FILE_ENV,
+    SpawnResult,
     read_run_result,
     run_with_logging,
 )
@@ -46,15 +47,34 @@ logger = getLogger(__name__)
 def venv_launch(spec: FlowSpec, base_dir: str, dry_run: bool) -> LaunchResult:
     # The eval logs live in the subprocess; only the success flag is signaled back
     # (via a per-run result file) on a clean exit. A crash raises in _venv_spawn.
-    success = _venv_spawn(spec, base_dir=base_dir, subcommand="run", dry_run=dry_run)
-    return LaunchResult(success=success, logs=[])
+    result = _venv_spawn(spec, base_dir=base_dir, subcommand="run", dry_run=dry_run)
+    return LaunchResult(success=result.ok, logs=[])
 
 
-def venv_check(spec: FlowSpec, base_dir: str) -> bool:
-    return _venv_spawn(spec, base_dir=base_dir, subcommand="check", dry_run=True)
+def venv_dry_run_json(spec: FlowSpec, base_dir: str) -> dict[str, Any] | None:
+    # The subprocess builds the JSON result and writes it to the result file.
+    return _venv_spawn(
+        spec, base_dir=base_dir, subcommand="run", dry_run=True, output_json=True
+    ).json_result
 
 
-def _venv_spawn(spec: FlowSpec, base_dir: str, subcommand: str, dry_run: bool) -> bool:
+def venv_check(spec: FlowSpec, base_dir: str, output_json: bool = False) -> SpawnResult:
+    return _venv_spawn(
+        spec,
+        base_dir=base_dir,
+        subcommand="check",
+        dry_run=True,
+        output_json=output_json,
+    )
+
+
+def _venv_spawn(
+    spec: FlowSpec,
+    base_dir: str,
+    subcommand: str,
+    dry_run: bool,
+    output_json: bool = False,
+) -> SpawnResult:
     action_keys = (
         list(RUN_ACTIONS.keys()) if subcommand == "run" else list(CHECK_ACTIONS.keys())
     )
@@ -64,6 +84,8 @@ def _venv_spawn(spec: FlowSpec, base_dir: str, subcommand: str, dry_run: bool) -
             run_path = (Path(__file__).parents[1] / "_runner" / "cli.py").absolute()
             base_dir = absolute_file_path(base_dir)
             run_args = ["--dry-run"] if dry_run and subcommand == "run" else []
+            if output_json:
+                run_args.append("--json")
             args = [
                 "--base-dir",
                 base_dir,

--- a/src/inspect_flow/_runner/cli.py
+++ b/src/inspect_flow/_runner/cli.py
@@ -115,6 +115,7 @@ def runner_run(
     set_display_type(display_type)
     cfg = _read_config(file)
     if output_json:
+        assert dry_run, "--json is only supported with --dry-run"
         with redirect_stdout(sys.stderr):
             find_result = dry_run_eval_set(cfg, base_dir=base_dir)
         _write_json_result(find_result, cfg)

--- a/src/inspect_flow/_runner/cli.py
+++ b/src/inspect_flow/_runner/cli.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import sys
+from contextlib import redirect_stdout
+
 import click
 import yaml
 
@@ -12,7 +15,8 @@ from inspect_flow._display.display import (
     set_display_type,
 )
 from inspect_flow._runner.check import check_eval_set
-from inspect_flow._runner.run import run_eval_set
+from inspect_flow._runner.logs import FindLogsResult, find_logs_result_to_json
+from inspect_flow._runner.run import dry_run_eval_set, run_eval_set
 from inspect_flow._types.flow_types import FlowSpec
 from inspect_flow._util.console import path
 from inspect_flow._util.constants import DEFAULT_LOG_LEVEL
@@ -36,6 +40,11 @@ def _read_config(config_file: str) -> FlowSpec:
     with open(config_file, "r") as f:
         data = yaml.safe_load(f)
         return FlowSpec.model_validate(data, extra="forbid")
+
+
+def _write_json_result(result: FindLogsResult, cfg: FlowSpec) -> None:
+    assert cfg.log_dir
+    write_run_result(result.is_complete, find_logs_result_to_json(result, cfg.log_dir))
 
 
 def _common_options(fn: click.decorators.FC) -> click.decorators.FC:
@@ -68,6 +77,13 @@ def _common_options(fn: click.decorators.FC) -> click.decorators.FC:
         default=DEFAULT_DISPLAY_TYPE,
         help="Display type.",
     )(fn)
+    fn = click.option(
+        "--json",
+        "output_json",
+        is_flag=True,
+        default=False,
+        help="Write a machine-readable result to the result file.",
+    )(fn)
     return fn
 
 
@@ -91,12 +107,18 @@ def runner_run(
     log_level: str,
     display_type: DisplayType,
     dry_run: bool,
+    output_json: bool,
 ) -> None:
     set_exception_hook()
     init_flow_logging(log_level=log_level)
     signal_ready_and_wait()
     set_display_type(display_type)
     cfg = _read_config(file)
+    if output_json:
+        with redirect_stdout(sys.stderr):
+            find_result = dry_run_eval_set(cfg, base_dir=base_dir)
+        _write_json_result(find_result, cfg)
+        return
     mode: DisplayMode = "dry_run" if dry_run else "run"
     with create_display(mode=mode, actions=RUN_ACTIONS) as disp:
         disp.set_title("VENV Flow Spec:", path(file))
@@ -111,12 +133,18 @@ def runner_check(
     base_dir: str,
     log_level: str,
     display_type: DisplayType,
+    output_json: bool,
 ) -> None:
     set_exception_hook()
     init_flow_logging(log_level=log_level)
     signal_ready_and_wait()
     set_display_type(display_type)
     cfg = _read_config(file)
+    if output_json:
+        with redirect_stdout(sys.stderr):
+            find_result = check_eval_set(cfg, base_dir=base_dir)
+        _write_json_result(find_result, cfg)
+        return
     with create_display(mode="check", actions=CHECK_ACTIONS) as disp:
         disp.set_title("VENV Flow Spec:", path(file))
         result = check_eval_set(cfg, base_dir=base_dir)

--- a/src/inspect_flow/_runner/logs.py
+++ b/src/inspect_flow/_runner/logs.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from logging import getLogger
-from typing import NamedTuple
+from typing import Any, NamedTuple
 
 from inspect_ai import Epochs, Task
 from inspect_ai._eval.eval import eval_resolve_tasks
@@ -48,6 +48,33 @@ class FindLogsResult(NamedTuple):
             (info.log_samples, info.task_samples)
             for info in self.task_log_info.values()
         )
+
+
+def _task_to_json(info: TaskLogInfo) -> dict[str, Any]:
+    complete = info.task_samples is not None and info.log_samples >= info.task_samples
+    return {
+        "name": info.task.name,
+        "log_file": info.eval_log.location if info.eval_log else None,
+        "samples": info.log_samples,
+        "total_samples": info.task_samples,
+        "complete": complete,
+        "duplicate_logs": list(info.duplicate_logs),
+    }
+
+
+def find_logs_result_to_json(result: FindLogsResult, log_dir: str) -> dict[str, Any]:
+    tasks = [_task_to_json(info) for info in result.task_log_info.values()]
+    complete = sum(1 for task in tasks if task["complete"])
+    return {
+        "log_dir": log_dir,
+        "tasks": tasks,
+        "unrecognized": list(result.unexpected_logs),
+        "summary": {
+            "total": len(tasks),
+            "complete": complete,
+            "incomplete": len(tasks) - complete,
+        },
+    }
 
 
 def get_task_ids_to_tasks(

--- a/src/inspect_flow/_runner/run.py
+++ b/src/inspect_flow/_runner/run.py
@@ -136,11 +136,6 @@ def run_eval_set(spec: FlowSpec, base_dir: str, dry_run: bool = False) -> Launch
     resolved_spec = ctx.spec
     assert resolved_spec.log_dir
     options = ctx.options
-    display_type = ctx.display_type
-    log_level = ctx.log_level
-    tasks = ctx.tasks
-    store = ctx.store
-    store_config = ctx.store_config
     task_log_info = ctx.logs_result.task_log_info
 
     with RunAction("evalset") as action:
@@ -162,15 +157,15 @@ def run_eval_set(spec: FlowSpec, base_dir: str, dry_run: bool = False) -> Launch
         return LaunchResult(success=False, logs=[])
 
     title = display().get_title()
-    if display_type == "full":
+    if ctx.display_type == "full":
         content = display().make_renderable()
         if content is not None:
             set_flow_content(content)
     display().stop()
 
-    update_log_level(log_level)
+    update_log_level(ctx.log_level)
 
-    eval_tasks = run_after_instantiate_hooks([t.task for t in tasks])
+    eval_tasks = run_after_instantiate_hooks([t.task for t in ctx.tasks])
 
     start_time = time.time()
     result: LaunchResult | None
@@ -196,12 +191,12 @@ def run_eval_set(spec: FlowSpec, base_dir: str, dry_run: bool = False) -> Launch
             tags=sequence_to_list(default_none(options.tags)),
             metadata=default_none(options.metadata),
             trace=default_none(options.trace),
-            display=default_none(display_type),
+            display=default_none(ctx.display_type),
             approval=default_none(options.approval),
             notification=default_none(options.notification),
             score=default(options.score, True),
             score_display=default_none(options.score_display),
-            log_level=default_none(log_level),
+            log_level=default_none(ctx.log_level),
             log_level_transcript=default_none(options.log_level_transcript),
             log_format=default_none(options.log_format),
             limit=default_none(options.limit),
@@ -268,10 +263,10 @@ def run_eval_set(spec: FlowSpec, base_dir: str, dry_run: bool = False) -> Launch
 
     _print_result(resolved_spec, result, elapsed_time, task_log_info, title)
 
-    if store and (store_config is None or store_config.write):
+    if ctx.store and (ctx.store_config is None or ctx.store_config.write):
         # Now that the logs have been created, need to add the log_dir again to ensure all logs are indexed
         try:
-            store.add_run_logs(result.logs)
+            ctx.store.add_run_logs(result.logs)
         except NoLogsError as e:
             logger.error(
                 f"No logs found in log directory: {resolved_spec.log_dir}. Cannot add to store. {e}"

--- a/src/inspect_flow/_runner/run.py
+++ b/src/inspect_flow/_runner/run.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import time
+from dataclasses import dataclass
 from datetime import timedelta
 from importlib.metadata import PackageNotFoundError, requires, version
 from logging import getLogger
@@ -12,6 +13,7 @@ from inspect_ai._display.textual.app import set_flow_content
 from inspect_ai._eval.evalset import list_all_eval_logs, task_identifier
 from inspect_ai._util.error import PrerequisiteError
 from inspect_ai.log import EvalLog
+from inspect_ai.util import DisplayType
 from inspect_ai.util._display import init_display_type
 from packaging.requirements import Requirement
 from packaging.utils import canonicalize_name
@@ -25,15 +27,16 @@ from inspect_flow._config.write import write_config_file
 from inspect_flow._display.display import display, get_display_type
 from inspect_flow._display.path_progress import ReadLogsProgress
 from inspect_flow._display.run_action import RunAction
-from inspect_flow._runner.instantiate import instantiate_tasks
+from inspect_flow._runner.instantiate import InstantiatedTask, instantiate_tasks
 from inspect_flow._runner.logs import (
+    FindLogsResult,
     find_existing_logs,
     get_task_ids_to_tasks,
     num_log_samples,
 )
 from inspect_flow._runner.resolve import resolve_spec
 from inspect_flow._runner.task_log import TaskLogInfo, create_task_log_display
-from inspect_flow._store.store import store_factory
+from inspect_flow._store.store import FlowStoreInternal, store_factory
 from inspect_flow._types.after_instantiate import run_after_instantiate_hooks
 from inspect_flow._types.flow_types import (
     FlowInternal,
@@ -63,7 +66,19 @@ def _option_string(options: FlowOptions) -> str | None:
     return ", ".join(f"{k}={getattr(options, k)!r}" for k in options.model_fields_set)
 
 
-def run_eval_set(spec: FlowSpec, base_dir: str, dry_run: bool = False) -> LaunchResult:
+@dataclass
+class _RunContext:
+    spec: FlowSpec
+    options: FlowOptions
+    display_type: DisplayType
+    log_level: str
+    tasks: list[InstantiatedTask]
+    logs_result: FindLogsResult
+    store: FlowStoreInternal | None
+    store_config: FlowStoreConfig | None
+
+
+def _prepare_run(spec: FlowSpec, base_dir: str, dry_run: bool) -> _RunContext:
     resolved_spec = resolve_spec(spec, base_dir=base_dir)
     # 470 - eval_resolve_tasks uses the display, which sets a global that causes it to be ignored when passed to eval_set
     # so we need to initialize the display type here first
@@ -100,7 +115,33 @@ def run_eval_set(spec: FlowSpec, base_dir: str, dry_run: bool = False) -> Launch
         store if (store_config is not None and store_config.read) else None,
         mode="dry_run" if dry_run else "run",
     )
-    task_log_info = logs_result.task_log_info
+    return _RunContext(
+        spec=resolved_spec,
+        options=options,
+        display_type=display_type,
+        log_level=log_level,
+        tasks=tasks,
+        logs_result=logs_result,
+        store=store,
+        store_config=store_config,
+    )
+
+
+def dry_run_eval_set(spec: FlowSpec, base_dir: str) -> FindLogsResult:
+    return _prepare_run(spec, base_dir=base_dir, dry_run=True).logs_result
+
+
+def run_eval_set(spec: FlowSpec, base_dir: str, dry_run: bool = False) -> LaunchResult:
+    ctx = _prepare_run(spec, base_dir=base_dir, dry_run=dry_run)
+    resolved_spec = ctx.spec
+    assert resolved_spec.log_dir
+    options = ctx.options
+    display_type = ctx.display_type
+    log_level = ctx.log_level
+    tasks = ctx.tasks
+    store = ctx.store
+    store_config = ctx.store_config
+    task_log_info = ctx.logs_result.task_log_info
 
     with RunAction("evalset") as action:
         task_log = create_task_log_display(task_log_info, mode="pre-run")

--- a/src/inspect_flow/_runner/run.py
+++ b/src/inspect_flow/_runner/run.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import time
+from dataclasses import dataclass
 from datetime import timedelta
 from importlib.metadata import PackageNotFoundError, requires, version
 from logging import getLogger
@@ -11,6 +12,7 @@ from inspect_ai._display.textual.app import set_flow_content
 from inspect_ai._eval.evalset import list_all_eval_logs, task_identifier
 from inspect_ai._util.error import PrerequisiteError
 from inspect_ai.log import EvalLog
+from inspect_ai.util import DisplayType
 from inspect_ai.util._display import init_display_type
 from packaging.requirements import Requirement
 from packaging.utils import canonicalize_name
@@ -24,15 +26,16 @@ from inspect_flow._config.write import write_config_file
 from inspect_flow._display.display import display, get_display_type
 from inspect_flow._display.path_progress import ReadLogsProgress
 from inspect_flow._display.run_action import RunAction
-from inspect_flow._runner.instantiate import instantiate_tasks
+from inspect_flow._runner.instantiate import InstantiatedTask, instantiate_tasks
 from inspect_flow._runner.logs import (
+    FindLogsResult,
     find_existing_logs,
     get_task_ids_to_tasks,
     num_log_samples,
 )
 from inspect_flow._runner.resolve import resolve_spec
 from inspect_flow._runner.task_log import TaskLogInfo, create_task_log_display
-from inspect_flow._store.store import store_factory
+from inspect_flow._store.store import FlowStoreInternal, store_factory
 from inspect_flow._types.after_instantiate import run_after_instantiate_hooks
 from inspect_flow._types.flow_types import (
     FlowInternal,
@@ -57,9 +60,19 @@ def _option_string(options: FlowOptions) -> str | None:
     return ", ".join(f"{k}={getattr(options, k)!r}" for k in options.model_fields_set)
 
 
-def run_eval_set(
-    spec: FlowSpec, base_dir: str, dry_run: bool = False
-) -> tuple[bool, list[EvalLog]]:
+@dataclass
+class _RunContext:
+    spec: FlowSpec
+    options: FlowOptions
+    display_type: DisplayType
+    log_level: str
+    tasks: list[InstantiatedTask]
+    logs_result: FindLogsResult
+    store: FlowStoreInternal | None
+    store_config: FlowStoreConfig | None
+
+
+def _prepare_run(spec: FlowSpec, base_dir: str, dry_run: bool) -> _RunContext:
     resolved_spec = resolve_spec(spec, base_dir=base_dir)
     # 470 - eval_resolve_tasks uses the display, which sets a global that causes it to be ignored when passed to eval_set
     # so we need to initialize the display type here first
@@ -96,7 +109,35 @@ def run_eval_set(
         store if (store_config is not None and store_config.read) else None,
         mode="dry_run" if dry_run else "run",
     )
-    task_log_info = logs_result.task_log_info
+    return _RunContext(
+        spec=resolved_spec,
+        options=options,
+        display_type=display_type,
+        log_level=log_level,
+        tasks=tasks,
+        logs_result=logs_result,
+        store=store,
+        store_config=store_config,
+    )
+
+
+def dry_run_eval_set(spec: FlowSpec, base_dir: str) -> FindLogsResult:
+    return _prepare_run(spec, base_dir=base_dir, dry_run=True).logs_result
+
+
+def run_eval_set(
+    spec: FlowSpec, base_dir: str, dry_run: bool = False
+) -> tuple[bool, list[EvalLog]]:
+    ctx = _prepare_run(spec, base_dir=base_dir, dry_run=dry_run)
+    resolved_spec = ctx.spec
+    assert resolved_spec.log_dir
+    options = ctx.options
+    display_type = ctx.display_type
+    log_level = ctx.log_level
+    tasks = ctx.tasks
+    store = ctx.store
+    store_config = ctx.store_config
+    task_log_info = ctx.logs_result.task_log_info
 
     with RunAction("evalset") as action:
         task_log = create_task_log_display(task_log_info, mode="pre-run")

--- a/src/inspect_flow/_util/subprocess_util.py
+++ b/src/inspect_flow/_util/subprocess_util.py
@@ -5,11 +5,17 @@ import os
 import subprocess
 from logging import getLogger
 from pathlib import Path
-from typing import Any
+from typing import Any, NamedTuple
 
 from inspect_flow._util.console import flow_print
 
 logger = getLogger(__name__)
+
+
+class SpawnResult(NamedTuple):
+    ok: bool
+    json_result: dict[str, Any] | None
+
 
 # Environment variable names for passing synchronization fd numbers to child.
 # The parent sets these before spawning the child process.
@@ -23,8 +29,8 @@ PARENT_ACK_FD_ENV = "INSPECT_FLOW_PARENT_ACK_FD"
 RUN_RESULT_FILE_ENV = "INSPECT_FLOW_RUN_RESULT_FILE"
 
 
-def write_run_result(ok: bool) -> None:
-    """Write the child runner's outcome flag to the per-run result file.
+def write_run_result(ok: bool, json_result: dict[str, Any] | None = None) -> None:
+    """Write the child runner's outcome to the per-run result file.
 
     Called by a child runner process spawned with `RUN_RESULT_FILE_ENV`. Does
     nothing when the env var is unset (e.g. when invoked standalone).
@@ -32,21 +38,23 @@ def write_run_result(ok: bool) -> None:
     Args:
         ok: The boolean outcome of the child's work — eval-set success for
             `run`, completeness for `check`.
+        json_result: The machine-readable result produced under `--json`, or
+            `None` when JSON output was not requested.
     """
     result_path = os.environ.get(RUN_RESULT_FILE_ENV)
     if result_path:
-        Path(result_path).write_text(json.dumps({"ok": ok}))
+        Path(result_path).write_text(json.dumps({"ok": ok, "json": json_result}))
 
 
-def read_run_result(result_path: str) -> bool:
-    """Read the outcome flag a child runner wrote to its per-run result file.
+def read_run_result(result_path: str) -> SpawnResult:
+    """Read the outcome a child runner wrote to its per-run result file.
 
     Args:
         result_path: Absolute path the child was told to write to.
 
     Returns:
-        The boolean outcome written by the child (success for `run`,
-        completeness for `check`).
+        The outcome flag (success for `run`, completeness for `check`) and the
+        JSON result, if any.
 
     Raises:
         RuntimeError: If the child exited without writing a result.
@@ -56,7 +64,8 @@ def read_run_result(result_path: str) -> bool:
         raise RuntimeError(
             f"venv run process exited without reporting a result at {result_path}"
         )
-    return bool(json.loads(path.read_text())["ok"])
+    data = json.loads(path.read_text())
+    return SpawnResult(ok=bool(data["ok"]), json_result=data.get("json"))
 
 
 def signal_ready_and_wait() -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -67,6 +67,39 @@ def init_log_handler() -> Generator[None, None, None]:
 
 
 @pytest.fixture(autouse=True)
+def reset_display_state() -> Generator[None, None, None]:
+    # Re-sync the display/console globals after each test. Modules bind the
+    # shared console via `from ..console import console`, so they must all point
+    # at the canonical object; tests (e.g. recording_console combined with a real
+    # eval) can leave them pointing at a stale recording console, which defeats
+    # `console.quiet` suppression and leaks display output into --json stdout.
+    import sys
+
+    from inspect_flow._display import display as display_module
+    from inspect_flow._util.console import console
+
+    console_modules = (
+        "inspect_flow._display.full",
+        "inspect_flow._display.full_actions",
+        "inspect_flow._display.plain",
+        "inspect_flow._cli.store",
+        "inspect_flow._steps.run",
+        "inspect_flow._steps.context",
+        "inspect_flow._steps.step",
+    )
+    try:
+        yield
+    finally:
+        for name in console_modules:
+            module = sys.modules.get(name)
+            if module is not None and "console" in vars(module):
+                vars(module)["console"] = console
+        console.quiet = False
+        display_module.set_display(None)
+        display_module.set_display_type(display_module.DEFAULT_DISPLAY_TYPE)
+
+
+@pytest.fixture(autouse=True)
 def isolate_user_data(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Ensure tests never touch real user data (store and flow data file)."""
     user_data = tmp_path / "user_data"

--- a/tests/local_eval/src/local_eval/noop.py
+++ b/tests/local_eval/src/local_eval/noop.py
@@ -24,6 +24,17 @@ def noop2() -> Task:
 
 
 @task
+def noisy_stdout() -> Task:
+    print("noisy-stdout-marker")
+    return Task(
+        dataset=[
+            Sample(id=1, input="Test sample 1"),
+            Sample(id=2, input="Test sample 2"),
+        ]
+    )
+
+
+@task
 def task_with_get_model() -> Task:
     _model = get_model()
     return Task()

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 import pytest
 from inspect_flow import FlowSpec, FlowTask
 from inspect_flow._runner.run import run_eval_set
+from inspect_flow._util.subprocess_util import SpawnResult
 from inspect_flow.api import check
 from rich.console import Console
 
@@ -109,7 +110,8 @@ def test_check_venv_returns_is_complete(tmp_path: Path, is_complete: bool) -> No
     )
 
     with patch(
-        "inspect_flow._launcher.launch.venv_check", return_value=is_complete
+        "inspect_flow._launcher.launch.venv_check",
+        return_value=SpawnResult(ok=is_complete, json_result=None),
     ) as mock_venv_check:
         result = check(spec=spec, base_dir=".")
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,6 +13,7 @@ from inspect_flow._config.load import ConfigOptions, _apply_overrides
 from inspect_flow._launcher.launch import CheckLaunchResult
 from inspect_flow._runner.run import LaunchResult
 from inspect_flow._types.flow_types import FlowSpec
+from inspect_flow._util.subprocess_util import SpawnResult
 from inspect_flow._version import __version__
 
 CONFIG_FILE = "./tests/config/mock_flow.py"
@@ -450,7 +451,8 @@ def test_check_command_venv_exit_code(
 ) -> None:
     runner = CliRunner()
     with patch(
-        "inspect_flow._launcher.launch.venv_check", return_value=is_complete
+        "inspect_flow._launcher.launch.venv_check",
+        return_value=SpawnResult(ok=is_complete, json_result=None),
     ) as mock_venv_check:
         result = runner.invoke(
             check_command,

--- a/tests/test_json_cli.py
+++ b/tests/test_json_cli.py
@@ -9,6 +9,9 @@ from inspect_flow._cli.list import list_command
 from inspect_flow._cli.run import run_command
 from inspect_flow._cli.store import store_command
 from inspect_flow._util.constants import EXIT_INCOMPLETE
+from inspect_flow._util.subprocess_util import RUN_RESULT_FILE_ENV
+
+from tests.conftest import MockVenvSubprocess
 
 _NOOP_PATH = str(Path("tests/local_eval/src/local_eval/noop.py").resolve())
 _TASK_ABS = f"{_NOOP_PATH}@noop"
@@ -108,20 +111,65 @@ def test_run_json_requires_dry_run(tmp_path: Path) -> None:
     assert "--json is only supported with --dry-run" in result.output
 
 
-def test_run_dry_run_json_rejects_venv(tmp_path: Path) -> None:
+def _mock_venv_json_result(
+    mock_venv_subprocess: MockVenvSubprocess,
+    json_result: dict[str, Any],
+    *,
+    ok: bool = True,
+) -> None:
+    """Make the fake venv child write a --json result file the parent will emit."""
+
+    def write_result() -> None:
+        env = mock_venv_subprocess.popen.call_args.kwargs.get("env") or {}
+        result_path = env.get(RUN_RESULT_FILE_ENV)
+        if result_path:
+            Path(result_path).write_text(json.dumps({"ok": ok, "json": json_result}))
+
+    mock_venv_subprocess.popen.return_value.wait.side_effect = write_result
+
+
+def test_check_json_venv(
+    tmp_path: Path, mock_venv_subprocess: MockVenvSubprocess
+) -> None:
     spec_file = _write_spec(tmp_path, str(tmp_path / "logs"))
-    result = CliRunner().invoke(
-        run_command, [spec_file, "--dry-run", "--json", "--venv"]
+    payload = {"log_dir": str(tmp_path / "logs"), "tasks": [], "summary": {}}
+    _mock_venv_json_result(mock_venv_subprocess, payload, ok=True)
+
+    data = _invoke_json(check_command, [spec_file, "--json", "--venv"])
+
+    assert data == payload
+    child_args = mock_venv_subprocess.popen.call_args.args[0]
+    assert "check" in child_args
+    assert "--json" in child_args
+
+
+def test_check_json_venv_incomplete_exit_code(
+    tmp_path: Path, mock_venv_subprocess: MockVenvSubprocess
+) -> None:
+    spec_file = _write_spec(tmp_path, str(tmp_path / "logs"))
+    _mock_venv_json_result(mock_venv_subprocess, {"tasks": []}, ok=False)
+
+    _invoke_json(
+        check_command,
+        [spec_file, "--json", "--venv"],
+        expected_exit_code=EXIT_INCOMPLETE,
     )
-    assert result.exit_code != 0
-    assert "--json is not supported with venv execution" in result.output
 
 
-def test_check_json_rejects_venv(tmp_path: Path) -> None:
+def test_run_dry_run_json_venv(
+    tmp_path: Path, mock_venv_subprocess: MockVenvSubprocess
+) -> None:
     spec_file = _write_spec(tmp_path, str(tmp_path / "logs"))
-    result = CliRunner().invoke(check_command, [spec_file, "--json", "--venv"])
-    assert result.exit_code != 0
-    assert "--json is not supported with venv execution" in result.output
+    payload = {"log_dir": str(tmp_path / "logs"), "tasks": [], "summary": {}}
+    _mock_venv_json_result(mock_venv_subprocess, payload)
+
+    data = _invoke_json(run_command, [spec_file, "--dry-run", "--json", "--venv"])
+
+    assert data == payload
+    child_args = mock_venv_subprocess.popen.call_args.args[0]
+    assert "run" in child_args
+    assert "--dry-run" in child_args
+    assert "--json" in child_args
 
 
 def test_store_info_json(tmp_path: Path) -> None:

--- a/tests/test_json_cli.py
+++ b/tests/test_json_cli.py
@@ -1,0 +1,114 @@
+import json
+from pathlib import Path
+from typing import Any
+
+from click.testing import CliRunner
+from inspect_flow._cli.check import check_command
+from inspect_flow._cli.config import config_command
+from inspect_flow._cli.list import list_command
+from inspect_flow._cli.run import run_command
+from inspect_flow._cli.store import store_command
+
+_TASK = "tests/local_eval/src/local_eval/noop.py@noop"
+_TASK_ABS = f"{Path(_TASK.split('@')[0]).resolve()}@{_TASK.split('@')[1]}"
+_NOOP_SAMPLES = 2
+_STORE_LOG_DIR = "tests/test_logs/logs1"
+
+
+def _write_spec(tmp_path: Path, log_dir: str) -> str:
+    spec_file = tmp_path / "flow.yaml"
+    spec_file.write_text(
+        f"log_dir: {log_dir}\n"
+        "tasks:\n"
+        f"  - name: {_TASK_ABS}\n"
+        "    model: mockllm/mock-llm\n"
+    )
+    return str(spec_file)
+
+
+def _invoke_json(command: Any, args: list[str]) -> Any:
+    result = CliRunner().invoke(command, args, catch_exceptions=False)
+    assert result.exit_code == 0, result.output
+    return json.loads(result.output)
+
+
+def test_config_json(tmp_path: Path) -> None:
+    spec_file = _write_spec(tmp_path, str(tmp_path / "logs"))
+    data = _invoke_json(config_command, [spec_file, "--json"])
+    assert data["tasks"][0]["name"].endswith("noop.py@noop")
+
+
+def test_check_json_no_logs(tmp_path: Path) -> None:
+    spec_file = _write_spec(tmp_path, str(tmp_path / "logs"))
+    data = _invoke_json(check_command, [spec_file, "--json"])
+
+    assert data["summary"] == {"total": 1, "complete": 0, "incomplete": 1}
+    assert data["unrecognized"] == []
+    (task,) = data["tasks"]
+    assert task["name"].endswith("noop.py@noop")
+    assert task["log_file"] is None
+    assert task["samples"] == 0
+    assert task["total_samples"] == _NOOP_SAMPLES
+    assert task["complete"] is False
+
+
+def test_check_json_with_completed_log(tmp_path: Path) -> None:
+    spec_file = _write_spec(tmp_path, str(tmp_path / "logs"))
+    runner = CliRunner()
+    assert runner.invoke(run_command, [spec_file]).exit_code == 0
+
+    data = _invoke_json(check_command, [spec_file, "--json"])
+    assert data["summary"] == {"total": 1, "complete": 1, "incomplete": 0}
+    (task,) = data["tasks"]
+    assert task["log_file"] is not None
+    assert task["samples"] == _NOOP_SAMPLES
+    assert task["complete"] is True
+
+
+def test_run_dry_run_json(tmp_path: Path) -> None:
+    spec_file = _write_spec(tmp_path, str(tmp_path / "logs"))
+    data = _invoke_json(run_command, [spec_file, "--dry-run", "--json"])
+    assert data["summary"] == {"total": 1, "complete": 0, "incomplete": 1}
+    assert data["tasks"][0]["name"].endswith("noop.py@noop")
+    assert not list(Path(tmp_path / "logs").glob("*.eval"))
+
+
+def test_run_json_requires_dry_run(tmp_path: Path) -> None:
+    spec_file = _write_spec(tmp_path, str(tmp_path / "logs"))
+    result = CliRunner().invoke(run_command, [spec_file, "--json"])
+    assert result.exit_code != 0
+    assert "--json is only supported with --dry-run" in result.output
+
+
+def test_store_info_json(tmp_path: Path) -> None:
+    runner = CliRunner()
+    runner.invoke(store_command, ["import", _STORE_LOG_DIR, "--log-level", "error"])
+    data = _invoke_json(store_command, ["info", "--json"])
+    assert data["logs"] == 2
+    assert data["log_dirs"] == 1
+    assert data["version"] == "0.2.0"
+    assert data["path"]
+
+
+def test_store_info_json_empty() -> None:
+    data = _invoke_json(store_command, ["info", "--json"])
+    assert data is None
+
+
+def test_store_list_json(tmp_path: Path) -> None:
+    runner = CliRunner()
+    runner.invoke(store_command, ["import", _STORE_LOG_DIR, "--log-level", "error"])
+    data = _invoke_json(store_command, ["list", "--json"])
+    assert len(data["logs"]) == 2
+    assert all(log.endswith(".eval") for log in data["logs"])
+    assert data["logs"] == sorted(data["logs"])
+
+
+def test_list_log_json() -> None:
+    data = _invoke_json(list_command, ["log", _STORE_LOG_DIR, "--json", "--no-page"])
+    assert len(data["logs"]) == 2
+    log = data["logs"][0]
+    assert log["task"] == "inspect_evals/gpqa_diamond"
+    assert log["status"] == "success"
+    assert log["samples"] == log["total_samples"]
+    assert log["log_file"].endswith(".eval")

--- a/tests/test_json_cli.py
+++ b/tests/test_json_cli.py
@@ -8,6 +8,7 @@ from inspect_flow._cli.config import config_command
 from inspect_flow._cli.list import list_command
 from inspect_flow._cli.run import run_command
 from inspect_flow._cli.store import store_command
+from inspect_flow._util.constants import EXIT_INCOMPLETE
 
 _TASK = "tests/local_eval/src/local_eval/noop.py@noop"
 _TASK_ABS = f"{Path(_TASK.split('@')[0]).resolve()}@{_TASK.split('@')[1]}"
@@ -26,9 +27,9 @@ def _write_spec(tmp_path: Path, log_dir: str) -> str:
     return str(spec_file)
 
 
-def _invoke_json(command: Any, args: list[str]) -> Any:
+def _invoke_json(command: Any, args: list[str], expected_exit_code: int = 0) -> Any:
     result = CliRunner().invoke(command, args, catch_exceptions=False)
-    assert result.exit_code == 0, result.output
+    assert result.exit_code == expected_exit_code, result.output
     return json.loads(result.output)
 
 
@@ -38,9 +39,23 @@ def test_config_json(tmp_path: Path) -> None:
     assert data["tasks"][0]["name"].endswith("noop.py@noop")
 
 
+def test_json_command_restores_display_state(tmp_path: Path) -> None:
+    from inspect_flow._display.display import get_display, get_display_type
+
+    prev_type = get_display_type()
+    prev_display = get_display()
+    spec_file = _write_spec(tmp_path, str(tmp_path / "logs"))
+    _invoke_json(run_command, [spec_file, "--dry-run", "--json"])
+    assert get_display_type() == prev_type
+    assert get_display() is prev_display
+
+
 def test_check_json_no_logs(tmp_path: Path) -> None:
     spec_file = _write_spec(tmp_path, str(tmp_path / "logs"))
-    data = _invoke_json(check_command, [spec_file, "--json"])
+    # An incomplete check still emits JSON but signals incompleteness via exit code.
+    data = _invoke_json(
+        check_command, [spec_file, "--json"], expected_exit_code=EXIT_INCOMPLETE
+    )
 
     assert data["summary"] == {"total": 1, "complete": 0, "incomplete": 1}
     assert data["unrecognized"] == []

--- a/tests/test_json_cli.py
+++ b/tests/test_json_cli.py
@@ -80,6 +80,22 @@ def test_run_json_requires_dry_run(tmp_path: Path) -> None:
     assert "--json is only supported with --dry-run" in result.output
 
 
+def test_run_dry_run_json_rejects_venv(tmp_path: Path) -> None:
+    spec_file = _write_spec(tmp_path, str(tmp_path / "logs"))
+    result = CliRunner().invoke(
+        run_command, [spec_file, "--dry-run", "--json", "--venv"]
+    )
+    assert result.exit_code != 0
+    assert "--json is not supported with venv execution" in result.output
+
+
+def test_check_json_rejects_venv(tmp_path: Path) -> None:
+    spec_file = _write_spec(tmp_path, str(tmp_path / "logs"))
+    result = CliRunner().invoke(check_command, [spec_file, "--json", "--venv"])
+    assert result.exit_code != 0
+    assert "--json is not supported with venv execution" in result.output
+
+
 def test_store_info_json(tmp_path: Path) -> None:
     runner = CliRunner()
     runner.invoke(store_command, ["import", _STORE_LOG_DIR, "--log-level", "error"])

--- a/tests/test_json_cli.py
+++ b/tests/test_json_cli.py
@@ -10,19 +10,16 @@ from inspect_flow._cli.run import run_command
 from inspect_flow._cli.store import store_command
 from inspect_flow._util.constants import EXIT_INCOMPLETE
 
-_TASK = "tests/local_eval/src/local_eval/noop.py@noop"
-_TASK_ABS = f"{Path(_TASK.split('@')[0]).resolve()}@{_TASK.split('@')[1]}"
+_NOOP_PATH = str(Path("tests/local_eval/src/local_eval/noop.py").resolve())
+_TASK_ABS = f"{_NOOP_PATH}@noop"
 _NOOP_SAMPLES = 2
 _STORE_LOG_DIR = "tests/test_logs/logs1"
 
 
-def _write_spec(tmp_path: Path, log_dir: str) -> str:
+def _write_spec(tmp_path: Path, log_dir: str, task: str = _TASK_ABS) -> str:
     spec_file = tmp_path / "flow.yaml"
     spec_file.write_text(
-        f"log_dir: {log_dir}\n"
-        "tasks:\n"
-        f"  - name: {_TASK_ABS}\n"
-        "    model: mockllm/mock-llm\n"
+        f"log_dir: {log_dir}\ntasks:\n  - name: {task}\n    model: mockllm/mock-llm\n"
     )
     return str(spec_file)
 
@@ -85,6 +82,22 @@ def test_run_dry_run_json(tmp_path: Path) -> None:
     data = _invoke_json(run_command, [spec_file, "--dry-run", "--json"])
     assert data["summary"] == {"total": 1, "complete": 0, "incomplete": 1}
     assert data["tasks"][0]["name"].endswith("noop.py@noop")
+
+
+def test_json_stdout_not_corrupted_by_task_print(tmp_path: Path) -> None:
+    spec_file = _write_spec(
+        tmp_path, str(tmp_path / "logs"), task=f"{_NOOP_PATH}@noisy_stdout"
+    )
+    result = CliRunner().invoke(
+        run_command, [spec_file, "--dry-run", "--json"], catch_exceptions=False
+    )
+    assert result.exit_code == 0, result.output
+    # The task's stdout print must not corrupt the JSON payload on stdout; it is
+    # redirected to stderr instead.
+    assert "noisy-stdout-marker" not in result.stdout
+    data = json.loads(result.stdout)
+    assert data["tasks"][0]["name"].endswith("noop.py@noisy_stdout")
+    assert "noisy-stdout-marker" in result.stderr
     assert not list(Path(tmp_path / "logs").glob("*.eval"))
 
 

--- a/tests/test_json_cli.py
+++ b/tests/test_json_cli.py
@@ -117,8 +117,7 @@ def _mock_venv_json_result(
     *,
     ok: bool = True,
 ) -> None:
-    """Make the fake venv child write a --json result file the parent will emit."""
-
+    # Make the fake venv child write a --json result file the parent will emit.
     def write_result() -> None:
         env = mock_venv_subprocess.popen.call_args.kwargs.get("env") or {}
         result_path = env.get(RUN_RESULT_FILE_ENV)

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -137,7 +137,7 @@ def test_runner_run_writes_success(
         )
 
     assert result.exit_code == 0
-    assert read_run_result(str(result_path)) is eval_set_success
+    assert read_run_result(str(result_path)).ok is eval_set_success
 
 
 @pytest.mark.parametrize("is_complete", [True, False])
@@ -164,7 +164,7 @@ def test_runner_check_writes_is_complete(
         )
 
     assert result.exit_code == 0
-    assert read_run_result(str(result_path)) is is_complete
+    assert read_run_result(str(result_path)).ok is is_complete
 
 
 def test_env(


### PR DESCRIPTION
Fixes #719

Adds a --json flag to the validate-before-run CLI commands (config,
check, list log, store list/info, and run --dry-run). When set, the
command suppresses Rich/display output and writes a single JSON
document to stdout, making the commands usable in coding-agent
feedback loops.

The runner is refactored to extract the dry-run preparation into
_prepare_run / dry_run_eval_set so run --dry-run --json can return the
structured FindLogsResult without duplicating logic.

Closes #719

Co-authored-by: Ransom Richardson <ransomr@users.noreply.github.com>