### PR TITLE
chore: card only the tracking issue on Atlas, not the reconciliation PR

### DIFF
--- a/.github/workflows/inspect-update.yml
+++ b/.github/workflows/inspect-update.yml
@@ -250,8 +250,12 @@ jobs:
                the issue that no flow changes were needed.
 
             7. Best-effort repo defaults: assign ransomr to the issue and the
-               PR, and add both to the Atlas project board if you have access
-               (skip gracefully if not permitted).
+               PR, and add the ISSUE (only — never the PR) to the Atlas
+               project board if you have access (skip gracefully if not
+               permitted). The board's model is track-the-issue, link-the-PR:
+               the PR reaches the board through its Fixes ref / Development
+               link on the issue's card, and a separate PR card is an
+               untracked duplicate nothing reconciles.
 
             Open exactly one issue and one PR, no more. If you cannot complete
             the task, comment on issue #766 describing what blocked you,


### PR DESCRIPTION
The weekly reconciliation prompt told the agent to add both the tracking issue and the PR to the Atlas board; the board's model is track-the-issue, link-the-PR (the PR reaches the board via its Fixes ref on the issue card), so the PR card is an untracked duplicate nothing reconciles — observed with #804 carded alongside its tracking issue #803. The prompt now says issue only, with the rationale inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)