### PR TITLE
feat: support renaming copies in the copy step (suffix and rename params)

### DIFF
--- a/docs/steps.qmd
+++ b/docs/steps.qmd
@@ -71,9 +71,12 @@ Copy eval logs to a destination directory:
 ``` bash
 flow step copy logs/ --dest s3://bucket/prod/
 flow step copy logs/ --dest ./archive/ --source-prefix ./logs/
+flow step copy logs/ --dest ./realigned/ --suffix +realigned
 ```
 
 Without `--source-prefix`, files are copied flat into the destination. With it, directory structure relative to the prefix is preserved. Use `--overwrite` to replace existing files. Use `--store` to add copied logs to the Flow Store index.
+
+Use `--suffix` to mark copies that are derivatives of the original — it is inserted before the file extension (`probe.eval` becomes `probe+realigned.eval`), so the marker travels with the file even when it is copied onward. From Python, `copy()` also accepts a `rename` function mapping the source filename to the destination filename for full control.
 
 ### [**scan**](reference/inspect_flow.api.qmd#scan)
 

--- a/src/inspect_flow/_cli/step.py
+++ b/src/inspect_flow/_cli/step.py
@@ -172,7 +172,12 @@ def _step_to_command(name: str, func: WrappedStepFunction) -> click.Command:
     original = getattr(func, "_step_func", func)
     # eval_str resolves stringized annotations (from __future__ import
     # annotations) so the annotation-based checks below see real types.
-    sig = inspect.signature(original, eval_str=True)
+    try:
+        sig = inspect.signature(original, eval_str=True)
+    except NameError:
+        # Annotations referencing TYPE_CHECKING-only imports can't be
+        # resolved; fall back to stringized annotations (options become str).
+        sig = inspect.signature(original)
     params: list[click.Parameter] = []
     doc = inspect.getdoc(original) or ""
     arg_help = _parse_arg_help(doc)
@@ -341,23 +346,35 @@ def _annotation_to_click_type(annotation: object) -> type:
     return str
 
 
+def _union_args(annotation: object) -> tuple[object, ...]:
+    """Members of a union annotation, or () if not a union.
+
+    Unions that accept str also return () — such params stay plain str
+    options (e.g. scan's ScannersSpec, `Sequence[...] | dict[...] | str`).
+    """
+    if get_origin(annotation) in (Union, types.UnionType):
+        args = get_args(annotation)
+        if str not in args:
+            return args
+    return ()
+
+
 def _is_callable(annotation: object) -> bool:
-    origin = get_origin(annotation)
-    if origin is collections.abc.Callable:
+    if get_origin(annotation) is collections.abc.Callable:
         return True
-    if origin in (Union, types.UnionType):
-        return any(_is_callable(a) for a in get_args(annotation))
-    return False
+    return any(_is_callable(a) for a in _union_args(annotation))
 
 
 def _is_dict_of_str(annotation: object) -> bool:
-    origin = getattr(annotation, "__origin__", None)
-    if origin is dict:
+    if get_origin(annotation) is dict:
         return True
-    if isinstance(annotation, types.UnionType):
-        args = getattr(annotation, "__args__", ())
-        return any(_is_dict_of_str(a) for a in args)
-    return False
+    return any(_is_dict_of_str(a) for a in _union_args(annotation))
+
+
+def _is_list_of_str(annotation: object) -> bool:
+    if get_origin(annotation) is list and get_args(annotation) == (str,):
+        return True
+    return any(_is_list_of_str(a) for a in _union_args(annotation))
 
 
 def _parse_key_value_pairs(values: tuple[str, ...]) -> dict[str, Any]:
@@ -368,17 +385,6 @@ def _parse_key_value_pairs(values: tuple[str, ...]) -> dict[str, Any]:
         key, value = item.split("=", 1)
         result[key] = maybe_json(value)
     return result
