### PR TITLE
ci: @i-am-marvin and @marvin as aliases for @claude

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -37,51 +37,58 @@ on:
 jobs:
   claude:
     # Cheap gate to avoid spending runner minutes on unrelated events; the
-    # action does its own authoritative trigger check. Three phrases are aliases
-    # for the one-shot dev agent: @claude, plus — now that the machine account
-    # exists — @i-am-marvin (resolves to that GitHub user) and @marvin (does
-    # not). They all do the same thing; the action's trigger_phrase is
-    # single-valued, so `with.trigger_phrase` below picks whichever is present
-    # and this gate just fires if any is.
+    # action does its own authoritative trigger check. Two phrases summon the
+    # one-shot dev agent: @claude and @i-am-marvin (the machine account — a real
+    # user, so the mention resolves to it and pings nothing else). They do the
+    # same thing; the action's trigger_phrase is single-valued, so
+    # `with.trigger_phrase` below resolves which phrase the *event's own text*
+    # contains (comment body for a comment, review body for a review, issue
+    # body/title for an issue — the same source the action checks) and this gate
+    # fires if that text has either phrase.
     #
-    # Machine-account guard: ignore comments authored by the machine account
-    # itself (i-am-marvin) so a marvin-authored comment that happens to contain
-    # its own name (or @claude) can't self-trigger the dev agent and loop.
+    # Machine-account guard: github.actor != 'i-am-marvin' over the whole gate,
+    # so a comment/review/issue authored by the machine account can't self-
+    # trigger the dev agent and loop (its own output — and the fork guidance —
+    # can contain @claude/@i-am-marvin). Hoisted rather than per-source: the
+    # sources are OR'd, so guarding only the comment branch is bypassable by a
+    # phrase left in the enclosing issue body/title.
+    #
+    # Sources are scoped to the event that carries them (github.event.action /
+    # event_name), so a comment event is judged by the comment alone — a stale
+    # @claude in the enclosing issue can't fire a runner-spin for an unrelated
+    # comment, nor mask an alias typed in the comment.
     #
     # On an edited comment (the only `edited` action we subscribe to), fire only
-    # when the edit newly introduced a trigger phrase — comparing against the
-    # pre-edit body — so re-editing a comment that already mentioned one does not
+    # when the edit newly introduced a phrase — comparing against the pre-edit
+    # body — so re-editing a comment that already mentioned one does not
     # re-trigger. Known limitation: contains() is a substring test, looser than
     # the action's word-boundary trigger; a pre-edit body holding a phrase only
     # as a NON-triggering substring (in backticks, or a token like foo@claude)
-    # blocks the edit path. Acceptable for a cheap gate (workflow expressions
-    # have no regex); the action remains the authoritative check on what fires.
+    # blocks the edit path. Acceptable for a cheap gate (no regex in workflow
+    # expressions); the action remains the authoritative check on what fires.
     if: |
