### PR TITLE
chore: regenerate release-please config (drop invalid key, hide docs/chore/refactor)

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -21,15 +21,18 @@
         },
         {
           "type": "refactor",
-          "section": "Code Refactoring"
+          "section": "Code Refactoring",
+          "hidden": true
         },
         {
           "type": "docs",
-          "section": "Documentation"
+          "section": "Documentation",
+          "hidden": true
         },
         {
           "type": "chore",
-          "section": "Miscellaneous"
+          "section": "Miscellaneous",
+          "hidden": true
         },
         {
           "type": "build",
@@ -51,10 +54,7 @@
           "section": "Styles",
           "hidden": true
         }
-      ],
-      "release-notes-config": {
-        "grouping": true
-      }
+      ]
     }
   }
 }


### PR DESCRIPTION
Regenerates the committed release-please config from the fixed generator.

Changes:
- Removes the invalid \`release-notes-config: { grouping: true }\` key (not a valid release-please config option).
- Hides the \`docs\`, \`chore\`, and \`refactor\` changelog sections so release notes surface only \`feat\`/\`fix\`/\`perf\`/\`revert\`.

Mirrors meridianlabs-ai/actions#64 / #65.

No change to release-type (\`python\`), tag-format (\`v\`), or versioning (default) — only changelog presentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)