### PR TITLE
feat: emit a launch handle file for run discoverability

### DIFF
--- a/src/inspect_flow/_api/api.py
+++ b/src/inspect_flow/_api/api.py
@@ -92,6 +92,7 @@ def run(
     *,
     dry_run: bool = False,
     resume: bool = False,
+    handle_file: str | None = None,
 ) -> RunResult:
     """Run an inspect_flow evaluation.
 
@@ -100,6 +101,10 @@ def run(
         base_dir: The base directory for resolving relative paths. Defaults to the current working directory.
         dry_run: If `True`, do not run eval, but show a count of tasks that would be run.
         resume: If `True`, reuse the log directory from the previous run.
+        handle_file: If set, write a JSON launch handle (with the run's `log_dir`
+            and `pid`) to this file once the log directory is resolved, so an
+            external monitor can discover a backgrounded run. Resolved relative
+            to `base_dir`.
 
     Returns:
         A RunResult with the success flag, eval logs, and log directory. `success`
@@ -125,6 +130,7 @@ def run(
         spec=spec,
         base_dir=base_dir,
         dry_run=dry_run,
+        handle_file=handle_file,
     )
     assert spec.log_dir
     return RunResult(success=result.success, logs=result.logs, log_dir=spec.log_dir)

--- a/src/inspect_flow/_cli/run.py
+++ b/src/inspect_flow/_cli/run.py
@@ -66,8 +66,6 @@ def run_command(
     config_options = parse_config_options(**kwargs)
     config_file = absolute_file_path(config_file)
     base_dir = str(Path(config_file).parent)
-    if handle_file is not None:
-        handle_file = absolute_file_path(handle_file)
     if output_json and not dry_run:
         raise click.UsageError("--json is only supported with --dry-run.")
     mode: DisplayMode = "dry_run" if dry_run else "run"

--- a/src/inspect_flow/_cli/run.py
+++ b/src/inspect_flow/_cli/run.py
@@ -46,7 +46,6 @@ _run_actions = {
     type=click.Path(
         file_okay=True,
         dir_okay=False,
-        writable=True,
         resolve_path=False,
     ),
     default=None,

--- a/src/inspect_flow/_cli/run.py
+++ b/src/inspect_flow/_cli/run.py
@@ -41,11 +41,24 @@ _run_actions = {
     help="Do not fail if the `log-dir` contains files that are not part of the eval set.",
     envvar="INSPECT_FLOW_LOG_DIR_ALLOW_DIRTY",
 )
+@click.option(
+    "--handle-file",
+    type=click.Path(
+        file_okay=True,
+        dir_okay=False,
+        writable=True,
+        resolve_path=False,
+    ),
+    default=None,
+    help="Write a JSON launch handle (with the run's `log_dir` and `pid`) to this file once the log directory is resolved. Lets a monitor discover a backgrounded run.",
+    envvar="INSPECT_FLOW_HANDLE_FILE",
+)
 @config_options
 def run_command(
     config_file: str,
     output_json: bool,
     dry_run: bool,
+    handle_file: str | None,
     **kwargs: Unpack[ConfigOptionArgs],
 ) -> None:
     """CLI command to run a spec."""
@@ -53,6 +66,8 @@ def run_command(
     config_options = parse_config_options(**kwargs)
     config_file = absolute_file_path(config_file)
     base_dir = str(Path(config_file).parent)
+    if handle_file is not None:
+        handle_file = absolute_file_path(handle_file)
     if output_json and not dry_run:
         raise click.UsageError("--json is only supported with --dry-run.")
     mode: DisplayMode = "dry_run" if dry_run else "run"
@@ -62,7 +77,11 @@ def run_command(
         spec = int_load_spec(config_file, options=config_options)
         json_result = launch_dry_run(spec, base_dir=base_dir) if output_json else None
         result = (
-            None if output_json else launch(spec, base_dir=base_dir, dry_run=dry_run)
+            None
+            if output_json
+            else launch(
+                spec, base_dir=base_dir, dry_run=dry_run, handle_file=handle_file
+            )
         )
     if output_json:
         assert json_result is not None

--- a/src/inspect_flow/_cli/run.py
+++ b/src/inspect_flow/_cli/run.py
@@ -50,7 +50,7 @@ _run_actions = {
         resolve_path=False,
     ),
     default=None,
-    help="Write a JSON launch handle (with the run's `log_dir` and `pid`) to this file once the log directory is resolved. Lets a monitor discover a backgrounded run.",
+    help="Write a JSON launch handle (with the run's `log_dir` and `pid`) to this file once the log directory is resolved. Lets a monitor discover a backgrounded run. A relative path is resolved relative to the config file's directory, not the current working directory.",
     envvar="INSPECT_FLOW_HANDLE_FILE",
 )
 @config_options

--- a/src/inspect_flow/_launcher/launch.py
+++ b/src/inspect_flow/_launcher/launch.py
@@ -49,7 +49,7 @@ def launch(
     handle_file: str | None = None,
 ) -> LaunchResult:
     _prepare_launch_spec(spec, base_dir=base_dir)
-    if handle_file:
+    if handle_file and not dry_run:
         assert spec.log_dir
         write_run_handle(
             absolute_path_relative_to(handle_file, base_dir=base_dir), spec.log_dir

--- a/src/inspect_flow/_launcher/launch.py
+++ b/src/inspect_flow/_launcher/launch.py
@@ -12,6 +12,7 @@ from inspect_flow._runner.run import LaunchResult
 from inspect_flow._types.flow_types import FlowSpec
 from inspect_flow._util.data import LAST_LOG_DIR_KEY, write_data
 from inspect_flow._util.path_util import absolute_path_relative_to
+from inspect_flow._util.run_handle import write_run_handle
 
 logger = getLogger(__name__)
 
@@ -41,8 +42,18 @@ def _prepare_launch_spec(spec: FlowSpec, base_dir: str) -> None:
             }
 
 
-def launch(spec: FlowSpec, base_dir: str, dry_run: bool = False) -> LaunchResult:
+def launch(
+    spec: FlowSpec,
+    base_dir: str,
+    dry_run: bool = False,
+    handle_file: str | None = None,
+) -> LaunchResult:
     _prepare_launch_spec(spec, base_dir=base_dir)
+    if handle_file:
+        assert spec.log_dir
+        write_run_handle(
+            absolute_path_relative_to(handle_file, base_dir=base_dir), spec.log_dir
+        )
     if spec.execution_type == "venv":
         return venv_launch(spec=spec, base_dir=base_dir, dry_run=dry_run)
     else:

--- a/src/inspect_flow/_util/run_handle.py
+++ b/src/inspect_flow/_util/run_handle.py
@@ -12,8 +12,11 @@ def run_handle(log_dir: str) -> dict[str, Any]:
         log_dir: The (absolute) log directory the run writes to.
 
     Returns:
-        A JSON-serializable handle with the run's `log_dir` and the process
-        `pid` of the launching `flow run` command.
+        A JSON-serializable handle with the run's `log_dir` and the `pid` of
+        the launching `flow run` process. For `inproc` execution this pid runs
+        the eval directly. For `venv` execution it is the launcher, which
+        blocks while the eval runs in a child subprocess, so signaling this pid
+        stops the launcher but does not on its own cleanly terminate the eval.
     """
     return {"log_dir": log_dir, "pid": os.getpid()}
 
