### PR TITLE
fix: verify FlowTask.version matches loaded task version instead of overwriting

### DIFF
--- a/src/inspect_flow/_runner/instantiate.py
+++ b/src/inspect_flow/_runner/instantiate.py
@@ -399,6 +399,13 @@ def _instantiate_task(spec: FlowSpec, flow_task: TaskSpec, base_dir: str) -> lis
     task_name = flow_task.name if len(tasks) == 1 else NOT_GIVEN
 
     for task in tasks:
+        if is_set(flow_task.version) and flow_task.version != task.version:
+            raise ValueError(
+                f"Task version mismatch for '{task.name}': flow config specifies "
+                f"version {flow_task.version!r} but the loaded task has version "
+                f"{task.version!r}"
+            )
+
         if is_set(flow_task.sample_id):
             task.dataset = slice_dataset(
                 task.dataset,
@@ -447,7 +454,6 @@ def _instantiate_task(spec: FlowSpec, flow_task: TaskSpec, base_dir: str) -> lis
             cost_limit=ng(flow_task.cost_limit),
             early_stopping=ng(flow_task.early_stopping),
             name=ng(task_name),
-            version=ng(flow_task.version),
             metadata=ng(flow_task.metadata),
             tags=ng(tags),
         )

--- a/src/inspect_flow/_types/flow_types.py
+++ b/src/inspect_flow/_types/flow_types.py
@@ -454,7 +454,7 @@ class FlowTask(FlowBase, arbitrary_types_allowed=True):
 
     version: int | str | NotGiven = Field(
         default=not_given,
-        description="Version of task (to distinguish evolutions of the task spec or breaking changes to it)",
+        description="Expected version of the task. Verified against the version of the loaded task; instantiation fails if they do not match.",
     )
 
     tags: Sequence[str] | None | NotGiven = Field(

--- a/src/inspect_flow/_types/generated.py
+++ b/src/inspect_flow/_types/generated.py
@@ -208,7 +208,7 @@ class FlowTaskDict(TypedDict, closed=True):
     early_stopping: NotRequired[NotGiven | None]
     """Early stopping callbacks."""
     version: NotRequired[int | str | NotGiven]
-    """Version of task (to distinguish evolutions of the task spec or breaking changes to it)"""
+    """Expected version of the task. Verified against the version of the loaded task; instantiation fails if they do not match."""
     tags: NotRequired[Sequence[str] | NotGiven | None]
     """Tags to associate with the task."""
     metadata: NotRequired[Mapping[str, Any] | NotGiven | None]

--- a/tests/test_instantiate.py
+++ b/tests/test_instantiate.py
@@ -305,6 +305,33 @@ def test_factory_str() -> None:
 
 
 @task
+def versioned_task() -> Task:
+    return Task(version=2)
+
+
+def test_version_match() -> None:
+    spec = FlowSpec(tasks=[FlowTask(name="versioned_task", version=2)])
+    tasks = instantiate_tasks(spec=spec, base_dir=".")
+    assert len(tasks) == 1
+    assert tasks[0].task.version == 2
+
+
+def test_version_mismatch_raises() -> None:
+    spec = FlowSpec(tasks=[FlowTask(name="versioned_task", version=1)])
+    with pytest.raises(ValueError) as e:
+        instantiate_tasks(spec=spec, base_dir=".")
+    assert "Task version mismatch for 'versioned_task'" in str(e.value)
+    assert "version 1" in str(e.value)
+    assert "version 2" in str(e.value)
+
+
+def test_version_not_set_preserves_loaded_version() -> None:
+    spec = FlowSpec(tasks=[FlowTask(name="versioned_task")])
+    tasks = instantiate_tasks(spec=spec, base_dir=".")
+    assert tasks[0].task.version == 2
+
+
+@task
 def instantiate_error_task() -> Task:
     raise ValueError("Instantiation Error")
 


### PR DESCRIPTION
Fixes #759

Setting version on a FlowTask previously overwrote the version of the
loaded task via task_with, silently masking a mismatch between the flow
config and the task code. Now the configured version is verified against
the loaded task's version and instantiation fails if they differ.

Fixes #759

Co-authored-by: Ransom Richardson <1209015+ransomr@users.noreply.github.com>
Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>