### PR TITLE
fix: reconcile with inspect-ai 0.3.248 (cloudflare provider rename)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,7 @@ default-groups = ["dev"]
 # API surface, advanced by .github/workflows/inspect-update.yml. Independent of
 # the `inspect-ai>=` dependency floor, which is only raised when a release
 # would completely break flow on older versions.
-inspect-reconciled-version = "0.3.246"
+inspect-reconciled-version = "0.3.248"
 
 [tool.pyright]
 include = ["src", "tests", "examples"]

--- a/src/inspect_flow/_launcher/auto_dependencies.py
+++ b/src/inspect_flow/_launcher/auto_dependencies.py
@@ -37,7 +37,8 @@ _MODEL_PROVIDERS: dict[str, list[str]] = {
     "google": ["google-genai"],
     "hf": ["torch", "transformers", "accelerate"],
     "vllm": ["vllm"],
-    "cf": [],
+    "cf": [],  # renamed to "cloudflare" in inspect-ai 0.3.248
+    "cloudflare": [],
     "mistral": ["mistralai"],
     "grok": ["xai_sdk"],
     "together": ["openai"],

--- a/src/inspect_flow/_launcher/auto_dependencies.py
+++ b/src/inspect_flow/_launcher/auto_dependencies.py
@@ -37,8 +37,8 @@ _MODEL_PROVIDERS: dict[str, list[str]] = {
     "google": ["google-genai"],
     "hf": ["torch", "transformers", "accelerate"],
     "vllm": ["vllm"],
-    "cf": [],  # renamed to "cloudflare" in inspect-ai 0.3.248
-    "cloudflare": [],
+    "cf": ["openai"],  # renamed to "cloudflare" in inspect-ai 0.3.248
+    "cloudflare": ["openai"],
     "mistral": ["mistralai"],
     "grok": ["xai_sdk"],
     "together": ["openai"],

--- a/tests/test_venv.py
+++ b/tests/test_venv.py
@@ -290,6 +290,15 @@ def test_715_collect_auto_dependencies_exclude_packages() -> None:
     assert "inspect_evals" in excluded
 
 
+def test_cloudflare_provider_adds_no_dependencies() -> None:
+    # inspect-ai 0.3.248 renamed the "cf" provider to "cloudflare"; neither
+    # prefix requires an extra package, so nothing should be auto-detected.
+    for model in ["cf/meta/llama-3.1-8b-instruct", "cloudflare/moonshotai/kimi-k3"]:
+        spec = FlowSpec(tasks=[FlowTask(name="inspect_evals/task_name", model=model)])
+        dependencies = collect_auto_dependencies(spec)
+        assert dependencies == ["inspect_evals"]
+
+
 def test_no_auto_dependency() -> None:
     with tempfile.TemporaryDirectory() as temp_dir:
         with patch("subprocess.run") as mock_run:

--- a/tests/test_venv.py
+++ b/tests/test_venv.py
@@ -290,13 +290,16 @@ def test_715_collect_auto_dependencies_exclude_packages() -> None:
     assert "inspect_evals" in excluded
 
 
-def test_cloudflare_provider_adds_no_dependencies() -> None:
-    # inspect-ai 0.3.248 renamed the "cf" provider to "cloudflare"; neither
-    # prefix requires an extra package, so nothing should be auto-detected.
+def test_cloudflare_provider_adds_openai_dependency() -> None:
+    # inspect-ai 0.3.248 renamed the "cf" provider to "cloudflare"; both
+    # prefixes use an OpenAI-compatible API that requires the openai package.
     for model in ["cf/meta/llama-3.1-8b-instruct", "cloudflare/moonshotai/kimi-k3"]:
         spec = FlowSpec(tasks=[FlowTask(name="inspect_evals/task_name", model=model)])
         dependencies = collect_auto_dependencies(spec)
-        assert dependencies == ["inspect_evals"]
+        assert dependencies == [
+            "inspect_evals",
+            _get_pip_string_with_version("openai"),
+        ]
 
 
 def test_no_auto_dependency() -> None:


### PR DESCRIPTION
Fixes #769

## Changes

- Add `"cloudflare"` to `_MODEL_PROVIDERS` in the launcher's auto-dependency detection. inspect-ai 0.3.248 renamed the CloudFlare provider from `cf` to `cloudflare` (breaking); without an entry, a `cloudflare/...` model fell through to the unknown-provider default and flow attempted to `pip install cloudflare` into the venv. The `cf` entry is kept since flow's dependency floor is `inspect-ai>=0.3.246`, where the old prefix is still valid.
- Map both `cf` and `cloudflare` to `["openai"]`: `CloudFlareAPI` is built on `OpenAICompatibleAPI` and imports `openai` at module level (in both 0.3.246 and 0.3.248), and `openai` is not a runtime dependency of inspect-ai or inspect-flow, so a launcher-built venv needs it installed explicitly — same as the other OpenAI-compatible providers (`together`, `ollama`, `openrouter`, ...). This also fixes the pre-existing `"cf": []` entry.
- Add a test covering both provider prefixes in `tests/test_venv.py`.
- Advance `inspect-reconciled-version` to `0.3.248` in pyproject.toml (`uv lock` re-run; no lock changes).

No other 0.3.247–0.3.248 changelog entry maps to a flow surface — `Task` / `eval` / `eval_set` / `GenerateConfig` signatures are unchanged between the tags (docstring-only edits). Full reconciliation notes in #769. The locked inspect-ai version is not upgraded since nothing here references new inspect-ai APIs, and the dependency floor is unchanged.

## Verification

- `ruff format`, `ruff check`, `pyright`: clean
- `pytest`: 644 passed, 7 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)
