### PR TITLE
chore: match click 8.5.0 Command.format_arguments signature

### DIFF
--- a/src/inspect_flow/_cli/store.py
+++ b/src/inspect_flow/_cli/store.py
@@ -47,11 +47,11 @@ class ArgumentsHelpCommand(click.Command):
         self.format_usage(ctx, formatter)
         self.format_help_text(ctx, formatter)
         if self.arguments_help:
-            self.format_arguments(formatter)
+            self.format_arguments(ctx, formatter)
         self.format_options(ctx, formatter)
         self.format_epilog(ctx, formatter)
 
-    def format_arguments(self, formatter: HelpFormatter) -> None:
+    def format_arguments(self, ctx: Context, formatter: HelpFormatter) -> None:
         with formatter.section("Arguments"):
             formatter.write_dl(list(self.arguments_help.items()))
 


### PR DESCRIPTION
Fixes #799

Click 8.5.0 added Command.format_arguments(ctx, formatter), making the
ArgumentsHelpCommand override incompatible under pyright. Accept ctx to
match the base signature (harmless on older click, where the method is
purely our own).

Co-authored-by: Ransom Richardson <1209015+ransomr@users.noreply.github.com>
Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>