-
-
-def _is_list_of_str(annotation: object) -> bool:
-    origin = getattr(annotation, "__origin__", None)
-    args = getattr(annotation, "__args__", ())
-    if origin is list and args == (str,):
-        return True
-    # Handle list[str] | None
-    if isinstance(annotation, types.UnionType):
-        return any(_is_list_of_str(a) for a in args)
-    return False
 
 
 @click.group(

--- a/src/inspect_flow/_cli/step.py
+++ b/src/inspect_flow/_cli/step.py
@@ -192,12 +192,16 @@ def _step_to_command(name: str, func: WrappedStepFunction) -> click.Command:
     # Skip the first parameter (logs: list[EvalLog]) — provided via PATH arg.
     # Skip params added as common options below, params already covered by custom
     # decorators, and callables (Python-only, not expressible on the CLI).
-    step_params = [
+    candidates = [
         p
         for p in list(sig.parameters.values())[1:]
-        if p.name not in _COMMON_OPTION_NAMES
-        and p.name not in custom_names
-        and not _is_callable(p.annotation)
+        if p.name not in _COMMON_OPTION_NAMES and p.name not in custom_names
+    ]
+    step_params = [p for p in candidates if not _is_callable(p.annotation)]
+    required_python_only = [
+        p.name
+        for p in candidates
+        if _is_callable(p.annotation) and p.default is inspect.Parameter.empty
     ]
     dict_params: set[str] = set()
     for param in step_params:
@@ -300,6 +304,11 @@ def _step_to_command(name: str, func: WrappedStepFunction) -> click.Command:
     help_text = doc.split("\n\n")[0] if doc else ""
 
     def callback(path: tuple[str, ...], **kwargs: Any) -> None:
+        if required_python_only:
+            raise click.UsageError(
+                f"Step '{name}' has required Python-only parameter(s) "
+                f"({', '.join(required_python_only)}) and cannot be run from the CLI."
+            )
         for dp in dict_params:
             if dp in kwargs:
                 kwargs[dp] = _parse_key_value_pairs(kwargs[dp])

--- a/src/inspect_flow/_cli/step.py
+++ b/src/inspect_flow/_cli/step.py
@@ -170,7 +170,9 @@ def _parse_arg_help(doc: str) -> dict[str, str]:
 def _step_to_command(name: str, func: WrappedStepFunction) -> click.Command:
     """Convert a @step function into a click.Command."""
     original = getattr(func, "_step_func", func)
-    sig = inspect.signature(original)
+    # eval_str resolves stringized annotations (from __future__ import
+    # annotations) so the annotation-based checks below see real types.
+    sig = inspect.signature(original, eval_str=True)
     params: list[click.Parameter] = []
     doc = inspect.getdoc(original) or ""
     arg_help = _parse_arg_help(doc)

--- a/src/inspect_flow/_cli/step.py
+++ b/src/inspect_flow/_cli/step.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
+import collections.abc
 import inspect
 import types
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, Union, cast, get_args, get_origin
 
 import click
 import griffe
@@ -182,11 +183,14 @@ def _step_to_command(name: str, func: WrappedStepFunction) -> click.Command:
     custom_names = {p.name for p in custom_params if p.name is not None}
 
     # Skip the first parameter (logs: list[EvalLog]) — provided via PATH arg.
-    # Skip params added as common options below or already covered by custom decorators.
+    # Skip params added as common options below, params already covered by custom
+    # decorators, and callables (Python-only, not expressible on the CLI).
     step_params = [
         p
         for p in list(sig.parameters.values())[1:]
-        if p.name not in _COMMON_OPTION_NAMES and p.name not in custom_names
+        if p.name not in _COMMON_OPTION_NAMES
+        and p.name not in custom_names
+        and not _is_callable(p.annotation)
     ]
     dict_params: set[str] = set()
     for param in step_params:
@@ -333,6 +337,15 @@ def _annotation_to_click_type(annotation: object) -> type:
     if annotation is bool:
         return bool
     return str
+
+
+def _is_callable(annotation: object) -> bool:
+    origin = get_origin(annotation)
+    if origin is collections.abc.Callable:
+        return True
+    if origin in (Union, types.UnionType):
+        return any(_is_callable(a) for a in get_args(annotation))
+    return False
 
 
 def _is_dict_of_str(annotation: object) -> bool:

--- a/src/inspect_flow/_cli/step.py
+++ b/src/inspect_flow/_cli/step.py
@@ -176,7 +176,8 @@ def _step_to_command(name: str, func: WrappedStepFunction) -> click.Command:
         sig = inspect.signature(original, eval_str=True)
     except NameError:
         # Annotations referencing TYPE_CHECKING-only imports can't be
-        # resolved; fall back to stringized annotations (options become str).
+        # resolved; fall back to stringized annotations. Options degrade to
+        # str, so callable params are not filtered from the CLI here.
         sig = inspect.signature(original)
     params: list[click.Parameter] = []
     doc = inspect.getdoc(original) or ""

--- a/src/inspect_flow/_steps/copy.py
+++ b/src/inspect_flow/_steps/copy.py
@@ -21,6 +21,10 @@ def _relative_path(location: str, source_prefix: str | None) -> str:
     return basename(location)
 
 
+def _dest_path(dest: str, rel_dir: str, name: str) -> str:
+    return dest.rstrip("/") + "/" + "/".join(p for p in (rel_dir, name) if p)
+
+
 def _dest_name(
     name: str, suffix: str | None, rename: Callable[[str], str] | None
 ) -> str:
@@ -68,7 +72,7 @@ def copy(
             rel_path = _relative_path(log.location, source_prefix)
             rel_dir, _, name = rel_path.rpartition("/")
             name = _dest_name(name, suffix, rename)
-            dest_path = "/".join(p for p in (dest.rstrip("/"), rel_dir, name) if p)
+            dest_path = _dest_path(dest, rel_dir, name)
             if not overwrite and exists(dest_path):
                 flow_print(f"Skipping (already exists): {dest_path}", format="warning")
             elif not context.dry_run:

--- a/src/inspect_flow/_steps/copy.py
+++ b/src/inspect_flow/_steps/copy.py
@@ -1,3 +1,6 @@
+from os.path import splitext
+from typing import Callable
+
 from fsspec.core import split_protocol
 from inspect_ai._util.file import absolute_file_path, basename, copy_file, exists
 from inspect_ai.log import EvalLog
@@ -18,12 +21,25 @@ def _relative_path(location: str, source_prefix: str | None) -> str:
     return basename(location)
 
 
+def _dest_name(
+    name: str, suffix: str | None, rename: Callable[[str], str] | None
+) -> str:
+    if rename:
+        return rename(name)
+    if suffix:
+        stem, ext = splitext(name)
+        return f"{stem}{suffix}{ext}"
+    return name
+
+
 @step
 def copy(
     logs: list[EvalLog],
     *,
     dest: str,
     source_prefix: str | None = None,
+    suffix: str | None = None,
+    rename: Callable[[str], str] | None = None,
     overwrite: bool = False,
     store: FlowStore | str | None = None,  # noqa: ARG001 handled by @step wrapper
 ) -> list[EvalLog]:
@@ -33,20 +49,26 @@ def copy(
         logs: list of EvalLog to copy.
         dest: Destination directory (local or S3).
         source_prefix: Directory prefix to strip from source paths. Without this option, files are copied flat into the destination. When provided, preserves directory structure relative to the prefix.
+        suffix: Suffix inserted before the file extension of each copy (e.g. `+realigned` copies `probe.eval` to `probe+realigned.eval`). Mutually exclusive with rename.
+        rename: Function mapping source filename to destination filename. Python-only. Mutually exclusive with suffix.
         overwrite: Overwrite existing files at the destination.
         store: Optional flow store. The copied log is added to the store.
 
     Returns:
         EvalLog at the destination location.
     """
+    if suffix and rename:
+        raise ValueError("Provide either suffix or rename, not both.")
+
     with step_context(logs) as context:
         context.write_dirty()
 
         dest_paths: list[str] = []
         for log in logs:
-            dest_path = (
-                dest.rstrip("/") + "/" + _relative_path(log.location, source_prefix)
-            )
+            rel_path = _relative_path(log.location, source_prefix)
+            rel_dir, _, name = rel_path.rpartition("/")
+            name = _dest_name(name, suffix, rename)
+            dest_path = "/".join(p for p in (dest.rstrip("/"), rel_dir, name) if p)
             if not overwrite and exists(dest_path):
                 flow_print(f"Skipping (already exists): {dest_path}", format="warning")
             elif not context.dry_run:

--- a/src/inspect_flow/_steps/copy.py
+++ b/src/inspect_flow/_steps/copy.py
@@ -49,7 +49,7 @@ def copy(
         logs: list of EvalLog to copy.
         dest: Destination directory (local or S3).
         source_prefix: Directory prefix to strip from source paths. Without this option, files are copied flat into the destination. When provided, preserves directory structure relative to the prefix.
-        suffix: Suffix inserted before the file extension of each copy (e.g. `+realigned` copies `probe.eval` to `probe+realigned.eval`). Mutually exclusive with rename.
+        suffix: Suffix inserted before the file extension of each copy (e.g. `+realigned` copies `probe.eval` to `probe+realigned.eval`). Mutually exclusive with the rename parameter (Python API only).
         rename: Function mapping source filename to destination filename. Python-only. Mutually exclusive with suffix.
         overwrite: Overwrite existing files at the destination.
         store: Optional flow store. The copied log is added to the store.

--- a/tests/config/file_step.py
+++ b/tests/config/file_step.py
@@ -1,14 +1,25 @@
+from __future__ import annotations
+
+from typing import Callable
+
 from inspect_ai.log import EvalLog, ProvenanceData, TagsEdit, edit_eval_log
 from inspect_flow._steps.step import step
 
 
 @step
-def file_step_a(logs: list[EvalLog], label: str = "default") -> list[EvalLog]:
+def file_step_a(
+    logs: list[EvalLog],
+    label: str = "default",
+    transform: Callable[[str], str] | None = None,
+) -> list[EvalLog]:
     """A test step loaded from a file.
 
     Args:
         label: A label to apply as a tag.
+        transform: Function applied to the label before tagging. Python-only.
     """
+    if transform:
+        label = transform(label)
     edits = [TagsEdit(tags_add=[label], tags_remove=[])]
     provenance = ProvenanceData(author="test")
     return [edit_eval_log(log, edits, provenance) for log in logs]

--- a/tests/config/file_step.py
+++ b/tests/config/file_step.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Callable
+from typing import Callable, Optional
 
 from inspect_ai.log import EvalLog, ProvenanceData, TagsEdit, edit_eval_log
 from inspect_flow._steps.step import step
@@ -26,6 +26,16 @@ def file_step_a(
 
 
 @step
-def file_step_b(logs: list[EvalLog]) -> list[EvalLog]:
-    """Another test step in the same file."""
-    return logs
+def file_step_b(
+    logs: list[EvalLog], labels: Optional[list[str]] = None
+) -> list[EvalLog]:
+    """Another test step in the same file.
+
+    Args:
+        labels: Labels to apply as tags.
+    """
+    if not labels:
+        return logs
+    edits = [TagsEdit(tags_add=list(labels), tags_remove=[])]
+    provenance = ProvenanceData(author="test")
+    return [edit_eval_log(log, edits, provenance) for log in logs]

--- a/tests/config/file_step.py
+++ b/tests/config/file_step.py
@@ -26,6 +26,20 @@ def file_step_a(
 
 
 @step
+def file_step_required_callable(
+    logs: list[EvalLog], transform: Callable[[str], str]
+) -> list[EvalLog]:
+    """A step with a required Python-only parameter.
+
+    Args:
+        transform: Function applied to each log's tags. Python-only.
+    """
+    edits = [TagsEdit(tags_add=[transform("tag")], tags_remove=[])]
+    provenance = ProvenanceData(author="test")
+    return [edit_eval_log(log, edits, provenance) for log in logs]
+
+
+@step
 def file_step_b(
     logs: list[EvalLog], labels: Optional[list[str]] = None
 ) -> list[EvalLog]:

--- a/tests/config/file_step_type_checking.py
+++ b/tests/config/file_step_type_checking.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from inspect_flow._steps.step import step
+
+if TYPE_CHECKING:
+    from inspect_ai.log import EvalLog
+
+
+@step
+def type_checking_step(logs: list[EvalLog], label: str = "default") -> list[EvalLog]:
+    """A step whose annotation imports are guarded by TYPE_CHECKING.
+
+    Args:
+        label: A label option.
+    """
+    return logs

--- a/tests/test_steps.py
+++ b/tests/test_steps.py
@@ -193,6 +193,42 @@ def test_copy_overwrite(tmp_path: Path) -> None:
     assert second.location == first.location
 
 
+def test_copy_with_suffix(tmp_path: Path) -> None:
+    log_path = _make_log(tmp_path / "src")
+    dest = str(tmp_path / "dest")
+    [result] = copy([log_path], dest=dest, suffix="+realigned")
+    assert Path(result.location).name == "test+realigned.eval"
+    reloaded = read_eval_log(result.location)
+    assert reloaded.eval.task == "test_task"
+    assert Path(log_path).exists()
+
+
+def test_copy_with_rename(tmp_path: Path) -> None:
+    log_path = _make_log(tmp_path / "src")
+    dest = str(tmp_path / "dest")
+    [result] = copy([log_path], dest=dest, rename=lambda name: f"renamed-{name}")
+    assert Path(result.location).name == "renamed-test.eval"
+    reloaded = read_eval_log(result.location)
+    assert reloaded.eval.task == "test_task"
+
+
+def test_copy_suffix_with_source_prefix(tmp_path: Path) -> None:
+    src_dir = tmp_path / "src" / "subdir"
+    src_dir.mkdir(parents=True)
+    log_path = _make_log(src_dir)
+    dest = str(tmp_path / "dest")
+    prefix = str(tmp_path / "src")
+    [result] = copy([log_path], dest=dest, source_prefix=prefix, suffix="+v2")
+    assert result.location.endswith("subdir/test+v2.eval")
+    assert Path(result.location).exists()
+
+
+def test_copy_error_suffix_and_rename(tmp_path: Path) -> None:
+    log_path = _make_log(tmp_path)
+    with pytest.raises(ValueError, match="suffix.*rename"):
+        copy([log_path], dest=str(tmp_path / "dest"), suffix="+a", rename=lambda n: n)
+
+
 def test_copy_via_run_step_with_source_prefix(tmp_path: Path) -> None:
     """run_step expands paths via list_eval_logs which returns file:/// URIs.
 
@@ -816,6 +852,8 @@ def test_cli_copy_help() -> None:
     assert result.exit_code == 0
     assert "--dest" in result.output
     assert "--source-prefix" in result.output
+    assert "--suffix" in result.output
+    assert "--rename" not in result.output
     assert "--args" not in result.output
     assert "--kwargs" not in result.output
 

--- a/tests/test_steps.py
+++ b/tests/test_steps.py
@@ -152,6 +152,23 @@ def test_relative_path_prefix_not_matching() -> None:
     assert _relative_path("/a/b/c/log.eval", "/x/y") == "log.eval"
 
 
+# --- _dest_path ---
+
+
+def test_dest_path_root_dest() -> None:
+    from inspect_flow._steps.copy import _dest_path
+
+    assert _dest_path("/", "sub", "test.eval") == "/sub/test.eval"
+    assert _dest_path("/", "", "test.eval") == "/test.eval"
+
+
+def test_dest_path_trailing_slash() -> None:
+    from inspect_flow._steps.copy import _dest_path
+
+    assert _dest_path("/a/b/", "sub", "test.eval") == "/a/b/sub/test.eval"
+    assert _dest_path("/a/b", "", "test.eval") == "/a/b/test.eval"
+
+
 # --- copy step ---
 
 

--- a/tests/test_steps.py
+++ b/tests/test_steps.py
@@ -1033,6 +1033,22 @@ def test_cli_file_step_type_checking_annotations() -> None:
     assert "--label" in result.output
 
 
+def test_cli_file_step_required_callable_errors() -> None:
+    """A step with a required Python-only param fails with a usage error.
+
+    The callable param can't be expressed on the CLI, so invoking the step
+    reports a clear error instead of crashing with a TypeError.
+    """
+    from click.testing import CliRunner
+    from inspect_flow._cli.step import step_command
+
+    result = CliRunner().invoke(
+        step_command, [FILE_STEP_PATH, "file_step_required_callable", "some.eval"]
+    )
+    assert result.exit_code == 2
+    assert "Python-only parameter(s) (transform)" in result.output
+
+
 def test_cli_file_step_optional_list_option(tmp_path: Path) -> None:
     """An Optional[list[str]] param maps to a repeatable CLI option."""
     from click.testing import CliRunner

--- a/tests/test_steps.py
+++ b/tests/test_steps.py
@@ -997,6 +997,40 @@ def test_cli_file_step_run(tmp_path: Path) -> None:
     assert "hello" in (reloaded.tags or [])
 
 
+def test_cli_file_step_type_checking_annotations() -> None:
+    """Steps with annotation imports guarded by TYPE_CHECKING still get a CLI.
+
+    eval_str annotation resolution raises NameError for such files; the CLI
+    falls back to the unevaluated signature instead of crashing.
+    """
+    from click.testing import CliRunner
+    from inspect_flow._cli.step import step_command
+
+    type_checking_path = str(
+        Path(__file__).parent / "config" / "file_step_type_checking.py"
+    )
+    result = CliRunner().invoke(
+        step_command, [type_checking_path, "type_checking", "--help"]
+    )
+    assert result.exit_code == 0
+    assert "--label" in result.output
+
+
+def test_cli_file_step_optional_list_option(tmp_path: Path) -> None:
+    """An Optional[list[str]] param maps to a repeatable CLI option."""
+    from click.testing import CliRunner
+    from inspect_flow._cli.step import step_command
+
+    log_path = _make_log(tmp_path)
+    result = CliRunner().invoke(
+        step_command,
+        [FILE_STEP_PATH, "file_step_b", "--labels", "a", "--labels", "b", log_path],
+    )
+    assert result.exit_code == 0
+    reloaded = read_eval_log(log_path, header_only=True)
+    assert {"a", "b"} <= set(reloaded.tags or [])
+
+
 def test_cli_file_step_at_syntax_run(tmp_path: Path) -> None:
     """flow step file.py@step_name PATH runs the step."""
     from click.testing import CliRunner

--- a/tests/test_steps.py
+++ b/tests/test_steps.py
@@ -875,6 +875,21 @@ def test_cli_copy_help() -> None:
     assert "--kwargs" not in result.output
 
 
+def test_cli_copy_suffix_run(tmp_path: Path) -> None:
+    """flow step copy PATH --dest DEST --suffix SUFFIX copies with the suffix."""
+    from click.testing import CliRunner
+    from inspect_flow._cli.step import step_command
+
+    log_path = _make_log(tmp_path / "src")
+    dest = str(tmp_path / "dest")
+    result = CliRunner().invoke(
+        step_command, ["copy", log_path, "--dest", dest, "--suffix", "+realigned"]
+    )
+    assert result.exit_code == 0
+    reloaded = read_eval_log(str(tmp_path / "dest" / "test+realigned.eval"))
+    assert reloaded.eval.task == "test_task"
+
+
 # --- etag concurrency guard ---
 
 

--- a/tests/test_steps.py
+++ b/tests/test_steps.py
@@ -956,13 +956,19 @@ def test_cli_file_step_group_help() -> None:
 
 
 def test_cli_file_step_subcommand_help() -> None:
-    """flow step file.py step_name --help shows that step's options."""
+    """flow step file.py step_name --help shows that step's options.
+
+    file_step.py uses `from __future__ import annotations`, so this also
+    verifies that stringized annotations are resolved: --label keeps its str
+    type and the callable --transform param is excluded from the CLI.
+    """
     from click.testing import CliRunner
     from inspect_flow._cli.step import step_command
 
     result = CliRunner().invoke(step_command, [FILE_STEP_PATH, "file_step_a", "--help"])
     assert result.exit_code == 0
     assert "--label" in result.output
+    assert "--transform" not in result.output
 
 
 def test_cli_file_step_at_syntax_help() -> None:


### PR DESCRIPTION
Fixes #756

Adds two ways to derive the destination filename in the built-in copy
step: suffix inserts a marker before the file extension (CLI-friendly
via --suffix), and rename maps source basename to destination basename
(Python-only). Both apply after source_prefix handling, so returned
headers, dirty-tracking, and store registration see only the final paths.

Callable-annotated step params are now skipped when generating CLI
options, since they cannot be expressed on the command line.

Closes #756

Co-authored-by: Ransom Richardson <32793463+alexandraabbas@users.noreply.github.com>