### PR TITLE
ci: harden inspect-ai reconciliation and canary-failure alerting

### DIFF
--- a/.github/workflows/inspect-ai-main-failure.yml
+++ b/.github/workflows/inspect-ai-main-failure.yml
@@ -1,0 +1,130 @@
+# Opens a tracking issue when the "Inspect AI Main CI" canary (which runs flow
+# against inspect-ai's git main every 3 hours) fails on a scheduled run.
+#
+# The canary going red means an unreleased inspect-ai change has broken flow —
+# a heads-up that a future release will need reconciliation. Rather than let
+# that fail silently every 3 hours, this opens ONE issue and keeps it as the
+# single source of truth: while it is open, later failures just add a comment
+# with the new run link instead of piling up duplicate issues. Closing the
+# issue (once flow is fixed) lets the next failure open a fresh one.
+#
+# Dedup is keyed on the `inspect-ai-main` label, not the failure signature: the
+# canary has one meaning ("flow is broken against inspect-ai main"), so one open
+# issue at a time is the right granularity.
+#
+# workflow_run only fires for workflow files on the default branch, so this
+# takes effect once merged to main. workflow_dispatch lets a human point it at a
+# specific failed run_id.
+
+name: Inspect AI Main Failure Issue
+
+on:
+  workflow_run:
+    workflows: ["Inspect AI Main CI"]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: "Run ID of a failed Inspect AI Main CI run to file"
+        required: true
+        type: string
+
+concurrency:
+  group: inspect-ai-main-failure
+  cancel-in-progress: false
+
+jobs:
+  open-issue:
+    # Only file for failed *scheduled* canary runs (skip successes and manual
+    # dispatches of the canary itself). A workflow_dispatch of THIS workflow
+    # always proceeds against the supplied run_id.
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'failure' &&
+       github.event.workflow_run.event == 'schedule')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+      issues: write
+    env:
+      # MARVIN_TOKEN (machine account) carries the `project` scope needed to add
+      # the issue to the org Atlas board; github.token cannot reach org
+      # projects. Fall back to github.token so issue create/comment still work
+      # where MARVIN_TOKEN is unavailable (the board step is best-effort).
+      GH_TOKEN: ${{ secrets.MARVIN_TOKEN || github.token }}
+      REPO: ${{ github.repository }}
+      RUN_ID: ${{ github.event.workflow_run.id || inputs.run_id }}
+      RUN_URL: ${{ github.event.workflow_run.html_url || format('https://github.com/{0}/actions/runs/{1}', github.repository, inputs.run_id) }}
+    steps:
+      - name: Collect failure context
+        run: |
+          set -uo pipefail
+          gh run view "$RUN_ID" --repo "$REPO" \
+            --json jobs,displayTitle,headBranch,headSha,url,createdAt > run.json || echo '{}' > run.json
+          gh run view "$RUN_ID" --repo "$REPO" --log-failed > failed.log 2>&1 || true
+          # Keep the last 200 lines of failed-step output — failures are near
+          # the end and the issue body must stay readable.
+          tail -n 200 failed.log > failed.tail.log || true
+
+      - name: Open or update tracking issue
+        run: |
+          set -uo pipefail
+
+          gh label create inspect-ai-main --repo "$REPO" \
+            --description "Flow broken against inspect-ai git main (canary CI)" \
+            --color B60205 2>/dev/null || true
+
+          existing=$(gh issue list --repo "$REPO" --state open \
+            --label inspect-ai-main --limit 1 --json number,url \
+            --jq '.[0].url // empty')
+
+          if [ -n "$existing" ]; then
+            echo "Existing open issue $existing — commenting instead of opening a new one."
+            gh issue comment "$existing" --repo "$REPO" --body "$(printf 'Still failing on a later run.\n\n- Failed run: %s\n- Triage run: https://github.com/%s/actions/runs/%s' "$RUN_URL" "$REPO" "$GITHUB_RUN_ID")"
+            exit 0
+          fi
+
+          failed_jobs=$(jq -r '.jobs // [] | map(select(.conclusion=="failure")) | if length==0 then "(none reported)" else map("- " + .name) | join("\n") end' run.json)
+          log_tail=$(cat failed.tail.log 2>/dev/null || echo "(no failed-step logs available)")
+
+          body=$(cat <<EOF
+          ## Summary
+
+          The [Inspect AI Main CI](.github/workflows/inspect_ai_main.yaml) canary — which installs inspect-ai from git \`main\` and runs flow against it — failed on a scheduled run. This usually means an unreleased inspect-ai change has broken flow and will need reconciliation before that release lands.
+
+          ## Failing jobs
+
+          $failed_jobs
+
+          ## Failed step output (last 200 lines)
+
+          <details>
+          <summary>failed.log</summary>
+
+          \`\`\`
+          $log_tail
+          \`\`\`
+
+          </details>
+
+          ## Links
+
+          - Failed run: $RUN_URL
+          - This issue was opened automatically by \`.github/workflows/inspect-ai-main-failure.yml\`.
+          EOF
+          )
+
+          url=$(gh issue create --repo "$REPO" \
+            --title "Inspect AI Main CI failing against inspect-ai main" \
+            --label inspect-ai-main \
+            --assignee ransomr \
+            --body "$body")
+          echo "Opened $url"
+
+          # Best-effort: add to the org Atlas board (needs MARVIN_TOKEN's project
+          # scope). Never fail the run if the token can't reach the project.
+          gh project item-add 1 --owner meridianlabs-ai --url "$url" || \
+            echo "Could not add to Atlas board (missing project scope?) — skipping."
+        env:
+          GITHUB_RUN_ID: ${{ github.run_id }}

--- a/.github/workflows/inspect-update.yml
+++ b/.github/workflows/inspect-update.yml
@@ -203,16 +203,31 @@ jobs:
                the best-effort flow changes:
                - Advance the reconciled marker in pyproject.toml:
                  [tool.inspect_flow] inspect-reconciled-version = "${{ needs.check.outputs.latest }}"
-                 then run `uv lock` so the uv-lock pre-commit/CI hook stays
-                 green.
-               - If your changes reference inspect-ai APIs introduced in these
-                 releases, also upgrade the locked version
-                 (`uv lock --upgrade-package inspect-ai` then `uv sync`) so
-                 checks run against the new release. Do NOT raise the
-                 `inspect-ai>=` dependency floor unless flow would be
-                 completely broken on older versions.
+               - Upgrade all locked dependencies (`uv lock --upgrade` then
+                 `uv sync`) so the pinned CI checks run against the reconciled
+                 inspect-ai release and the latest of everything else, rather
+                 than stale pins. Do NOT raise the `inspect-ai>=` dependency
+                 floor unless flow would be completely broken on older
+                 versions.
+               - Regenerate the generated types after the upgrade
+                 (`python src/inspect_flow/_types/type_gen.py`) and commit any
+                 changes. type_gen copies inspect-ai's type/docstring surface
+                 verbatim, so even a docstring-only upstream change makes
+                 generated.py stale; the check-type-gen CI job regenerates
+                 against the locked inspect-ai and fails if it differs.
                - Verify with `ruff format`, `ruff check --fix`, `pyright`, and
                  the relevant tests before pushing.
+               - If the full upgrade cannot produce a green build because a
+                 dependency has not caught up to the reconciled release (e.g.
+                 inspect-scout still imports a symbol inspect-ai renamed), do
+                 NOT commit a broken lock: hold the offending package(s) back
+                 at their last working version — either add a temporary
+                 upper-bound constraint in pyproject.toml and re-lock, or
+                 upgrade selectively with `uv lock --upgrade-package <pkg>` for
+                 only the packages that work — still advance the reconciled
+                 marker, and call out the blocking dependency in the issue with
+                 @ransomr so it can be picked up once the dependency releases a
+                 fix.
 
             5. Push the branch and open ONE PR:
                gh pr create --base main --label auto --label inspect-update ...

--- a/.github/workflows/inspect-update.yml
+++ b/.github/workflows/inspect-update.yml
@@ -220,14 +220,21 @@ jobs:
                - If the full upgrade cannot produce a green build because a
                  dependency has not caught up to the reconciled release (e.g.
                  inspect-scout still imports a symbol inspect-ai renamed), do
-                 NOT commit a broken lock: hold the offending package(s) back
-                 at their last working version — either add a temporary
-                 upper-bound constraint in pyproject.toml and re-lock, or
-                 upgrade selectively with `uv lock --upgrade-package <pkg>` for
-                 only the packages that work — still advance the reconciled
-                 marker, and call out the blocking dependency in the issue with
-                 @ransomr so it can be picked up once the dependency releases a
-                 fix.
+                 NOT commit a broken lock. Hold the offending package(s) back at
+                 their last working version by adding a temporary
+                 `constraint-dependencies` entry under `[tool.uv]` in
+                 pyproject.toml and re-locking (prefer this over an upper bound
+                 in `[project] dependencies`, which would ship in the published
+                 wheel's metadata and constrain downstream installs). If no
+                 released version of the lagging dependency works with the
+                 reconciled inspect-ai at all (every release still imports the
+                 renamed symbol), the only green lock is one that also keeps
+                 inspect-ai itself at its previously locked version — do that as
+                 the last resort rather than chasing an unsatisfiable "upgrade
+                 inspect-ai AND stay green". Either way, still advance the
+                 reconciled marker (it is independent of the locked version) and
+                 call out the blocking dependency in the issue with @ransomr so
+                 it can be picked up once the dependency releases a fix.
 
             5. Push the branch and open ONE PR:
                gh pr create --base main --label auto --label inspect-update ...


### PR DESCRIPTION
Two related CI-automation improvements around inspect-ai reconciliation.

## 1. inspect-update: upgrade the full lock and regenerate types

The weekly `inspect-update` agent advanced the `inspect-reconciled-version` marker but left `uv.lock` pinned to the *previous* inspect-ai release and never regenerated the generated types. So the pinned CI validated against a stale version, and an upstream `GenerateConfig.max_retries` docstring change in 0.3.248 only tripped the inspect-ai-main canary — not anywhere the agent could catch it.

Prompt-only changes to step 4 of [.github/workflows/inspect-update.yml](.github/workflows/inspect-update.yml):
- **Upgrade the whole lock** — `uv lock --upgrade` + `uv sync` (all packages), replacing the old conditional inspect-ai-only upgrade. `inspect-ai>=` floor still stays put unless flow is broken on older versions.
- **Regenerate types after the upgrade** — explicit `python src/inspect_flow/_types/type_gen.py` + commit, with rationale.
- **Graceful fallback** — if a lagging transitive dep makes a green build impossible (e.g. inspect-scout still importing a symbol inspect-ai renamed), hold that package back rather than committing a broken lock, still advance the marker, and flag the blocker.

## 2. Open a tracking issue when the inspect-ai-main canary fails

New workflow [.github/workflows/inspect-ai-main-failure.yml](.github/workflows/inspect-ai-main-failure.yml). The "Inspect AI Main CI" canary runs flow against inspect-ai git `main` every 3 hours; a failure previously produced no signal beyond a red run. On a failed *scheduled* canary run this:
- Opens **one** tracking issue (label `inspect-ai-main`, assigned to `ransomr`, added to the Atlas board), including the failed jobs and the last 200 lines of failed-step output.
- If such an issue is **already open**, comments on it with the new run link instead of opening a duplicate. Closing the issue lets the next failure open a fresh one.

Deterministic (no agent): dedup keys on the open `inspect-ai-main` label since the canary has a single meaning. Patterned on the trigger/log-fetch structure of `meridianlabs-ai/actions` `triage-test-failures`. `workflow_run` only fires for workflows on the default branch, so it takes effect once merged; `workflow_dispatch` lets a human file a specific `run_id`.

## Notes
- No runtime code changes; both are CI-only.
- The Atlas-board step needs `MARVIN_TOKEN`'s `project` scope and is best-effort (`|| true`); issue create/assign fall back to `github.token`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)