### PR TITLE
feat: widen --display/DisplayType to Inspect's full set

### DIFF
--- a/src/inspect_flow/README.md
+++ b/src/inspect_flow/README.md
@@ -83,7 +83,7 @@ The store indexes logs by task identifier so the runner can find and reuse compl
 [_display](./_display) provides a pluggable terminal display for rendering flow progress and status.
 
 [display.py](./_display/display.py) defines the `Display` ABC and manages a global singleton.
-`DisplayType = Literal["full", "rich", "plain"]` controls the display mode.
+`DisplayType = Literal["full", "conversation", "rich", "plain", "log", "none"]` controls the display mode.
 `create_display()` creates a display context with action tracking for CLI commands.
 
 Display implementations:

--- a/src/inspect_flow/_cli/options.py
+++ b/src/inspect_flow/_cli/options.py
@@ -53,7 +53,7 @@ def output_options(f: F) -> F:
     f = click.option(
         "--display",
         type=click.Choice(
-            ["full", "rich", "plain"],
+            ["full", "conversation", "rich", "plain", "log", "none"],
             case_sensitive=False,
         ),
         default=DEFAULT_DISPLAY_TYPE,

--- a/src/inspect_flow/_display/display.py
+++ b/src/inspect_flow/_display/display.py
@@ -44,17 +44,22 @@ def get_display_type() -> DisplayType:
 
 def set_display_type(display_type: DisplayType) -> None:
     global _display_type
+    prev_display_type = _display_type
     _display_type = display_type
     plain = display_type in _PLAIN_DISPLAY_TYPES or display_type == "none"
     console.no_color = plain
     console.highlighter = NullHighlighter() if plain else ReprHighlighter()
     if display_type == "none":
         # Fully suppress Flow's own console output (flow_print, the result
-        # summary). We only ever enable quiet here: JSON commands drive
-        # console.quiet themselves via quiet_output(), and clearing it for
-        # non-"none" types would clobber that transient suppression when an
-        # inner init_output() re-runs mid-command.
+        # summary).
         console.quiet = True
+    elif prev_display_type == "none":
+        # Leaving "none" clears the suppression it set. We only touch quiet on
+        # entering/leaving "none": JSON commands drive console.quiet themselves
+        # via quiet_output(), and clearing it on every non-"none" call would
+        # clobber that transient suppression when an inner init_output() re-runs
+        # mid-command.
+        console.quiet = False
 
 
 def display() -> Display:

--- a/src/inspect_flow/_display/display.py
+++ b/src/inspect_flow/_display/display.py
@@ -31,7 +31,7 @@ DEFAULT_DISPLAY_TYPE: DisplayType = "full"
 DisplayMode = Literal["run", "dry_run", "check"]
 """Display mode for flow output."""
 
-_PLAIN_DISPLAY_TYPES: tuple[DisplayType, ...] = ("plain", "log", "none")
+_PLAIN_DISPLAY_TYPES: tuple[DisplayType, ...] = ("plain", "log")
 """Display types that Flow renders as flat, non-interactive plain text."""
 
 _display_type: DisplayType = DEFAULT_DISPLAY_TYPE
@@ -45,7 +45,7 @@ def get_display_type() -> DisplayType:
 def set_display_type(display_type: DisplayType) -> None:
     global _display_type
     _display_type = display_type
-    plain = display_type in _PLAIN_DISPLAY_TYPES
+    plain = display_type in _PLAIN_DISPLAY_TYPES or display_type == "none"
     console.no_color = plain
     console.highlighter = NullHighlighter() if plain else ReprHighlighter()
 
@@ -53,7 +53,11 @@ def set_display_type(display_type: DisplayType) -> None:
 def display() -> Display:
     global _display
     if _display is None:
-        if _display_type in _PLAIN_DISPLAY_TYPES:
+        if _display_type == "none":
+            from inspect_flow._display.no import NoDisplay
+
+            _display = NoDisplay()
+        elif _display_type in _PLAIN_DISPLAY_TYPES:
             from inspect_flow._display.plain import PlainDisplay
 
             _display = PlainDisplay()
@@ -115,7 +119,11 @@ class Display(ABC):
 
 
 def create_display(mode: DisplayMode, actions: dict[str, DisplayAction]) -> Display:
-    if _display_type in _PLAIN_DISPLAY_TYPES:
+    if _display_type == "none":
+        from inspect_flow._display.no import NoDisplay
+
+        return NoDisplay()
+    elif _display_type in _PLAIN_DISPLAY_TYPES:
         from inspect_flow._display.plain import PlainDisplay
 
         return PlainDisplay()

--- a/src/inspect_flow/_display/display.py
+++ b/src/inspect_flow/_display/display.py
@@ -48,6 +48,13 @@ def set_display_type(display_type: DisplayType) -> None:
     plain = display_type in _PLAIN_DISPLAY_TYPES or display_type == "none"
     console.no_color = plain
     console.highlighter = NullHighlighter() if plain else ReprHighlighter()
+    if display_type == "none":
+        # Fully suppress Flow's own console output (flow_print, the result
+        # summary). We only ever enable quiet here: JSON commands drive
+        # console.quiet themselves via quiet_output(), and clearing it for
+        # non-"none" types would clobber that transient suppression when an
+        # inner init_output() re-runs mid-command.
+        console.quiet = True
 
 
 def display() -> Display:

--- a/src/inspect_flow/_display/display.py
+++ b/src/inspect_flow/_display/display.py
@@ -13,20 +13,27 @@ from rich.text import Text
 from inspect_flow._display.action import DisplayAction
 from inspect_flow._util.console import Formats, console
 
-DisplayType = Literal["full", "rich", "plain"]
-"""Display type for flow output."""
+DisplayType = Literal["full", "conversation", "rich", "plain", "log", "none"]
+"""Display type for flow output.
+
+Matches Inspect's set of display types:
+    - "full": Full interactive display with progress bars and rich formatting.
+    - "conversation": Stream the model conversation to the terminal.
+    - "rich": Rich text formatting without interactive elements.
+    - "plain": Plain text output.
+    - "log": Flat, ANSI-free log lines.
+    - "none": No display output.
+"""
 
 DEFAULT_DISPLAY_TYPE: DisplayType = "full"
 """Default display type for flow output."""
 
 DisplayMode = Literal["run", "dry_run", "check"]
-"""Display mode for flow output.
+"""Display mode for flow output."""
 
-Options:
-    - "full": Full interactive display with progress bars and rich formatting
-    - "rich": Rich text formatting without interactive elements
-    - "plain": Plain text output
-"""
+_PLAIN_DISPLAY_TYPES: tuple[DisplayType, ...] = ("plain", "log", "none")
+"""Display types that Flow renders as flat, non-interactive plain text."""
+
 _display_type: DisplayType = DEFAULT_DISPLAY_TYPE
 _display: Display | None = None
 
@@ -38,7 +45,7 @@ def get_display_type() -> DisplayType:
 def set_display_type(display_type: DisplayType) -> None:
     global _display_type
     _display_type = display_type
-    plain = display_type == "plain"
+    plain = display_type in _PLAIN_DISPLAY_TYPES
     console.no_color = plain
     console.highlighter = NullHighlighter() if plain else ReprHighlighter()
 
@@ -46,7 +53,7 @@ def set_display_type(display_type: DisplayType) -> None:
 def display() -> Display:
     global _display
     if _display is None:
-        if _display_type == "plain":
+        if _display_type in _PLAIN_DISPLAY_TYPES:
             from inspect_flow._display.plain import PlainDisplay
 
             _display = PlainDisplay()
@@ -108,7 +115,7 @@ class Display(ABC):
 
 
 def create_display(mode: DisplayMode, actions: dict[str, DisplayAction]) -> Display:
-    if _display_type == "plain":
+    if _display_type in _PLAIN_DISPLAY_TYPES:
         from inspect_flow._display.plain import PlainDisplay
 
         return PlainDisplay()

--- a/src/inspect_flow/_display/display.py
+++ b/src/inspect_flow/_display/display.py
@@ -60,6 +60,13 @@ def set_display_type(display_type: DisplayType) -> None:
         # clobber that transient suppression when an inner init_output() re-runs
         # mid-command.
         console.quiet = False
+    if display_type != prev_display_type:
+        # Drop any lazily-cached display so display() rebuilds it for the new
+        # type; otherwise a display() materialized under the old type (e.g. the
+        # silent NoDisplay under "none") stays cached after the type changes.
+        # set_display_type is never called while a context-managed display is
+        # active, so this only ever clears the lazy singleton.
+        set_display(None)
 
 
 def display() -> Display:

--- a/src/inspect_flow/_display/no.py
+++ b/src/inspect_flow/_display/no.py
@@ -1,0 +1,58 @@
+"""Silent display that suppresses all output."""
+
+from __future__ import annotations
+
+from types import TracebackType
+from typing import Optional, Type
+
+from rich.console import RenderableType
+from rich.text import Text
+
+from inspect_flow._display.action import DisplayAction
+from inspect_flow._display.display import Display, set_display
+from inspect_flow._util.console import Formats
+
+
+class NoDisplay(Display):
+    def __init__(self) -> None:
+        self._started = False
+
+    def update_action(self, key: str, action: DisplayAction) -> None:
+        pass
+
+    def print(
+        self,
+        *objects: RenderableType,
+        action_key: str,
+        format: Formats = "default",
+        copyable: bool = False,
+    ) -> None:
+        pass
+
+    def set_footer(self, renderable: RenderableType | None) -> None:
+        pass
+
+    def get_title(self) -> list[str | Text] | None:
+        return None
+
+    def set_title(self, *objects: str | Text) -> None:
+        pass
+
+    def __enter__(self) -> Display:
+        set_display(self)
+        self._started = True
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ) -> None:
+        self.stop()
+
+    def stop(self, remove_actions: list[str] | None = None) -> None:
+        if not self._started:
+            return
+        set_display(None)
+        self._started = False

