### PR TITLE
fix: reconcile with inspect-ai 0.3.249 (scout CLI import shim, moonshot provider, regenerated types)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,7 @@ default-groups = ["dev"]
 # API surface, advanced by .github/workflows/inspect-update.yml. Independent of
 # the `inspect-ai>=` dependency floor, which is only raised when a release
 # would completely break flow on older versions.
-inspect-reconciled-version = "0.3.248"
+inspect-reconciled-version = "0.3.249"
 
 [tool.pyright]
 include = ["src", "tests", "examples"]

--- a/src/inspect_flow/_launcher/auto_dependencies.py
+++ b/src/inspect_flow/_launcher/auto_dependencies.py
@@ -40,6 +40,7 @@ _MODEL_PROVIDERS: dict[str, list[str]] = {
     "cf": ["openai"],  # renamed to "cloudflare" in inspect-ai 0.3.248
     "cloudflare": ["openai"],
     "mistral": ["mistralai"],
+    "moonshot": ["openai"],  # added in inspect-ai 0.3.249
     "grok": ["xai_sdk"],
     "together": ["openai"],
     "fireworks": ["openai"],

--- a/src/inspect_flow/_steps/scan.py
+++ b/src/inspect_flow/_steps/scan.py
@@ -207,7 +207,7 @@ def scan(
                 "validation requires importing inspect_scout._cli, which failed. "
                 "This usually means the installed inspect-scout is incompatible "
                 "with the installed inspect-ai; upgrade inspect-scout to a version "
-                "compatible with the installed inspect-ai, or pin inspect-ai<0.3.248."
+                "compatible with the installed inspect-ai."
             ) from ex
 
         parsed_validation = _parse_validation(validation)

--- a/src/inspect_flow/_steps/scan.py
+++ b/src/inspect_flow/_steps/scan.py
@@ -206,7 +206,8 @@ def scan(
             raise PrerequisiteError(
                 "validation requires importing inspect_scout._cli, which failed. "
                 "This usually means the installed inspect-scout is incompatible "
-                "with the installed inspect-ai; upgrade inspect-scout."
+                "with the installed inspect-ai; upgrade inspect-scout to a version "
+                "compatible with the installed inspect-ai, or pin inspect-ai<0.3.248."
             ) from ex
 
         parsed_validation = _parse_validation(validation)

--- a/src/inspect_flow/_steps/scan.py
+++ b/src/inspect_flow/_steps/scan.py
@@ -28,7 +28,6 @@ from inspect_scout import (
 from inspect_scout import (
     scan as scout_scan,
 )
-from inspect_scout._cli.scan import _parse_validation
 from inspect_scout._project import read_project
 from inspect_scout._scanjob import (
     merge_project_into_scanjob,
@@ -195,7 +194,16 @@ def scan(
         scans = _canonical_path(scans) if scans else path_join(log_dir, "scans")
         _write_scout_project_file(scans=scans, transcripts=log_dir)
 
-    parsed_validation = _parse_validation(validation) if validation else None
+    if validation:
+        # Deferred: importing inspect_scout._cli pulls in inspect_ai._cli internals
+        # that can break when scout and inspect-ai versions are out of sync (e.g.
+        # scout <= 0.4.44 with inspect-ai >= 0.3.248), which would make all of
+        # inspect_flow.api unimportable if done at module level.
+        from inspect_scout._cli.scan import _parse_validation
+
+        parsed_validation = _parse_validation(validation)
+    else:
+        parsed_validation = None
     parsed_model_args = (
         parse_cli_config(m, model_config) if (m or model_config) else None
     )

--- a/src/inspect_flow/_steps/scan.py
+++ b/src/inspect_flow/_steps/scan.py
@@ -199,7 +199,14 @@ def scan(
         # that can break when scout and inspect-ai versions are out of sync (e.g.
         # scout <= 0.4.44 with inspect-ai >= 0.3.248), which would make all of
         # inspect_flow.api unimportable if done at module level.
-        from inspect_scout._cli.scan import _parse_validation
+        try:
+            from inspect_scout._cli.scan import _parse_validation
+        except ImportError as ex:
+            raise RuntimeError(
+                "validation requires importing inspect_scout._cli, which failed. "
+                "This usually means the installed inspect-scout is incompatible "
+                "with the installed inspect-ai; upgrade inspect-scout."
+            ) from ex
 
         parsed_validation = _parse_validation(validation)
     else:

--- a/src/inspect_flow/_steps/scan.py
+++ b/src/inspect_flow/_steps/scan.py
@@ -9,6 +9,7 @@ from inspect_ai._cli.util import (
     parse_model_role_cli_args,
 )
 from inspect_ai._util.config import resolve_args
+from inspect_ai._util.error import PrerequisiteError
 from inspect_ai._util.file import (
     absolute_file_path,
     dirname,
@@ -202,7 +203,7 @@ def scan(
         try:
             from inspect_scout._cli.scan import _parse_validation
         except ImportError as ex:
-            raise RuntimeError(
+            raise PrerequisiteError(
                 "validation requires importing inspect_scout._cli, which failed. "
                 "This usually means the installed inspect-scout is incompatible "
                 "with the installed inspect-ai; upgrade inspect-scout."

--- a/src/inspect_flow/_types/generated.py
+++ b/src/inspect_flow/_types/generated.py
@@ -281,7 +281,7 @@ class GenerateConfigDict(TypedDict):
     """Model generation options."""
 
     max_retries: NotRequired[int | None]
-    """Maximum number of times to retry request, so e.g. 1 allows two attempts total (defaults to unlimited)."""
+    """Maximum number of times to retry request (defaults to unlimited)."""
     timeout: NotRequired[int | None]
     """Timeout (in seconds) for an entire request (including retries)."""
     attempt_timeout: NotRequired[int | None]

--- a/src/inspect_flow/_types/generated.py
+++ b/src/inspect_flow/_types/generated.py
@@ -281,7 +281,7 @@ class GenerateConfigDict(TypedDict):
     """Model generation options."""
 
     max_retries: NotRequired[int | None]
-    """Maximum number of times to retry request (defaults to unlimited)."""
+    """Maximum number of times to retry request, so e.g. 1 allows two attempts total (defaults to unlimited)."""
     timeout: NotRequired[int | None]
     """Timeout (in seconds) for an entire request (including retries)."""
     attempt_timeout: NotRequired[int | None]

--- a/tests/test_steps.py
+++ b/tests/test_steps.py
@@ -1263,9 +1263,7 @@ def test_scan_validation_actionable_error_on_scout_import_failure(
     # simulating the version skew regardless of the installed scout version.
     monkeypatch.setitem(sys.modules, "inspect_scout._cli.scan", None)
 
-    with pytest.raises(
-        PrerequisiteError, match=r"upgrade inspect-scout.*pin inspect-ai<0\.3\.248"
-    ):
+    with pytest.raises(PrerequisiteError, match=r"upgrade inspect-scout"):
         scan([log], scanners=[], validation=("validation.yaml",))
 
 

--- a/tests/test_steps.py
+++ b/tests/test_steps.py
@@ -1263,7 +1263,9 @@ def test_scan_validation_actionable_error_on_scout_import_failure(
     # simulating the version skew regardless of the installed scout version.
     monkeypatch.setitem(sys.modules, "inspect_scout._cli.scan", None)
 
-    with pytest.raises(PrerequisiteError, match="upgrade inspect-scout"):
+    with pytest.raises(
+        PrerequisiteError, match=r"upgrade inspect-scout.*pin inspect-ai<0\.3\.248"
+    ):
         scan([log], scanners=[], validation=("validation.yaml",))
 
 

--- a/tests/test_steps.py
+++ b/tests/test_steps.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 import pytest
 from botocore.client import BaseClient
+from inspect_ai._util.error import PrerequisiteError
 from inspect_ai.log import (
     EvalConfig,
     EvalDataset,
@@ -1262,7 +1263,7 @@ def test_scan_validation_actionable_error_on_scout_import_failure(
     # simulating the version skew regardless of the installed scout version.
     monkeypatch.setitem(sys.modules, "inspect_scout._cli.scan", None)
 
-    with pytest.raises(RuntimeError, match="upgrade inspect-scout"):
+    with pytest.raises(PrerequisiteError, match="upgrade inspect-scout"):
         scan([log], scanners=[], validation=("validation.yaml",))
 
 

--- a/tests/test_steps.py
+++ b/tests/test_steps.py
@@ -1248,6 +1248,24 @@ def test_scan_default_scans_absolute_when_location_is_file_uri(
     assert project == {"transcripts": str(tmp_path), "scans": expected_scans}
 
 
+def test_scan_validation_actionable_error_on_scout_import_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When inspect_scout._cli is unimportable (scout/inspect-ai version skew),
+    scan(validation=...) raises an actionable error instead of a raw ImportError."""
+    import sys
+
+    from inspect_flow._steps.scan import scan
+
+    log = read_eval_log(_make_log(tmp_path))
+    # Setting a sys.modules entry to None makes its import raise ImportError,
+    # simulating the version skew regardless of the installed scout version.
+    monkeypatch.setitem(sys.modules, "inspect_scout._cli.scan", None)
+
+    with pytest.raises(RuntimeError, match="upgrade inspect-scout"):
+        scan([log], scanners=[], validation=("validation.yaml",))
+
+
 def test_cli_scan_help_describes_default_scans() -> None:
     """`flow step scan --help` documents the inferred --scans default."""
     from click.testing import CliRunner

--- a/tests/test_venv.py
+++ b/tests/test_venv.py
@@ -302,6 +302,19 @@ def test_cloudflare_provider_adds_openai_dependency() -> None:
         ]
 
 
+def test_moonshot_provider_adds_openai_dependency() -> None:
+    # inspect-ai 0.3.249 added the "moonshot" provider, which uses an
+    # OpenAI-compatible API that requires the openai package.
+    spec = FlowSpec(
+        tasks=[FlowTask(name="inspect_evals/task_name", model="moonshot/kimi-k3")]
+    )
+    dependencies = collect_auto_dependencies(spec)
+    assert dependencies == [
+        "inspect_evals",
+        _get_pip_string_with_version("openai"),
+    ]
+
+
 def test_no_auto_dependency() -> None:
     with tempfile.TemporaryDirectory() as temp_dir:
         with patch("subprocess.run") as mock_run:

--- a/uv.lock
+++ b/uv.lock
@@ -524,12 +524,12 @@ name = "black"
 version = "26.5.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click", marker = "python_full_version < '3.11' or sys_platform != 'emscripten'" },
-    { name = "mypy-extensions", marker = "python_full_version < '3.11' or sys_platform != 'emscripten'" },
-    { name = "packaging", marker = "python_full_version < '3.11' or sys_platform != 'emscripten'" },
-    { name = "pathspec", marker = "python_full_version < '3.11' or sys_platform != 'emscripten'" },
-    { name = "platformdirs", marker = "python_full_version < '3.11' or sys_platform != 'emscripten'" },
-    { name = "pytokens", marker = "python_full_version < '3.11' or sys_platform != 'emscripten'" },
+    { name = "click" },
+    { name = "mypy-extensions" },
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "platformdirs" },
+    { name = "pytokens" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
@@ -1358,7 +1358,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1799,7 +1799,7 @@ wheels = [
 
 [[package]]
 name = "inspect-ai"
-version = "0.3.246"
+version = "0.3.249"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "agent-client-protocol" },
@@ -1845,9 +1845,9 @@ dependencies = [
     { name = "zipp" },
     { name = "zstandard" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f1/6f/6c4d56a838d77cda79a8beefb60019dc50f9d2d6beb1c5f414dde5db610e/inspect_ai-0.3.246.tar.gz", hash = "sha256:2edebb069318042bca0638de50be666a50e514096a90070ee00aceccf858c84b", size = 49563205, upload-time = "2026-07-10T23:54:07.489Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c6/2a/b994c824e233cbc2a7d6154013a0d01fbe7b1911da66646b2dc6ef19de3f/inspect_ai-0.3.249.tar.gz", hash = "sha256:e0b01e92a41c4fb13c006b59e6d0db4d1be0cd27060b909e34098169c0f10036", size = 49387023, upload-time = "2026-07-21T00:35:41.972Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/b2/635fc2d46379eb7da73cd04ec1b23486a113be55c256c5bce8193198f97e/inspect_ai-0.3.246-py3-none-any.whl", hash = "sha256:b010b5759332f8f780757bfcae854fcfe5f71c6387988a14ca6a7b024a4a9e88", size = 37185092, upload-time = "2026-07-10T23:53:59.87Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/a5/b93b5ebc7f82c04622b3955df7b3575eb935d73047f13b335725106a54ce/inspect_ai-0.3.249-py3-none-any.whl", hash = "sha256:e32907ec09b78b6ed6258233e259020d396b1532d12019231ed840c18e0df9fc", size = 36910040, upload-time = "2026-07-21T00:35:32.7Z" },
 ]
 
 [[package]]
@@ -2044,17 +2044,17 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version < '3.11'" },
-    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
-    { name = "jedi", marker = "python_full_version < '3.11'" },
-    { name = "matplotlib-inline", marker = "python_full_version < '3.11'" },
-    { name = "pexpect", marker = "python_full_version < '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version < '3.11'" },
-    { name = "pygments", marker = "python_full_version < '3.11'" },
-    { name = "stack-data", marker = "python_full_version < '3.11'" },
-    { name = "traitlets", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "exceptiongroup" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/40/18/f8598d287006885e7136451fdea0755af4ebcbfe342836f24deefaed1164/ipython-8.39.0.tar.gz", hash = "sha256:4110ae96012c379b8b6db898a07e186c40a2a1ef5d57a7fa83166047d9da7624", size = 5513971, upload-time = "2026-03-27T10:02:13.94Z" }
 wheels = [
@@ -2080,18 +2080,18 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version >= '3.11' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version >= '3.11'" },
-    { name = "ipython-pygments-lexers", marker = "python_full_version >= '3.11'" },
-    { name = "jedi", marker = "python_full_version >= '3.11'" },
-    { name = "matplotlib-inline", marker = "python_full_version >= '3.11'" },
-    { name = "pexpect", marker = "python_full_version >= '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version >= '3.11'" },
-    { name = "psutil", marker = "python_full_version >= '3.11' and sys_platform != 'cygwin' and sys_platform != 'emscripten'" },
-    { name = "pygments", marker = "python_full_version >= '3.11'" },
-    { name = "stack-data", marker = "python_full_version >= '3.11'" },
-    { name = "traitlets", marker = "python_full_version >= '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version == '3.11.*'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "ipython-pygments-lexers" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "psutil", marker = "sys_platform != 'cygwin' and sys_platform != 'emscripten'" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/53/59/165d3b4d75cc34add3122c4417ecb229085140ac573103c223cd01dde96f/ipython-9.15.0.tar.gz", hash = "sha256:da2819ce2aa83135257df830660b1176d986c3d2876db24df01974fa955b2756", size = 4442580, upload-time = "2026-06-26T11:03:35.913Z" }
 wheels = [
@@ -2103,7 +2103,7 @@ name = "ipython-pygments-lexers"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pygments", marker = "python_full_version >= '3.11'" },
+    { name = "pygments" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ef/4c/5dd1d8af08107f88c7f741ead7a40854b8ac24ddf9ae850afbcf698aa552/ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81", size = 8393, upload-time = "2025-01-17T11:24:34.505Z" }
 wheels = [
@@ -3538,10 +3538,10 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "python-dateutil", marker = "python_full_version < '3.11'" },
-    { name = "pytz", marker = "python_full_version < '3.11'" },
-    { name = "tzdata", marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "python-dateutil" },
+    { name = "pytz" },
+    { name = "tzdata" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/33/01/d40b85317f86cf08d853a4f495195c73815fdf205eef3993821720274518/pandas-2.3.3.tar.gz", hash = "sha256:e05e1af93b977f7eafa636d043f9f94c7ee3ac81af99c13508215942e64c993b", size = 4495223, upload-time = "2025-09-29T23:34:51.853Z" }
 wheels = [
@@ -3613,10 +3613,10 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "python-dateutil", marker = "python_full_version >= '3.11'" },
-    { name = "tzdata", marker = "(python_full_version >= '3.11' and sys_platform == 'emscripten') or (python_full_version >= '3.11' and sys_platform == 'win32')" },
+    { name = "python-dateutil" },
+    { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f8/87/4341c6252d1c47b08768c3d25ac487362bf403f0313ddae4a2a26c9b1b4c/pandas-3.0.3.tar.gz", hash = "sha256:696a4a00a2a2a35d4e5deb3fc946641b96c944f02230e4f76137fe35d806c4fc", size = 4651414, upload-time = "2026-05-11T18:54:29.21Z" }
 wheels = [
@@ -3723,7 +3723,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "ptyprocess" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -5794,7 +5794,7 @@ name = "zipfile-zstd"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zstandard", marker = "python_full_version < '3.14'" },
+    { name = "zstandard" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f7/2a/2e0941bc0058d10ab37d8c578b94a19f611f6ae54f124140f2fb451f0932/zipfile-zstd-0.0.4.tar.gz", hash = "sha256:c1498e15b7922a3d1af0ea55df8b11b2af4e8f7e0e80e414e25d66899f7def89", size = 4603, upload-time = "2021-12-08T07:38:16.245Z" }
 wheels = [


### PR DESCRIPTION
Fixes #772

inspect-ai 0.3.248 renamed inspect_ai._cli.trace.anomolies_command_impl to
anomalies_command_impl; released inspect-scout (<= 0.4.44) still imports the
old name, so flow's module-level import of inspect_scout._cli.scan made all
of inspect_flow.api unimportable. Defer the _parse_validation import to the
scan() call that needs it.

Also reconcile with inspect-ai 0.3.249: add the new moonshot provider to the
launcher's auto-dependency map (OpenAI-compatible, needs openai), upgrade the
locked inspect-ai to 0.3.249 and regenerate generated.py (max_retries
docstring), and advance inspect-reconciled-version.

Fixes #772

Co-authored-by: Ransom Richardson <1209015+ransomr@users.noreply.github.com>

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>