-      ( github.event.action == 'edited'
-        && github.event.comment.user.login != 'i-am-marvin'
-        && ( contains(github.event.comment.body, '@claude')
-          || contains(github.event.comment.body, '@i-am-marvin')
-          || contains(github.event.comment.body, '@marvin') )
-        && !( contains(github.event.changes.body.from, '@claude')
-          || contains(github.event.changes.body.from, '@i-am-marvin')
-          || contains(github.event.changes.body.from, '@marvin') ) ) ||
-      ( github.event.action != 'edited' && (
-          ( github.event.comment.user.login != 'i-am-marvin' && (
-              contains(github.event.comment.body, '@claude') ||
-              contains(github.event.comment.body, '@i-am-marvin') ||
-              contains(github.event.comment.body, '@marvin')
-          ) ) ||
-          contains(github.event.review.body, '@claude') ||
-          contains(github.event.review.body, '@i-am-marvin') ||
-          contains(github.event.review.body, '@marvin') ||
-          contains(github.event.issue.body, '@claude') ||
-          contains(github.event.issue.body, '@i-am-marvin') ||
-          contains(github.event.issue.body, '@marvin') ||
-          contains(github.event.issue.title, '@claude') ||
-          contains(github.event.issue.title, '@i-am-marvin') ||
-          contains(github.event.issue.title, '@marvin') ||
-          github.event.label.name == 'claude'
-      ) )
+      github.actor != 'i-am-marvin' && (
+        ( github.event.action == 'edited'
+          && ( contains(github.event.comment.body, '@claude')
+            || contains(github.event.comment.body, '@i-am-marvin') )
+          && !( contains(github.event.changes.body.from, '@claude')
+            || contains(github.event.changes.body.from, '@i-am-marvin') ) ) ||
+        ( github.event.action == 'created' && (
+            contains(github.event.comment.body, '@claude') ||
+            contains(github.event.comment.body, '@i-am-marvin')
+        ) ) ||
+        ( github.event.action == 'submitted' && (
+            contains(github.event.review.body, '@claude') ||
+            contains(github.event.review.body, '@i-am-marvin')
+        ) ) ||
+        ( github.event_name == 'issues' && (
+            contains(github.event.issue.body, '@claude') ||
+            contains(github.event.issue.body, '@i-am-marvin') ||
+            contains(github.event.issue.title, '@claude') ||
+            contains(github.event.issue.title, '@i-am-marvin') ||
+            github.event.label.name == 'claude'
+        ) )
+      )
     uses: meridianlabs-ai/agents/.github/workflows/claude.yml@main
     # Pass the machine-account PAT (MARVIN_TOKEN, an org secret) through to the
     # reusable workflow so agent-opened PRs trigger CI and @review. Passed
@@ -100,22 +107,20 @@ jobs:
       id-token: write
       actions: read
     with:
-      # trigger_phrase is single-valued; pick whichever alias is present so the
-      # action's own word-boundary check matches what the user typed. @claude
-      # first (most common), then @i-am-marvin, else @marvin (the gate above
-      # guarantees one of the three matched, so @marvin is the safe fallback).
+      # trigger_phrase is single-valued, so resolve it from the SAME source the
+      # action will check for this event (comment > review > issue), not from a
+      # union of all sources — otherwise a stale @claude in an enclosing issue
+      # would mask an @i-am-marvin typed in a comment, resolving @claude and
+      # then no-op'ing (the action only checks the comment body on a comment
+      # event). Within a source, default @claude and only switch to
+      # @i-am-marvin when that's what's present; the trailing @claude covers the
+      # `claude` label event and is a harmless fallback.
       trigger_phrase: >-
         ${{
-        (contains(github.event.comment.body, '@claude') ||
-        contains(github.event.review.body, '@claude') ||
-        contains(github.event.issue.body, '@claude') ||
-        contains(github.event.issue.title, '@claude') ||
-        github.event.label.name == 'claude') && '@claude' ||
-        (contains(github.event.comment.body, '@i-am-marvin') ||
-        contains(github.event.review.body, '@i-am-marvin') ||
-        contains(github.event.issue.body, '@i-am-marvin') ||
-        contains(github.event.issue.title, '@i-am-marvin')) && '@i-am-marvin' ||
-        '@marvin'
+        github.event.comment && (contains(github.event.comment.body, '@i-am-marvin') && '@i-am-marvin' || '@claude') ||
+        github.event.review && (contains(github.event.review.body, '@i-am-marvin') && '@i-am-marvin' || '@claude') ||
+        (contains(github.event.issue.body, '@i-am-marvin') || contains(github.event.issue.title, '@i-am-marvin')) && '@i-am-marvin' ||
+        '@claude'
         }}
 
   # @auto kickoff (distinct from the one-shot `claude` above). An `auto` label or
@@ -128,18 +133,22 @@ jobs:
     # See the `claude` job's `if:` — same edited-comment guard, so adding @auto
     # to an existing comment kicks off the autonomous loop but re-editing a
     # comment that already mentioned @auto does not re-fire it (which could
-    # otherwise open a duplicate PR).
+    # otherwise open a duplicate PR). Same machine-account guard too: @auto is
+    # the loop-prone trigger, so keep the machine account from kicking it off
+    # (nothing in the designed loop relies on marvin posting @auto).
     if: |
