### PR TITLE
ci: enable manual/hotfix dispatch (single-control)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,11 +4,6 @@ on:
     push:
         branches: [main]
     workflow_dispatch:
-        inputs:
-            target-branch:
-                description: "Maintenance branch to release from (e.g. hotfix/1.4.x). Leave as main for a normal release."
-                type: string
-                default: main
 
 jobs:
     release-please:
@@ -18,7 +13,6 @@ jobs:
         uses: meridianlabs-ai/actions/.github/workflows/release-please-python.yml@v1
         with:
             approvers: "ransomr jjallaire dragonstyle"
-            target-branch: ${{ inputs.target-branch }}
         secrets: inherit
 
     # Release announcement to flow's Slack channel (shared converter action).

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,6 +3,12 @@ name: Release
 on:
     push:
         branches: [main]
+    workflow_dispatch:
+        inputs:
+            target-branch:
+                description: "Maintenance branch to release from (e.g. hotfix/1.4.x). Leave as main for a normal release."
+                type: string
+                default: main
 
 jobs:
     release-please:
@@ -12,6 +18,7 @@ jobs:
         uses: meridianlabs-ai/actions/.github/workflows/release-please-python.yml@v1
         with:
             approvers: "ransomr jjallaire dragonstyle"
+            target-branch: ${{ inputs.target-branch }}
         secrets: inherit
 
     # Release announcement to flow's Slack channel (shared converter action).


### PR DESCRIPTION
Adds a `workflow_dispatch` trigger with a `target-branch` input and passes it through to the `release-please-python.yml@v1` reusable workflow. Backward compatible: on `push`, `inputs` is null so `target-branch` is empty and the reusable workflow falls back to its default branch (unchanged behavior). On manual dispatch it releases from the chosen maintenance branch, enabling hotfix/maintenance-branch releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)