--- a/src/inspect_flow/_runner/cli.py
+++ b/src/inspect_flow/_runner/cli.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import sys
 from contextlib import redirect_stdout
+from typing import get_args
 
 import click
 import yaml
@@ -73,7 +74,7 @@ def _common_options(fn: click.decorators.FC) -> click.decorators.FC:
     fn = click.option(
         "--display",
         "display_type",
-        type=click.Choice(["full", "rich", "plain"]),
+        type=click.Choice(list(get_args(DisplayType))),
         default=DEFAULT_DISPLAY_TYPE,
         help="Display type.",
     )(fn)

--- a/src/inspect_flow/_steps/scan.py
+++ b/src/inspect_flow/_steps/scan.py
@@ -159,7 +159,7 @@ def scan(
     """
     flow_display = get_display_type()
     scout_display: Literal["rich", "plain", "log", "none"] = (
-        "rich" if flow_display == "full" else flow_display
+        "rich" if flow_display in ("full", "conversation") else flow_display
     )
 
     scanjob_args = parse_cli_args(s)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -598,6 +598,24 @@ def test_run_display_passed_to_eval_set(mock_eval_set: MagicMock) -> None:
     assert mock_eval_set.call_args.kwargs["display"] == "rich"
 
 
+@pytest.mark.parametrize(
+    "display", ["full", "conversation", "rich", "plain", "log", "none"]
+)
+def test_run_display_accepts_full_inspect_set(
+    display: str, mock_eval_set: MagicMock
+) -> None:
+    runner = CliRunner()
+    result = runner.invoke(
+        run_command,
+        [CONFIG_FILE, "--display", display, "--log-dir-allow-dirty"],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    mock_eval_set.assert_called_once()
+    assert mock_eval_set.call_args.kwargs["display"] == display
+
+
 def test_run_command_resume() -> None:
     runner = CliRunner()
     with (

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -177,6 +177,24 @@ class TestDisplayFactory:
             set_display_type(display_type)
             assert console.no_color is True
 
+    def test_none_suppresses_flow_print(self) -> None:
+        from inspect_flow._util.console import console, flow_print
+
+        set_display_type("none")
+        assert console.quiet is True
+        with console.capture() as capture:
+            flow_print("Log dir:", "some/path")
+            flow_print("All tasks completed", format="success")
+        assert capture.get() == ""
+
+    def test_non_none_does_not_suppress_flow_print(self) -> None:
+        from inspect_flow._util.console import console, flow_print
+
+        set_display_type("plain")
+        with console.capture() as capture:
+            flow_print("Log dir:", "some/path")
+        assert "Log dir:" in capture.get()
+
 
 class TestFullDisplay:
     def test_context_manager_sets_and_clears_global(self) -> None:

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -18,6 +18,7 @@ from inspect_flow._display.full_actions import (
     _OutputCapture,
     _SafeRenderable,
 )
+from inspect_flow._display.no import NoDisplay
 from inspect_flow._display.plain import PlainDisplay
 from rich.console import Console, ConsoleOptions, RenderableType, RenderResult
 from rich.measure import Measurement
@@ -101,6 +102,26 @@ class TestPlainDisplay:
         d.stop()  # not started, should be a no-op
 
 
+class TestNoDisplay:
+    def test_context_manager_sets_and_clears_global(self) -> None:
+        with NoDisplay() as d:
+            assert display() is d
+        assert display() is not d
+
+    def test_produces_no_output(self, recording_console: Console) -> None:
+        d = NoDisplay()
+        d.update_action("k", DisplayAction(description="Setup", status="success"))
+        d.print("hello", action_key="a", format="error")
+        d.set_footer("footer")
+        d.set_title("My Flow")
+        assert d.get_title() is None
+        assert recording_console.export_text() == ""
+
+    def test_stop_idempotent(self) -> None:
+        d = NoDisplay()
+        d.stop()  # not started, should be a no-op
+
+
 class TestDisplayFactory:
     _prev_display_type: DisplayType
 
@@ -127,16 +148,23 @@ class TestDisplayFactory:
         d = create_display(mode="run", actions={})
         assert isinstance(d, FullActionsDisplay)
 
-    def test_display_returns_plain_for_log_and_none(self) -> None:
-        for display_type in ("log", "none"):
-            set_display_type(display_type)
-            set_display(None)
-            assert isinstance(display(), PlainDisplay)
+    def test_display_returns_plain_for_log(self) -> None:
+        set_display_type("log")
+        set_display(None)
+        assert isinstance(display(), PlainDisplay)
 
-    def test_create_display_returns_plain_for_log_and_none(self) -> None:
-        for display_type in ("log", "none"):
-            set_display_type(display_type)
-            assert isinstance(create_display(mode="run", actions={}), PlainDisplay)
+    def test_create_display_returns_plain_for_log(self) -> None:
+        set_display_type("log")
+        assert isinstance(create_display(mode="run", actions={}), PlainDisplay)
+
+    def test_display_returns_no_display_for_none(self) -> None:
+        set_display_type("none")
+        set_display(None)
+        assert isinstance(display(), NoDisplay)
+
+    def test_create_display_returns_no_display_for_none(self) -> None:
+        set_display_type("none")
+        assert isinstance(create_display(mode="run", actions={}), NoDisplay)
 
     def test_conversation_uses_full_actions(self) -> None:
         set_display_type("conversation")

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -195,6 +195,27 @@ class TestDisplayFactory:
             flow_print("Log dir:", "some/path")
         assert "Log dir:" in capture.get()
 
+    def test_leaving_none_clears_quiet(self) -> None:
+        from inspect_flow._util.console import console, flow_print
+
+        set_display_type("none")
+        assert console.quiet is True
+        set_display_type("full")
+        assert console.quiet is False
+        with console.capture() as capture:
+            flow_print("Log dir:", "some/path")
+        assert "Log dir:" in capture.get()
+
+    def test_non_none_transition_preserves_transient_quiet(self) -> None:
+        # quiet_output() sets console.quiet transiently; a non-"none" init that
+        # re-runs mid-command must not clobber it.
+        from inspect_flow._util.console import console
+
+        set_display_type("plain")
+        console.quiet = True
+        set_display_type("full")
+        assert console.quiet is True
+
 
 class TestFullDisplay:
     def test_context_manager_sets_and_clears_global(self) -> None:

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -206,6 +206,13 @@ class TestDisplayFactory:
             flow_print("Log dir:", "some/path")
         assert "Log dir:" in capture.get()
 
+    def test_leaving_none_rebuilds_cached_display(self) -> None:
+        set_display(None)
+        set_display_type("none")
+        assert isinstance(display(), NoDisplay)
+        set_display_type("full")
+        assert isinstance(display(), FullDisplay)
+
     def test_non_none_transition_preserves_transient_quiet(self) -> None:
         # quiet_output() sets console.quiet transiently; a non-"none" init that
         # re-runs mid-command must not clobber it.

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -127,6 +127,28 @@ class TestDisplayFactory:
         d = create_display(mode="run", actions={})
         assert isinstance(d, FullActionsDisplay)
 
+    def test_display_returns_plain_for_log_and_none(self) -> None:
+        for display_type in ("log", "none"):
+            set_display_type(display_type)
+            set_display(None)
+            assert isinstance(display(), PlainDisplay)
+
+    def test_create_display_returns_plain_for_log_and_none(self) -> None:
+        for display_type in ("log", "none"):
+            set_display_type(display_type)
+            assert isinstance(create_display(mode="run", actions={}), PlainDisplay)
+
+    def test_conversation_uses_full_actions(self) -> None:
+        set_display_type("conversation")
+        assert isinstance(create_display(mode="run", actions={}), FullActionsDisplay)
+
+    def test_log_and_none_disable_color(self) -> None:
+        from inspect_flow._util.console import console
+
+        for display_type in ("log", "none"):
+            set_display_type(display_type)
+            assert console.no_color is True
+
 
 class TestFullDisplay:
     def test_context_manager_sets_and_clears_global(self) -> None:

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -483,3 +483,29 @@ class TestFlowRunCli:
         assert result.exit_code == 0, result.output
         mock_run.assert_called_once()
         mock_signal.assert_called_once()
+
+    @pytest.mark.parametrize(
+        "display_type", ["full", "conversation", "rich", "plain", "log", "none"]
+    )
+    @patch("inspect_flow._runner.cli.signal_ready_and_wait")
+    @patch("inspect_flow._runner.cli.run_eval_set")
+    def test_accepts_all_display_types(
+        self,
+        mock_run: MagicMock,
+        mock_signal: MagicMock,
+        display_type: str,
+        tmp_path: pytest.TempPathFactory,
+    ) -> None:
+        # The venv child CLI must accept every display type the public CLI does,
+        # since venv launch forwards get_display_type() into the child.
+        mock_run.return_value = LaunchResult(success=True, logs=[])
+        config_data = {"tasks": ["my_task"], "log_dir": "./logs"}
+        config_file = tmp_path / "flow.yaml"  # type: ignore[operator]
+        config_file.write_text(yaml.dump(config_data))
+
+        cli_runner = CliRunner()
+        result = cli_runner.invoke(
+            runner,
+            ["run", "--display", display_type, "--file", str(config_file)],
+        )
+        assert result.exit_code == 0, result.output


### PR DESCRIPTION
Fixes #720

Widen DisplayType and the --display click.Choice to pass through
Inspect's full set of display types (full, conversation, rich, plain,
log, none), so agents can request the flat, ANSI-free log/none streams.
Flow renders log/none as its plain, non-interactive display.

Closes #720

Co-authored-by: Ransom Richardson <ransomr@users.noreply.github.com>