-      ( github.event.action == 'edited'
-        && contains(github.event.comment.body, '@auto')
-        && !contains(github.event.changes.body.from, '@auto') ) ||
-      ( github.event.action != 'edited' && (
-          contains(github.event.comment.body, '@auto') ||
-          contains(github.event.review.body, '@auto') ||
-          contains(github.event.issue.body, '@auto') ||
-          contains(github.event.issue.title, '@auto') ||
-          github.event.label.name == 'auto'
-      ) )
+      github.actor != 'i-am-marvin' && (
+        ( github.event.action == 'edited'
+          && contains(github.event.comment.body, '@auto')
+          && !contains(github.event.changes.body.from, '@auto') ) ||
+        ( github.event.action != 'edited' && (
+            contains(github.event.comment.body, '@auto') ||
+            contains(github.event.review.body, '@auto') ||
+            contains(github.event.issue.body, '@auto') ||
+            contains(github.event.issue.title, '@auto') ||
+            github.event.label.name == 'auto'
+        ) )
+      )
     uses: meridianlabs-ai/agents/.github/workflows/claude.yml@main
     secrets:
       MARVIN_TOKEN: ${{ secrets.MARVIN_TOKEN }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -115,6 +115,14 @@ jobs:
       # event). Within a source, default @claude and only switch to
       # @i-am-marvin when that's what's present; the trailing @claude covers the
       # `claude` label event and is a harmless fallback.
+      # Caveat: this pick is substring-based (workflow expressions have no
+      # regex), so it also SELECTS which phrase the action then re-checks with
+      # word boundaries. In the contrived case where the other phrase appears
+      # only as a NON-triggering substring (backticked, or glued into a token
+      # like foo@i-am-marvin) a genuine trigger can be mis-resolved and no-op,
+      # not merely cost gate minutes. Accepted: the collision needs someone to,
+      # in one comment, write one phrase for real and the other as a bare
+      # substring — and both phrases route to the same dev agent anyway.
       trigger_phrase: >-
         ${{
         github.event.comment && (contains(github.event.comment.body, '@i-am-marvin') && '@i-am-marvin' || '@claude') ||

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -37,25 +37,49 @@ on:
 jobs:
   claude:
     # Cheap gate to avoid spending runner minutes on unrelated events; the
-    # action does its own authoritative trigger check. On an edited comment
-    # (the only `edited` action we subscribe to), fire only when the edit newly
-    # introduced @claude — comparing against the pre-edit body — so re-editing a
-    # comment that already mentioned @claude does not re-trigger a run.
-    # Known limitation: contains() is a substring test, looser than the action's
-    # word-boundary trigger. A pre-edit body that held @claude only as a
-    # NON-triggering substring (in backticks, or a token like foo@claude) blocks
-    # the edit path — adding a real @claude later still sees the old substring.
-    # Acceptable for a cheap gate (workflow expressions have no regex); the
-    # action remains the authoritative check on whatever does fire.
+    # action does its own authoritative trigger check. Three phrases are aliases
+    # for the one-shot dev agent: @claude, plus — now that the machine account
+    # exists — @i-am-marvin (resolves to that GitHub user) and @marvin (does
+    # not). They all do the same thing; the action's trigger_phrase is
+    # single-valued, so `with.trigger_phrase` below picks whichever is present
+    # and this gate just fires if any is.
+    #
+    # Machine-account guard: ignore comments authored by the machine account
+    # itself (i-am-marvin) so a marvin-authored comment that happens to contain
+    # its own name (or @claude) can't self-trigger the dev agent and loop.
+    #
+    # On an edited comment (the only `edited` action we subscribe to), fire only
+    # when the edit newly introduced a trigger phrase — comparing against the
+    # pre-edit body — so re-editing a comment that already mentioned one does not
+    # re-trigger. Known limitation: contains() is a substring test, looser than
+    # the action's word-boundary trigger; a pre-edit body holding a phrase only
+    # as a NON-triggering substring (in backticks, or a token like foo@claude)
+    # blocks the edit path. Acceptable for a cheap gate (workflow expressions
+    # have no regex); the action remains the authoritative check on what fires.
     if: |
       ( github.event.action == 'edited'
-        && contains(github.event.comment.body, '@claude')
-        && !contains(github.event.changes.body.from, '@claude') ) ||
+        && github.event.comment.user.login != 'i-am-marvin'
+        && ( contains(github.event.comment.body, '@claude')
+          || contains(github.event.comment.body, '@i-am-marvin')
+          || contains(github.event.comment.body, '@marvin') )
+        && !( contains(github.event.changes.body.from, '@claude')
+          || contains(github.event.changes.body.from, '@i-am-marvin')
+          || contains(github.event.changes.body.from, '@marvin') ) ) ||
       ( github.event.action != 'edited' && (
-          contains(github.event.comment.body, '@claude') ||
+          ( github.event.comment.user.login != 'i-am-marvin' && (
+              contains(github.event.comment.body, '@claude') ||
+              contains(github.event.comment.body, '@i-am-marvin') ||
+              contains(github.event.comment.body, '@marvin')
+          ) ) ||
           contains(github.event.review.body, '@claude') ||
+          contains(github.event.review.body, '@i-am-marvin') ||
+          contains(github.event.review.body, '@marvin') ||
           contains(github.event.issue.body, '@claude') ||
+          contains(github.event.issue.body, '@i-am-marvin') ||
+          contains(github.event.issue.body, '@marvin') ||
           contains(github.event.issue.title, '@claude') ||
+          contains(github.event.issue.title, '@i-am-marvin') ||
+          contains(github.event.issue.title, '@marvin') ||
           github.event.label.name == 'claude'
       ) )
     uses: meridianlabs-ai/agents/.github/workflows/claude.yml@main
@@ -75,6 +99,24 @@ jobs:
       issues: write
       id-token: write
       actions: read
+    with:
+      # trigger_phrase is single-valued; pick whichever alias is present so the
+      # action's own word-boundary check matches what the user typed. @claude
+      # first (most common), then @i-am-marvin, else @marvin (the gate above
+      # guarantees one of the three matched, so @marvin is the safe fallback).
+      trigger_phrase: >-
+        ${{
+        (contains(github.event.comment.body, '@claude') ||
+        contains(github.event.review.body, '@claude') ||
+        contains(github.event.issue.body, '@claude') ||
+        contains(github.event.issue.title, '@claude') ||
+        github.event.label.name == 'claude') && '@claude' ||
+        (contains(github.event.comment.body, '@i-am-marvin') ||
+        contains(github.event.review.body, '@i-am-marvin') ||
+        contains(github.event.issue.body, '@i-am-marvin') ||
+        contains(github.event.issue.title, '@i-am-marvin')) && '@i-am-marvin' ||
+        '@marvin'
+        }}
 
   # @auto kickoff (distinct from the one-shot `claude` above). An `auto` label or
   # `@auto` mention drives the issue autonomously: the dev agent opens a PR, the


### PR DESCRIPTION
Now that the `i-am-marvin` machine account exists, let people summon the one-shot dev agent by its name, in addition to `@claude`:

- **`@i-am-marvin`** — resolves to our machine account (autocompletes, pings us, not a stranger).

Both do exactly what `@claude` does.

### How
`claude-code-action`'s `trigger_phrase` is single-valued, so:
- The cheap `if:` gate fires if either phrase is present **in the event's own source** (comment body for a comment, review body for a review, issue body/title for an issue).
- `with.trigger_phrase` resolves **which** phrase from that same source (defaults to `@claude`), matching what the action's authoritative word-boundary check will look at.

### Correctness fixes (from review)
- **Source-scoped resolution:** an earlier draft scanned all sources at once, so a stale `@claude` in an enclosing issue masked an `@i-am-marvin` typed in a comment (resolved `@claude` → action found nothing in the comment → silent no-op). Now resolved per-source.
- **Guard hoisted:** `github.actor != 'i-am-marvin'` wraps the whole gate (previously only the comment branch, which was bypassable via the unguarded issue disjuncts). Same guard added to `claude-auto` as defense-in-depth.
- **Dropped `@marvin`:** it resolves to an unrelated GitHub user (`github.com/Marvin`, case-insensitive logins) and can't be triggered without pinging them — there's no way to match it that isn't also a live mention. `@i-am-marvin` (our own account) is the only added alias.

Mirrors `meridianlabs-ai/agents` `examples/claude-stub.yml` (already at `@main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)