### PR TITLE
ci: skip auto-review on draft PRs

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -16,6 +16,8 @@ jobs:
     # Run on PR events, or on a PR comment containing @review. `@review` does
     # not collide with the dev agent's `@claude` trigger.
     # Skip release-bot PRs (auto-generated changelog/version bumps).
+    # Skip draft PRs (auto-reviewed when marked Ready for review; an explicit
+    # `@review` comment still works on a draft).
     if: >
       (github.event_name == 'pull_request' &&
        github.event.pull_request.draft != true &&

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -18,6 +18,7 @@ jobs:
     # Skip release-bot PRs (auto-generated changelog/version bumps).
     if: >
       (github.event_name == 'pull_request' &&
+       github.event.pull_request.draft != true &&
        github.event.pull_request.user.login != 'meridian-release-bot[bot]') ||
       (github.event.issue.pull_request != null &&
        contains(github.event.comment.body, '@review'))


### PR DESCRIPTION
Adds the example stub's `draft != true` guard this copy predates: draft PRs are no longer auto-reviewed on open/reopen. They get their auto-review when marked **Ready for review** (`ready_for_review` is already subscribed), and an explicit `@review` comment still works on a draft. Local customizations (bot/fork exclusions) preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)