### PR TITLE
docs: add contributing guide

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,12 +55,12 @@ See [src/inspect_flow/README.md](src/inspect_flow/README.md) for detailed module
 - **Error Handling**: Use appropriate exception types; include context in error messages. Avoid try/except blocks unless absolutely necessary—if you add one, include a test that exercises that code path.
 - **Testing**: Write tests with pytest. Prefer integration tests that exercise real behavior through public entry points (CLI commands, public API) over unit tests that mock internal details. Only mock at system boundaries (external APIs, file system, network). Avoid mocking internal classes or methods—this couples tests to implementation and makes refactoring harder. Test what the code *does* (observable output, side effects), not *how* it does it. Tests should rarely need to change when internal code is refactored. Use existing fixtures (e.g. `recording_console`) instead of ad-hoc mocking.
 - **Bug Fixes**: Include a test that reproduces the bug before fixing it
-- **Pull Requests**: Keep PRs small and focused. Include a description of changes and rationale. Use conventional commit messages for PR titles. Release notes are generated from `feat:` and `fix:` titles, so choose the prefix accordingly:
+- **Pull Requests**: Keep PRs small and focused. Include a description of changes and rationale. Use conventional commit messages for PR titles. `feat:` and `fix:` titles drive the version bump and headline the release notes (`perf:`/`revert:` also appear; the rest are hidden), so choose the prefix accordingly:
   - `feat:` — only for significant user-facing features.
   - `fix:` — only for product bug fixes that affect users.
   - `build:` — build system, dependencies, and packaging changes.
   - `test:` — test additions, fixes, and CI test infrastructure.
-  - Use other conventional types (`docs:`, `refactor:`, `chore:`, `ci:`) as appropriate. Anything that is not a user-facing feature or product bug fix should avoid `feat:`/`fix:` so it is excluded from release notes.
+  - Use other conventional types (`docs:`, `refactor:`, `chore:`, `ci:`) as appropriate. Anything that is not a user-facing feature or product bug fix should avoid `feat:`/`fix:` so it stays out of the headline sections.
 
 Respect existing code patterns when modifying files. Run linting before committing changes.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,19 +55,21 @@ matters. Format it as `<type>: <description>`.
 Releases are automated with [Release Please](https://github.com/googleapis/release-please):
 **don't edit `CHANGELOG.md` or bump the version by hand.** Release Please reads the
 merged commit types, opens a release PR that updates the changelog and version, and
-merging that PR tags and publishes the release.
+merging that PR tags the release; the publish then runs once a maintainer approves
+the deployment.
 
-Choose the type deliberately — only `feat:` and `fix:` appear in the release notes
-and drive the version bump:
+Choose the type deliberately — `feat:` and `fix:` drive the version bump and
+headline the release notes:
 
-| Type | Use for |
+| Type | Effect |
 | --- | --- |
-| `feat:` | a user-facing feature |
-| `fix:` | a user-facing bug fix |
-| `docs:`, `refactor:`, `perf:`, `test:`, `build:`, `chore:`, `ci:` | everything else — excluded from the release notes |
+| `feat:` | a user-facing feature — bumps the minor version |
+| `fix:` | a user-facing bug fix — bumps the patch version |
+| `perf:`, `revert:` | appear in the release notes (no bump on their own) |
+| `docs:`, `refactor:`, `chore:`, `build:`, `ci:`, `test:`, `style:` | hidden from the release notes |
 
 Anything that isn't a user-facing feature or fix should avoid `feat:`/`fix:` so it
-stays out of the release notes.
+stays out of the headline sections.
 
 ## Reporting issues
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,75 @@
+# Contributing to Inspect Flow
+
+Thanks for contributing to Inspect Flow! This guide covers local setup, the checks
+we run, and how commits and releases work.
+
+## Development setup
+
+Inspect Flow requires Python 3.10 or later. Clone the repository and sync the
+environment (this installs the `dev` dependency group by default):
+
+```bash
+git clone https://github.com/meridianlabs-ai/inspect_flow
+cd inspect_flow
+uv sync
+source .venv/bin/activate
+```
+
+Optionally install the pre-commit hooks:
+
+```bash
+make hooks
+```
+
+Note: don't use `uv run` to execute Python commands — it re-syncs the lockfile and
+can overwrite editable installs. Use `python` directly instead.
+
+## Checks and tests
+
+Run linting, formatting, and type checking (ruff + pyright):
+
+```bash
+make check
+```
+
+Run the test suite:
+
+```bash
+make test
+```
+
+To run a single test:
+
+```bash
+pytest tests/path/to/test_file.py::test_function_name -v
+```
+
+For a coverage report, use `make cov`.
+
+## Commit messages and releases
+
+We use [Conventional Commits](https://www.conventionalcommits.org/). Because we
+squash-merge, **the PR title becomes the commit message** — so the title is what
+matters. Format it as `<type>: <description>`.
+
+Releases are automated with [Release Please](https://github.com/googleapis/release-please):
+**don't edit `CHANGELOG.md` or bump the version by hand.** Release Please reads the
+merged commit types, opens a release PR that updates the changelog and version, and
+merging that PR tags and publishes the release.
+
+Choose the type deliberately — only `feat:` and `fix:` appear in the release notes
+and drive the version bump:
+
+| Type | Use for |
+| --- | --- |
+| `feat:` | a user-facing feature |
+| `fix:` | a user-facing bug fix |
+| `docs:`, `refactor:`, `perf:`, `test:`, `build:`, `chore:`, `ci:` | everything else — excluded from the release notes |
+
+Anything that isn't a user-facing feature or fix should avoid `feat:`/`fix:` so it
+stays out of the release notes.
+
+## Reporting issues
+
+Found a bug or have a feature request? Please open an issue on the
+[GitHub issue tracker](https://github.com/meridianlabs-ai/inspect_flow/issues).


### PR DESCRIPTION
Adds a `CONTRIBUTING.md` covering local development setup, checks/tests, the conventional-commit + Release Please workflow, and how to report issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)