### PR TITLE
chore: avoid collision with click 8.5 Command.format_arguments

### DIFF
--- a/src/inspect_flow/_cli/store.py
+++ b/src/inspect_flow/_cli/store.py
@@ -47,11 +47,11 @@ class ArgumentsHelpCommand(click.Command):
         self.format_usage(ctx, formatter)
         self.format_help_text(ctx, formatter)
         if self.arguments_help:
-            self.format_arguments(formatter)
+            self._format_arguments(formatter)
         self.format_options(ctx, formatter)
         self.format_epilog(ctx, formatter)
 
-    def format_arguments(self, formatter: HelpFormatter) -> None:
+    def _format_arguments(self, formatter: HelpFormatter) -> None:
         with formatter.section("Arguments"):
             formatter.write_dl(list(self.arguments_help.items()))
 


### PR DESCRIPTION
Fixes #799

## Root cause

The scheduled "Inspect AI Main CI" canary run ([32986087188](https://github.com/meridianlabs-ai/inspect_flow/actions/runs/32986087188)) failed in the pyright job. This is **not** an inspect-ai break — tests passed against inspect-ai main. The canary's dev-dependency upgrade pulled in **click 8.5.0** (lockfile has 8.4.2), which added a native `Command.format_arguments(self, ctx, formatter)` method (`format_help` now calls it, and `click.Argument` gained a `help=` param). Flow's `ArgumentsHelpCommand` in `src/inspect_flow/_cli/store.py` defined its own private helper named `format_arguments(self, formatter)`, which pyright now flags as an incompatible override of the new base method.

## Fix

Rename the helper to `_format_arguments`. This works with both click 8.4 and 8.5, and help output is unchanged.

(Longer term, once the lock moves to click ≥ 8.5, `ArgumentsHelpCommand` could be dropped entirely in favor of click's native `help=` on arguments — left out of this PR to keep the canary fix minimal and avoid raising the click floor.)

## Verification

With `uv sync --dev --upgrade` (click 8.5.0) + inspect-ai from git main:
- `ruff format` / `ruff check --fix` — clean
- `pyright` — 0 errors (previously reproduced the exact canary error)
- `pytest tests/test_store_cli.py tests/test_cli.py` — 64 passed
- `flow store import --help` still renders the Arguments section identically

🤖 Generated with [Claude Code](https://claude.com/claude-code)