@@ -22,8 +25,9 @@ def write_run_handle(handle_file: str, log_dir: str) -> dict[str, Any]:
     """Write a launch handle JSON file so a run can be discovered.
 
     A coding agent (or any external monitor) that backgrounds `flow run` can
-    read this file to learn where the run is writing logs and which process to
-    signal, without having to parse the interactive display.
+    read this file to learn where the run is writing logs and the pid of the
+    launching process, without having to parse the interactive display. See
+    `run_handle` for the `pid` semantics under `inproc` vs `venv` execution.
 
     Args:
         handle_file: Path to write the handle JSON to.

--- a/src/inspect_flow/_util/run_handle.py
+++ b/src/inspect_flow/_util/run_handle.py
@@ -1,0 +1,38 @@
+import json
+import os
+from typing import Any
+
+from inspect_ai._util.file import file
+
+
+def run_handle(log_dir: str) -> dict[str, Any]:
+    """Build a launch handle describing a run for external discovery.
+
+    Args:
+        log_dir: The (absolute) log directory the run writes to.
+
+    Returns:
+        A JSON-serializable handle with the run's `log_dir` and the process
+        `pid` of the launching `flow run` command.
+    """
+    return {"log_dir": log_dir, "pid": os.getpid()}
+
+
+def write_run_handle(handle_file: str, log_dir: str) -> dict[str, Any]:
+    """Write a launch handle JSON file so a run can be discovered.
+
+    A coding agent (or any external monitor) that backgrounds `flow run` can
+    read this file to learn where the run is writing logs and which process to
+    signal, without having to parse the interactive display.
+
+    Args:
+        handle_file: Path to write the handle JSON to.
+        log_dir: The (absolute) log directory the run writes to.
+
+    Returns:
+        The handle that was written.
+    """
+    handle = run_handle(log_dir)
+    with file(handle_file, "w") as f:
+        f.write(json.dumps(handle, indent=2) + "\n")
+    return handle

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from click.testing import CliRunner
+from inspect_ai._util.file import absolute_file_path
 from inspect_flow._cli.check import check_command
 from inspect_flow._cli.config import config_command
 from inspect_flow._cli.main import flow
@@ -22,6 +23,7 @@ CONFIG_FILE_DIR = Path(CONFIG_FILE).parent.resolve().as_posix()
 
 COMMON_DEFAULTS = {
     "dry_run": False,
+    "handle_file": None,
 }
 
 
@@ -96,6 +98,33 @@ def test_run_command_overrides() -> None:
         # Verify that run was called with the config object and file path
         mock_run.assert_called_once_with(
             mock_config_obj, **COMMON_DEFAULTS, base_dir=CONFIG_FILE_DIR
+        )
+
+
+def test_run_command_handle_file() -> None:
+    runner = CliRunner()
+    with (
+        patch(
+            "inspect_flow._cli.run.launch",
+            return_value=LaunchResult(success=True, logs=[]),
+        ) as mock_run,
+        patch("inspect_flow._cli.run.int_load_spec") as mock_config,
+    ):
+        mock_config_obj = MagicMock()
+        mock_config.return_value = mock_config_obj
+
+        result = runner.invoke(
+            run_command,
+            [CONFIG_FILE, "--handle-file", "run-handle.json"],
+            catch_exceptions=False,
+        )
+
+        assert result.exit_code == 0
+        mock_run.assert_called_once_with(
+            mock_config_obj,
+            dry_run=False,
+            base_dir=CONFIG_FILE_DIR,
+            handle_file=absolute_file_path("run-handle.json"),
         )
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,7 +3,6 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from click.testing import CliRunner
-from inspect_ai._util.file import absolute_file_path
 from inspect_flow._cli.check import check_command
 from inspect_flow._cli.config import config_command
 from inspect_flow._cli.main import flow
@@ -120,11 +119,13 @@ def test_run_command_handle_file() -> None:
         )
 
         assert result.exit_code == 0
+        # The raw value is passed through; launch() resolves it relative to
+        # base_dir, matching the run() API's documented semantics.
         mock_run.assert_called_once_with(
             mock_config_obj,
             dry_run=False,
             base_dir=CONFIG_FILE_DIR,
-            handle_file=absolute_file_path("run-handle.json"),
+            handle_file="run-handle.json",
         )
 
 

--- a/tests/test_run_handle.py
+++ b/tests/test_run_handle.py
@@ -50,3 +50,18 @@ def test_launch_without_handle_file(mock_eval_set: MagicMock, tmp_path: Path) ->
 
     mock_eval_set.assert_called_once()
     assert not handle_file.exists()
+
+
+def test_launch_dry_run_skips_handle_file(
+    mock_eval_set: MagicMock, tmp_path: Path
+) -> None:
+    handle_file = tmp_path / "handle.json"
+    spec = FlowSpec(
+        log_dir=init_test_logs(),
+        tasks=[FlowTask(name=task_file + "@noop", model="mockllm/mock-llm")],
+    )
+    launch(spec=spec, base_dir=".", dry_run=True, handle_file=str(handle_file))
+
+    # A dry run does no real work, so the handle would point at a log_dir that
+    # was never written and a pid that is already dead; it must not be written.
+    assert not handle_file.exists()

--- a/tests/test_run_handle.py
+++ b/tests/test_run_handle.py
@@ -40,6 +40,22 @@ def test_launch_writes_handle_file(mock_eval_set: MagicMock, tmp_path: Path) -> 
     assert handle["pid"] == os.getpid()
 
 
+def test_launch_resolves_handle_file_relative_to_base_dir(
+    mock_eval_set: MagicMock, tmp_path: Path
+) -> None:
+    abs_task_file = str(Path(task_file).resolve())
+    spec = FlowSpec(
+        log_dir=init_test_logs(),
+        tasks=[FlowTask(name=abs_task_file + "@noop", model="mockllm/mock-llm")],
+    )
+    launch(spec=spec, base_dir=str(tmp_path), handle_file="handle.json")
+
+    handle_file = tmp_path / "handle.json"
+    assert handle_file.exists()
+    handle = json.loads(handle_file.read_text())
+    assert handle["log_dir"] == spec.log_dir
+
+
 def test_launch_without_handle_file(mock_eval_set: MagicMock, tmp_path: Path) -> None:
     handle_file = tmp_path / "handle.json"
     spec = FlowSpec(

--- a/tests/test_run_handle.py
+++ b/tests/test_run_handle.py
@@ -1,0 +1,52 @@
+import json
+import os
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from inspect_flow import FlowSpec, FlowTask
+from inspect_flow._launcher.launch import launch
+from inspect_flow._util.run_handle import run_handle, write_run_handle
+
+from .test_helpers.log_helpers import init_test_logs
+
+task_file = "tests/local_eval/src/local_eval/noop.py"
+
+
+def test_run_handle_contents() -> None:
+    handle = run_handle("/some/log/dir")
+    assert handle == {"log_dir": "/some/log/dir", "pid": os.getpid()}
+
+
+def test_write_run_handle(tmp_path: Path) -> None:
+    handle_file = str(tmp_path / "handle.json")
+    write_run_handle(handle_file, "/some/log/dir")
+    handle = json.loads(Path(handle_file).read_text())
+    assert handle == {"log_dir": "/some/log/dir", "pid": os.getpid()}
+
+
+def test_launch_writes_handle_file(mock_eval_set: MagicMock, tmp_path: Path) -> None:
+    log_dir = init_test_logs()
+    handle_file = str(tmp_path / "handle.json")
+    spec = FlowSpec(
+        log_dir=log_dir,
+        tasks=[FlowTask(name=task_file + "@noop", model="mockllm/mock-llm")],
+    )
+    launch(spec=spec, base_dir=".", handle_file=handle_file)
+
+    mock_eval_set.assert_called_once()
+    handle = json.loads(Path(handle_file).read_text())
+    # launch() resolves log_dir to an absolute path before writing the handle
+    assert handle["log_dir"] == spec.log_dir
+    assert handle["pid"] == os.getpid()
+
+
+def test_launch_without_handle_file(mock_eval_set: MagicMock, tmp_path: Path) -> None:
+    handle_file = tmp_path / "handle.json"
+    spec = FlowSpec(
+        log_dir=init_test_logs(),
+        tasks=[FlowTask(name=task_file + "@noop", model="mockllm/mock-llm")],
+    )
+    launch(spec=spec, base_dir=".")
+
+    mock_eval_set.assert_called_once()
+    assert not handle_file.exists()


### PR DESCRIPTION
Fixes #721

Add a `--handle-file` option to `flow run` (and a `handle_file` param to the
`run()` API) that writes a JSON launch handle with the run's `log_dir` and
`pid` once the log directory is resolved. This lets a monitor that backgrounds
`flow run` discover where the run is writing logs and which process to signal
without parsing the interactive display.

Co-authored-by: Ransom Richardson <ransomr@users.noreply.github.com>