### PR TITLE
ci: trigger @claude/@auto when added via a comment edit

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -41,6 +41,12 @@ jobs:
     # (the only `edited` action we subscribe to), fire only when the edit newly
     # introduced @claude — comparing against the pre-edit body — so re-editing a
     # comment that already mentioned @claude does not re-trigger a run.
+    # Known limitation: contains() is a substring test, looser than the action's
+    # word-boundary trigger. A pre-edit body that held @claude only as a
+    # NON-triggering substring (in backticks, or a token like foo@claude) blocks
+    # the edit path — adding a real @claude later still sees the old substring.
+    # Acceptable for a cheap gate (workflow expressions have no regex); the
+    # action remains the authoritative check on whatever does fire.
     if: |
       ( github.event.action == 'edited'
         && contains(github.event.comment.body, '@claude')

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -17,9 +17,16 @@ name: Claude
 # two never fire; only top-level @claude comments (issue_comment) and the
 # `claude` label (issues) work. Drop the two review triggers in that setup so
 # the surface matches reality (the fork's deployed stub does).
+#
+# `issue_comment: edited` is included so that ADDING @claude/@auto to an
+# existing comment (a common way people invoke the agent after the fact) fires
+# the workflow — GitHub only delivers the edited action when it's subscribed
+# here. The job `if:` below guards it to edits that newly introduce the phrase
+# (via github.event.changes.body.from), so re-editing a comment that already
+# mentioned the agent does NOT re-trigger it.
 on:
   issue_comment:
-    types: [created]
+    types: [created, edited]
   pull_request_review_comment:
     types: [created]
   pull_request_review:
@@ -30,13 +37,21 @@ on:
 jobs:
   claude:
     # Cheap gate to avoid spending runner minutes on unrelated events; the
-    # action does its own authoritative trigger check.
+    # action does its own authoritative trigger check. On an edited comment
+    # (the only `edited` action we subscribe to), fire only when the edit newly
+    # introduced @claude — comparing against the pre-edit body — so re-editing a
+    # comment that already mentioned @claude does not re-trigger a run.
     if: |
-      contains(github.event.comment.body, '@claude') ||
-      contains(github.event.review.body, '@claude') ||
-      contains(github.event.issue.body, '@claude') ||
-      contains(github.event.issue.title, '@claude') ||
-      github.event.label.name == 'claude'
+      ( github.event.action == 'edited'
+        && contains(github.event.comment.body, '@claude')
+        && !contains(github.event.changes.body.from, '@claude') ) ||
+      ( github.event.action != 'edited' && (
+          contains(github.event.comment.body, '@claude') ||
+          contains(github.event.review.body, '@claude') ||
+          contains(github.event.issue.body, '@claude') ||
+          contains(github.event.issue.title, '@claude') ||
+          github.event.label.name == 'claude'
+      ) )
     uses: meridianlabs-ai/agents/.github/workflows/claude.yml@main
     # Pass the machine-account PAT (MARVIN_TOKEN, an org secret) through to the
     # reusable workflow so agent-opened PRs trigger CI and @review. Passed
@@ -62,12 +77,21 @@ jobs:
   # action's trigger_phrase/label_trigger are single-valued, so `auto` needs its
   # own invocation. Needs MARVIN_TOKEN (the PR must trigger CI/@review).
   claude-auto:
+    # See the `claude` job's `if:` — same edited-comment guard, so adding @auto
+    # to an existing comment kicks off the autonomous loop but re-editing a
+    # comment that already mentioned @auto does not re-fire it (which could
+    # otherwise open a duplicate PR).
     if: |
-      contains(github.event.comment.body, '@auto') ||
-      contains(github.event.review.body, '@auto') ||
-      contains(github.event.issue.body, '@auto') ||
-      contains(github.event.issue.title, '@auto') ||
-      github.event.label.name == 'auto'
+      ( github.event.action == 'edited'
+        && contains(github.event.comment.body, '@auto')
+        && !contains(github.event.changes.body.from, '@auto') ) ||
+      ( github.event.action != 'edited' && (
+          contains(github.event.comment.body, '@auto') ||
+          contains(github.event.review.body, '@auto') ||
+          contains(github.event.issue.body, '@auto') ||
+          contains(github.event.issue.title, '@auto') ||
+          github.event.label.name == 'auto'
+      ) )
     uses: meridianlabs-ai/agents/.github/workflows/claude.yml@main
     secrets:
       MARVIN_TOKEN: ${{ secrets.MARVIN_TOKEN }}


### PR DESCRIPTION
### Problem
The `claude.yml` stub subscribed `issue_comment` to only `created`. Editing an existing comment to add `@claude` or `@auto` fires an `issue_comment` event with `action: edited`, which GitHub does not deliver unless the workflow subscribes to it — so the invocation was silently dropped.

### Fix
- Subscribe `issue_comment` to `[created, edited]`.
- Guard both the `claude` and `claude-auto` job `if:` gates so an `edited` event fires **only when the edit newly introduced** the phrase (comparing `github.event.comment.body` against `github.event.changes.body.from`). Re-editing a comment that already mentioned the agent does **not** re-trigger — important for `@auto`, where a spurious re-fire could open a duplicate PR.
- `created` behavior is unchanged.

Mirrors `meridianlabs-ai/agents` `examples/claude-stub.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)