### PR TITLE
ci: close canary tracking issue on green; harden fix-PR issue link

### DIFF
--- a/.github/workflows/inspect-ai-main-failure.yml
+++ b/.github/workflows/inspect-ai-main-failure.yml
@@ -21,6 +21,14 @@
 #     release (`hold:release`), and applies `triaged` when done. Gating on the
 #     label (not "was just opened") makes triage retry-safe: an agent that dies
 #     before finishing leaves no label, so the next failure re-triages.
+#   close-on-green — the inverse of triage-gate. The tracking issue means "the
+#     canary is currently red"; a green scheduled run is the ground-truth signal
+#     that flow is no longer broken, so it closes the open issue. This is the
+#     ONLY reliable close path: a fix PR's `Fixes #<n>` link closes the issue
+#     only for causes that get a PR and only when the keyword is well-formed, so
+#     a self-resolved break or a no-PR flake would otherwise leave the issue
+#     open forever — and a stale open issue wedges the dedup above (later
+#     failures pile onto it instead of opening a fresh, correctly-scoped one).
 #
 # Dedup is keyed on the `inspect-ai-main` label, not the failure signature: the
 # canary has one meaning ("flow is broken against inspect-ai main"), so one open
@@ -295,7 +303,19 @@ jobs:
                  gh pr create --base main --label auto ...
                - Conventional-commit title per AGENTS.md (a linter/formatting or
                  dependency fix is not `feat:`/`fix:`).
-               - Body starts with "Fixes #${{ needs.triage-gate.outputs.issue_number }}".
+               - The body's FIRST LINE must be exactly
+                 `Fixes #${{ needs.triage-gate.outputs.issue_number }}` on its
+                 own line — nothing before it, no other words on that line.
+                 GitHub auto-closes the issue only when the keyword is
+                 immediately followed by the reference; prose like "Fixes the
+                 canary failure tracked in #<n>" does NOT link and will leave
+                 the issue open.
+               - After creating the PR, VERIFY the link took:
+                 `gh pr view <pr> --repo ${{ github.repository }} --json closingIssuesReferences`
+                 must list the issue. If it is empty, the keyword was malformed
+                 — edit the body with `gh pr edit` so the first line is exactly
+                 `Fixes #${{ needs.triage-gate.outputs.issue_number }}` and
+                 re-verify.
                - Applying the `auto` label AT CREATION is required: it opts the
                  PR into the autonomous review/CI-fix loop, and labeling later
                  races the auto-reviewer.
@@ -346,3 +366,36 @@ jobs:
           name: claude-execution-output
           path: /home/runner/work/_temp/claude-execution-output.json
           if-no-files-found: ignore
+
+  # Close the tracking issue when the canary is green again. Green is the
+  # ground-truth "flow is no longer broken" signal — more reliable than a fix
+  # PR's `Fixes #<n>` link, which fires only for causes that get a PR and only
+  # when the keyword is well-formed. Closing here resets the dedup so the next
+  # red run opens a fresh, correctly-scoped issue instead of piling onto a stale
+  # one. Only for scheduled successes; the serialized concurrency group ensures
+  # this never races a triage run on the same issue.
+  close-on-green:
+    if: >
+      github.event_name == 'workflow_run' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    env:
+      GH_TOKEN: ${{ secrets.MARVIN_TOKEN || github.token }}
+      REPO: ${{ github.repository }}
+      RUN_URL: ${{ github.event.workflow_run.html_url }}
+    steps:
+      - name: Close the tracking issue if the canary is green again
+        run: |
+          set -uo pipefail
+          url=$(gh issue list --repo "$REPO" --state open \
+            --label inspect-ai-main --limit 1 --json url --jq '.[0].url // empty')
+          if [ -z "$url" ]; then
+            echo "No open canary issue — nothing to close."
+            exit 0
+          fi
+          gh issue comment "$url" --repo "$REPO" \
+            --body "$(printf '✅ Canary green again on %s — flow is no longer broken against inspect-ai main. Closing; the next red run opens a fresh issue.' "$RUN_URL")"
+          gh issue close "$url" --repo "$REPO" --reason completed

--- a/.github/workflows/inspect-ai-main-failure.yml
+++ b/.github/workflows/inspect-ai-main-failure.yml
@@ -7,7 +7,7 @@
 # the canary upgrades ALL dev dependencies. So "canary red" must be diagnosed,
 # not assumed to mean "inspect-ai broke us".
 #
-# Two jobs:
+# Three jobs:
 #   triage-gate — deterministic. Opens ONE tracking issue (deduped on the
 #     `inspect-ai-main` label) and, while it stays open, appends a "still
 #     failing" comment on later failures instead of piling up duplicate issues.
