### PR TITLE
docs: clarify FlowSpec config grouping and generation-config precedence

### DIFF
--- a/src/inspect_flow/_types/flow_types.py
+++ b/src/inspect_flow/_types/flow_types.py
@@ -103,7 +103,7 @@ class FlowModel(FlowBase):
 
     config: GenerateConfig | None | NotGiven = Field(
         default=not_given,
-        description="Configuration for model. Config values will be override settings on the `FlowTask` and `FlowSpec`.",
+        description="Model generation config. Highest precedence: overrides `config` on `FlowTask` and `defaults.config`.",
     )
 
     base_url: str | None | NotGiven = Field(
@@ -392,7 +392,7 @@ class FlowTask(FlowBase, arbitrary_types_allowed=True):
 
     config: GenerateConfig | NotGiven = Field(
         default=not_given,
-        description="Model generation config for default model (does not apply to model roles). Will override config settings on the `FlowSpec`. Will be overridden by settings on the `FlowModel`.",
+        description="Model generation config for the default model (does not apply to model roles). Overrides `defaults.config`; overridden by `FlowModel.config`.",
     )
 
     model_roles: ModelRolesConfig | None | NotGiven = Field(
@@ -733,7 +733,7 @@ class FlowDefaults(FlowBase):
 
     config: GenerateConfig | None | NotGiven = Field(
         default=not_given,
-        description="Default model generation options. Will be overriden by settings on the `FlowModel` and `FlowTask`.",
+        description="Default model generation config. Lowest precedence: overridden by `config` on `FlowTask` and `FlowModel`.",
     )
 
     agent: FlowAgent | None | NotGiven = Field(
@@ -870,11 +870,24 @@ class FlowStoreConfig(FlowBase):
 class FlowSpec(FlowBase, arbitrary_types_allowed=True):
     """Top-level flow specification: the tasks to run plus how to run them.
 
-    `tasks` lists what to evaluate; per-task configuration (model, solver, scorer,
-    epochs, limits) lives on each `FlowTask`. Cross-cutting settings live in dedicated
-    fields: `defaults` (`FlowDefaults`, applied to every task), `options` (`FlowOptions`,
-    eval-set-wide options forwarded to Inspect), and `dependencies` (`FlowDependencies`,
-    for venv mode). Eval parameters are not set directly at this top level.
+    This is the root object of every flow config. Settings are grouped by scope, and
+    putting each in the right place avoids the most common configuration mistake:
+
+    - **What to evaluate** — `tasks`, a list of `FlowTask`. Per-task settings (`model`,
+      `solver`, `scorer`, `config`, `epochs`, limits) live on each `FlowTask`, not here.
+    - **Defaults across tasks** — `defaults` (`FlowDefaults`), applied to every task. A
+      value set on an individual `FlowTask` overrides the matching default.
+    - **Eval-set-wide options** — `options` (`FlowOptions`), forwarded to Inspect's
+      `eval_set()`. These apply to the whole run (retries, global limits, display,
+      scoring), not to individual tasks.
+    - **Run environment** — top-level fields on this spec: `execution_type`,
+      `python_version`, `dependencies` (venv mode), `env`, `store`, `log_dir`.
+
+    Model generation `config` can be set in several places; later entries win:
+    `defaults.config` < `FlowTask.config` < `FlowModel.config`.
+
+    Eval parameters (`model`, `solver`, limits, etc.) are not set directly on `FlowSpec`;
+    put them on `FlowTask` (or `defaults` to apply them to every task).
     """
 
     includes: Sequence[str | FlowSpec] | None | NotGiven = Field(

--- a/src/inspect_flow/_types/generated.py
+++ b/src/inspect_flow/_types/generated.py
@@ -95,7 +95,7 @@ class FlowModelDict(TypedDict, closed=True):
     default: NotRequired[str | NotGiven | None]
     """Optional. Fallback model in case the specified model or role is not found. Should be a fully qualified model name (e.g. `openai/gpt-4o`)."""
     config: NotRequired[GenerateConfig | NotGiven | None]
-    """Configuration for model. Config values will be override settings on the `FlowTask` and `FlowSpec`."""
+    """Model generation config. Highest precedence: overrides `config` on `FlowTask` and `defaults.config`."""
     base_url: NotRequired[str | NotGiven | None]
     """Optional. Alternate base URL for model."""
     api_key: NotRequired[str | NotGiven | None]
@@ -117,7 +117,7 @@ class FlowModelMatrixDict(TypedDict, closed=True):
     """
 
     config: NotRequired[Sequence[GenerateConfig | NotGiven | None] | None]
-    """Configuration for model. Config values will be override settings on the `FlowTask` and `FlowSpec`."""
+    """Model generation config. Highest precedence: overrides `config` on `FlowTask` and `defaults.config`."""
 
 
 class FlowSolverDict(TypedDict, closed=True):
@@ -180,7 +180,7 @@ class FlowTaskDict(TypedDict, closed=True):
     model: NotRequired[str | FlowModel | Model | NotGiven | None]
     """Default model for task (Optional, defaults to eval model)."""
     config: NotRequired[GenerateConfig | NotGiven]
-    """Model generation config for default model (does not apply to model roles). Will override config settings on the `FlowSpec`. Will be overridden by settings on the `FlowModel`."""
+    """Model generation config for the default model (does not apply to model roles). Overrides `defaults.config`; overridden by `FlowModel.config`."""
     model_roles: NotRequired[Mapping[str, FlowModel | str | Model] | NotGiven | None]
     """Named roles for use in `get_model()`."""
     sandbox: NotRequired[
@@ -247,7 +247,7 @@ class FlowTaskMatrixDict(TypedDict, closed=True):
     model: NotRequired[Sequence[str | FlowModel | Model | NotGiven | None] | None]
     """Default model for task (Optional, defaults to eval model)."""
     config: NotRequired[Sequence[GenerateConfig | NotGiven] | None]
-    """Model generation config for default model (does not apply to model roles). Will override config settings on the `FlowSpec`. Will be overridden by settings on the `FlowModel`."""
+    """Model generation config for the default model (does not apply to model roles). Overrides `defaults.config`; overridden by `FlowModel.config`."""
     model_roles: NotRequired[
         Sequence[Mapping[str, FlowModel | str | Model] | NotGiven | None] | None
     ]


### PR DESCRIPTION
## Summary

Addresses the config-authoring half of #722 for **consuming agents** — agents (and humans) that write flow specs against a `pip install`ed inspect_flow.

Flow specs are authored in Python, and the exported, typed pydantic models are the real contract (validated at construction, and via pyright since the models use `extra="forbid"`). So the guidance that helps a consuming agent has to travel with those classes — as docstrings/field descriptions surfaced by hover and go-to-definition — not as a separate file that never ships in the wheel. This PR improves exactly that surface.

## Changes

- **`FlowSpec` docstring → a scannable "where does each setting go" map** (tasks / `defaults` / `options` / run environment), with the explicit note that eval parameters belong on `FlowTask`, not the top level. This is the type an agent reads first, and it targets the failure mode #722 describes: guessing *where* config belongs.
- **Consolidated the model-generation `config` precedence** into one consistent chain everywhere it appears: `defaults.config` < `FlowTask.config` < `FlowModel.config`. Previously each `config` field described the order piecemeal, referenced a non-existent "config on the `FlowSpec`" (it's `defaults.config`), and had two typos ("will be override", "overriden").
- **Regenerated `generated.py`** to match the updated field descriptions.

## Why this direction (and not a `flow schema` command / `get_schema()` API)

See the issue comment for full rationale. In short: a JSON schema / editor-`$schema` contract is only useful for the **YAML** authoring path, which isn't the priority — consuming agents author **Python**. For Python, the typed classes already provide validation and autocomplete; a separate schema is redundant, doesn't ship usefully via `pip install`, and can drift. Putting the grouping guidance in the docstrings is what actually reaches a consuming agent.

## Test plan

- `make check` passes (ruff + pyright).
- Pre-commit type-gen drift check passes (`generated.py` regenerated and in sync).
- No behavior change — docstrings/descriptions only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)