### PR TITLE
fix: select the interpreter explicitly when freezing requirements

### DIFF
--- a/src/inspect_flow/_launcher/freeze.py
+++ b/src/inspect_flow/_launcher/freeze.py
@@ -12,13 +12,16 @@ logger = logging.getLogger(__name__)
 
 
 def write_flow_requirements(
-    spec: FlowSpec, cwd: str, env: dict[str, str], dry_run: bool
+    spec: FlowSpec, cwd: str, env: dict[str, str], dry_run: bool, python: str
 ) -> None:
     if dry_run or not spec.log_dir:
         return
-    # Freeze installed packages to flow-requirements.txt in log_dir
+    # Freeze installed packages to flow-requirements.txt in log_dir. Target the
+    # interpreter explicitly rather than letting uv discover it from cwd/PATH/
+    # VIRTUAL_ENV, which can silently record the host environment instead of the
+    # evaluation environment (e.g. under in-process embedding).
     freeze_result = run_with_logging(
-        ["uv", "pip", "freeze"],
+        ["uv", "pip", "freeze", "--python", python],
         cwd=cwd,
         env=env,
         log_output=False,  # Don't log the full freeze output
@@ -40,6 +43,8 @@ def write_flow_requirements(
                 "uv",
                 "pip",
                 "compile",
+                "--python",
+                python,
                 "--generate-hashes",
                 "--no-header",
                 "--no-annotate",

--- a/src/inspect_flow/_launcher/inproc.py
+++ b/src/inspect_flow/_launcher/inproc.py
@@ -1,4 +1,5 @@
 import os
+import sys
 from logging import getLogger
 
 from inspect_flow._display.run_action import RunAction
@@ -16,7 +17,13 @@ def inproc_launch(spec: FlowSpec, base_dir: str, dry_run: bool) -> LaunchResult:
         if spec.env:
             os.environ.update(spec.env)
 
-        write_flow_requirements(spec, cwd=".", env=os.environ.copy(), dry_run=dry_run)
+        write_flow_requirements(
+            spec,
+            cwd=".",
+            env=os.environ.copy(),
+            dry_run=dry_run,
+            python=sys.executable,
+        )
     return run_eval_set(spec, base_dir=base_dir, dry_run=dry_run)
 
 

--- a/src/inspect_flow/_launcher/venv.py
+++ b/src/inspect_flow/_launcher/venv.py
@@ -46,6 +46,10 @@ from inspect_flow._util.subprocess_util import (
 logger = getLogger(__name__)
 
 
+def _venv_python(temp_dir: str) -> str:
+    return str(Path(temp_dir) / ".venv" / "bin" / "python")
+
+
 def venv_launch(spec: FlowSpec, base_dir: str, dry_run: bool) -> LaunchResult:
     # The eval logs live in the subprocess; only the success flag is signaled back
     # (via a per-run result file) on a clean exit. A crash raises in _venv_spawn.
@@ -115,7 +119,7 @@ def _venv_spawn(
 
             action.update(info="venv created")
 
-            python_path = Path(temp_dir) / ".venv" / "bin" / "python"
+            python_path = _venv_python(temp_dir)
             file = write_config_file(spec)
 
             action.update(
@@ -140,7 +144,7 @@ def _venv_spawn(
         env[RUN_RESULT_FILE_ENV] = str(result_path)
 
         process = subprocess.Popen(
-            [str(python_path), str(run_path), subcommand, "--file", file, *args],
+            [python_path, str(run_path), subcommand, "--file", file, *args],
             env=env,
             pass_fds=(child_ready_w, parent_ack_r),
         )
@@ -254,7 +258,7 @@ def _create_venv(
 
     _uv_pip_install(dependencies, temp_dir, env)
 
-    write_flow_requirements(spec, temp_dir, env, dry_run)
+    write_flow_requirements(spec, temp_dir, env, dry_run, python=_venv_python(temp_dir))
 
 
 def _resolve_dependency(dependency: str, base_dir: str) -> str:

--- a/tests/test_venv.py
+++ b/tests/test_venv.py
@@ -1,8 +1,10 @@
 import os
 import subprocess
+import sys
 import tempfile
 import threading
 from pathlib import Path
+from typing import Any
 from unittest.mock import patch
 
 import pytest
@@ -1035,6 +1037,7 @@ def test_712_concurrent_flow_requirements_no_race() -> None:
                     cwd=str(cwd),
                     env=os.environ.copy(),
                     dry_run=False,
+                    python=sys.executable,
                 )
             except BaseException as e:  # noqa: BLE001
                 errors[name] = e
@@ -1054,3 +1057,106 @@ def test_712_concurrent_flow_requirements_no_race() -> None:
             assert requirements_txt.read_text() == expected
         # The temporary input files must be cleaned up.
         assert list(cwd.glob("*.in")) == []
+
+
+def test_freeze_forwards_explicit_interpreter_to_uv() -> None:
+    # write_flow_requirements must forward the interpreter it is given to both
+    # the freeze and the compile commands (a caller could pass it to one and
+    # forget the other). Behavior against a real interpreter is covered by
+    # test_freeze_targets_explicit_interpreter_not_virtual_env below.
+    with tempfile.TemporaryDirectory() as temp_dir:
+        log_dir = Path(temp_dir) / "logs"
+        captured: list[list[str]] = []
+
+        def fake_run(
+            args: list[str], *pos: object, **kwargs: object
+        ) -> subprocess.CompletedProcess[str]:
+            captured.append(args)
+            if args[:3] == ["uv", "pip", "freeze"]:
+                return subprocess.CompletedProcess(
+                    args=args, returncode=0, stdout="package-a==1.0.0\n"
+                )
+            # uv pip compile: echo back the contents of the input file.
+            requirements_in = Path(args[-1])
+            return subprocess.CompletedProcess(
+                args=args, returncode=0, stdout=requirements_in.read_text()
+            )
+
+        with patch("subprocess.run", side_effect=fake_run):
+            write_flow_requirements(
+                spec=FlowSpec(
+                    log_dir=log_dir.as_posix(),
+                    tasks=[FlowTask(name="task_name")],
+                ),
+                cwd=temp_dir,
+                env=os.environ.copy(),
+                dry_run=False,
+                python="/custom/interpreter/python",
+            )
+
+        freeze_cmd = next(c for c in captured if c[:3] == ["uv", "pip", "freeze"])
+        assert (
+            freeze_cmd[freeze_cmd.index("--python") + 1] == "/custom/interpreter/python"
+        )
+
+        compile_cmd = next(c for c in captured if c[:3] == ["uv", "pip", "compile"])
+        assert (
+            compile_cmd[compile_cmd.index("--python") + 1]
+            == "/custom/interpreter/python"
+        )
+
+
+@pytest.mark.slow
+def test_freeze_targets_explicit_interpreter_not_virtual_env() -> None:
+    # The real freeze must resolve against the explicitly-passed interpreter,
+    # not the VIRTUAL_ENV uv would otherwise discover. Point VIRTUAL_ENV (and
+    # cwd) at a fresh, empty venv and freeze the running interpreter: the
+    # recorded requirements must reflect the running interpreter, not the empty
+    # venv (which would freeze to nothing). Only the network-bound compile step
+    # is stubbed; the freeze runs for real so it actually exercises `--python`.
+    with tempfile.TemporaryDirectory() as temp_dir:
+        decoy_venv = Path(temp_dir) / "decoy"
+        subprocess.run(
+            ["uv", "venv", "--python", sys.executable, str(decoy_venv)],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        cwd = Path(temp_dir) / "cwd"
+        cwd.mkdir()
+        log_dir = Path(temp_dir) / "logs"
+
+        env = os.environ.copy()
+        env["VIRTUAL_ENV"] = str(decoy_venv)
+
+        real_run = subprocess.run
+
+        def fake_run(
+            args: list[str], *pos: Any, **kwargs: Any
+        ) -> subprocess.CompletedProcess[str]:
+            # Stub only compile (its --generate-hashes would hit the package
+            # index); let the real freeze run against the given interpreter.
+            if args[:3] == ["uv", "pip", "compile"]:
+                requirements_in = Path(args[-1])
+                return subprocess.CompletedProcess(
+                    args=args, returncode=0, stdout=requirements_in.read_text()
+                )
+            return real_run(args, *pos, **kwargs)
+
+        with patch("subprocess.run", side_effect=fake_run):
+            write_flow_requirements(
+                spec=FlowSpec(
+                    log_dir=log_dir.as_posix(),
+                    tasks=[FlowTask(name="task_name")],
+                ),
+                cwd=str(cwd),
+                env=env,
+                dry_run=False,
+                python=sys.executable,
+            )
+
+        requirements = (log_dir / "flow-requirements.txt").read_text()
+        # pydantic is installed in the running interpreter but not the empty
+        # decoy venv, so its presence proves the freeze used --python, not
+        # VIRTUAL_ENV. Dropping --python would freeze the empty venv instead.
+        assert "pydantic==" in requirements


### PR DESCRIPTION
When an orchestrator (like Hawk) embeds Flow in-process (`execution_type="inproc"`), `write_flow_requirements` could record the wrong environment. It ran `uv pip freeze` / `uv pip compile` without naming a target interpreter, so uv discovered one from `VIRTUAL_ENV`, the working directory, or `PATH` — none of which need identify the interpreter actually running Flow. As a result `flow-requirements.txt` could silently capture the host environment instead of the evaluation environment.

Pass the active interpreter explicitly via `--python`: `sys.executable` for `inproc`, and the venv's python for `venv`. In `venv` mode this resolves to the same environment uv already found via `VIRTUAL_ENV`, so behavior there is unchanged; the fix only affects `inproc`.

Surfaced while building Flow support in Hawk, which is still in development.

🤖 Generated with [Claude Code](https://claude.com/claude-code)