@@ -29,6 +29,11 @@
 #     a self-resolved break or a no-PR flake would otherwise leave the issue
 #     open forever — and a stale open issue wedges the dedup above (later
 #     failures pile onto it instead of opening a fresh, correctly-scoped one).
+#     Exception: a `hold:release` issue is deliberately left open to defer to
+#     the next inspect-ai release, and in-flux upstream changes are the ones
+#     most likely to flap green transiently — so close-on-green skips those,
+#     keeping the deferred thread (and its human context) intact until the
+#     release actually reconciles it.
 #
 # Dedup is keyed on the `inspect-ai-main` label, not the failure signature: the
 # canary has one meaning ("flow is broken against inspect-ai main"), so one open
@@ -367,13 +372,10 @@ jobs:
           path: /home/runner/work/_temp/claude-execution-output.json
           if-no-files-found: ignore
 
-  # Close the tracking issue when the canary is green again. Green is the
-  # ground-truth "flow is no longer broken" signal — more reliable than a fix
-  # PR's `Fixes #<n>` link, which fires only for causes that get a PR and only
-  # when the keyword is well-formed. Closing here resets the dedup so the next
-  # red run opens a fresh, correctly-scoped issue instead of piling onto a stale
-  # one. Only for scheduled successes; the serialized concurrency group ensures
-  # this never races a triage run on the same issue.
+  # Close the tracking issue when the canary is green again (see the header
+  # comment for why green — not a fix PR's `Fixes #<n>` link — is the
+  # authoritative close signal). Only for scheduled successes; the serialized
+  # concurrency group ensures this never races a triage run on the same issue.
   close-on-green:
     if: >
       github.event_name == 'workflow_run' &&
@@ -390,10 +392,24 @@ jobs:
       - name: Close the tracking issue if the canary is green again
         run: |
           set -uo pipefail
-          url=$(gh issue list --repo "$REPO" --state open \
-            --label inspect-ai-main --limit 1 --json url --jq '.[0].url // empty')
+          # Fail loudly on a query error so a missed close is visible rather
+          # than silently indistinguishable from "no open issue" (as triage-gate
+          # does for gh issue create). Fetch labels too so we can skip holds.
+          if ! open=$(gh issue list --repo "$REPO" --state open \
+            --label inspect-ai-main --limit 1 --json url,labels); then
+            echo "::error::gh issue list failed — cannot determine whether to close."
+            exit 1
+          fi
+          url=$(echo "$open" | jq -r '.[0].url // empty')
           if [ -z "$url" ]; then
             echo "No open canary issue — nothing to close."
+            exit 0
+          fi
+          # A hold:release issue is deliberately deferred to the next inspect-ai
+          # release; in-flux upstream changes flap green, so leave it open and
+          # keep its deferred thread intact.
+          if echo "$open" | jq -e '.[0].labels | map(.name) | index("hold:release")' >/dev/null; then
+            echo "Open issue $url carries hold:release — leaving it open."
             exit 0
           fi
           gh issue comment "$url" --repo "$REPO" \


### PR DESCRIPTION
## Summary

The `Inspect AI Main CI` canary's tracking issue means "the canary is currently red", but nothing closed it when flow got fixed — so it never reset. This is exactly what happened with #777:

- #781 fixed the ruff-upgrade failure #777 tracked, but its body said *"Fixes the live … canary failure tracked in #777"* rather than the literal `Fixes #777` keyword. GitHub only auto-closes when the keyword *immediately* precedes the reference, so it created no closing link (`closingIssuesReferences: []`) and #777 stayed open after merge.
- The canary then went **green**, but #777 stayed open. A later, **unrelated** `ty==0.0.64` PyPI-upload flake appended to the *same* stale issue — conflating two root causes in one thread and wedging the dedup (later failures pile onto the stale issue instead of opening a fresh, correctly-scoped one).

## Changes

- **`close-on-green` job** — when a scheduled canary run concludes `success`, close the open `inspect-ai-main` issue with a link to the green run. Green is the ground-truth "flow is no longer broken" signal and the **only reliable close path**: a fix PR's `Fixes #<n>` link fires only for causes that get a PR and only when the keyword is well-formed, so self-resolved breaks and no-PR flakes (like the `ty` race) would otherwise leave the issue open forever. Restores the open→triage→close→reopen-fresh loop the workflow header describes. The serialized concurrency group ensures it never races a triage run.
- **Harden the triage prompt** — require the fix PR's *first body line* to be exactly `Fixes #<n>`, and have the agent verify `closingIssuesReferences` actually took (repairing the body via `gh pr edit` if not). Keeps the PR link as provenance / changelog value; `close-on-green` is now the authoritative close.

#777 has been closed manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)