### PR TITLE
fix: detect venv providers from every declared model reference (#779)

### DIFF
--- a/src/inspect_flow/_launcher/auto_dependencies.py
+++ b/src/inspect_flow/_launcher/auto_dependencies.py
@@ -9,24 +9,22 @@ from inspect_ai._util.registry import (
     registry_package_name,
 )
 from inspect_ai.agent import Agent
-from inspect_ai.model import Model
 from inspect_ai.scorer import Scorer
 from inspect_ai.solver import Solver
 from inspect_ai.util import SandboxEnvironmentType
 from inspect_ai.util._sandbox.registry import registry_match_sandboxenv
 from packaging.utils import canonicalize_name
 
+from inspect_flow._config.model_refs import iter_model_refs
 from inspect_flow._launcher.pip_string import get_pip_string
 from inspect_flow._types.flow_types import (
     FlowAgent,
-    FlowModel,
     FlowScorer,
     FlowSolver,
     FlowSpec,
     FlowTask,
     NotGiven,
 )
-from inspect_flow._util.list_util import is_sequence
 
 logger = getLogger(__name__)
 
@@ -66,6 +64,10 @@ def collect_auto_dependencies(
 
     for task in spec.tasks or []:
         _collect_task_dependencies(task, result)
+    for ref in iter_model_refs(spec):
+        # fallback_models are provider-native ids, so they name no provider
+        if ref.name and ref.kind != "fallback":
+            _collect_model_dependencies(ref.name, result)
 
     # An explicit pin must win over the auto-detected host version of the same
     # package, so drop any package the user named directly. Its version
@@ -98,15 +100,6 @@ def _collect_task_dependencies(
     _collect_sandbox_dependencies(task.sandbox, dependencies)
     # Issue #262 _collect_approver_dependencies(task.approver, dependencies)
 
-    if task.model:
-        _collect_model_dependencies(task.model, dependencies)
-    if task.model_roles:
-        for model_role in task.model_roles.values():
-            if is_sequence(model_role):
-                for model in model_role:
-                    _collect_model_dependencies(model, dependencies)
-            else:
-                _collect_model_dependencies(model_role, dependencies)
     if not task.model and not task.model_roles:
         _collect_env_model_dependencies(dependencies)
 
@@ -129,15 +122,7 @@ def _collect_name_dependencies(
         dependencies.add(split[0])
 
 
-def _collect_model_dependencies(
-    model: str | FlowModel | Model | None, dependencies: set[str]
-) -> None:
-    assert not isinstance(model, Model), (
-        "validate_portable_spec should have ensured no Model instances"
-    )
-    name = model.name if isinstance(model, FlowModel) else model
-    if not name:
-        return
+def _collect_model_dependencies(name: str, dependencies: set[str]) -> None:
     split = name.split("/", maxsplit=1)
     if len(split) == 2:
         dependencies.update(_MODEL_PROVIDERS.get(split[0], [split[0]]))

--- a/tests/test_venv.py
+++ b/tests/test_venv.py
@@ -9,8 +9,17 @@ from unittest.mock import patch
 
 import pytest
 from botocore.client import BaseClient
+from inspect_ai import ScannerConfig
+from inspect_ai.model import GenerateConfig
 from inspect_ai.util import SandboxEnvironmentSpec
-from inspect_flow import FlowDependencies, FlowModel, FlowSolver, FlowSpec, FlowTask
+from inspect_flow import (
+    FlowDependencies,
+    FlowModel,
+    FlowOptions,
+    FlowSolver,
+    FlowSpec,
+    FlowTask,
+)
 from inspect_flow._display.run_action import RunAction
 from inspect_flow._launcher.auto_dependencies import collect_auto_dependencies
 from inspect_flow._launcher.freeze import (
@@ -334,6 +343,88 @@ def test_auto_dependency_list_valued_model_role() -> None:
         _get_pip_string_with_version("google-genai"),
         _get_pip_string_with_version("groq"),
         "inspect_evals",
+    ]
+
+
+def test_779_auto_dependency_inline_scanner_models() -> None:
+    # options.scanner runs inside the venv, so its model and role providers
+    # must be installed alongside the task providers
+    spec = FlowSpec(
+        tasks=[FlowTask(name="inspect_evals/task_name", model="openai/gpt-4o")],
+        options=FlowOptions(
+            scanner=ScannerConfig(
+                scanners=["scanner_name"],
+                model="google/gemini-2.5-pro",
+                model_roles={"grader": "groq/model-a"},
+            )
+        ),
+    )
+    assert collect_auto_dependencies(spec) == [
+        _get_pip_string_with_version("google-genai"),
+        _get_pip_string_with_version("groq"),
+        "inspect_evals",
+        _get_pip_string_with_version("openai"),
+    ]
+
+
+def test_779_auto_dependency_flow_model_default() -> None:
+    spec = FlowSpec(
+        tasks=[
+            FlowTask(
+                name="inspect_evals/task_name",
+                model=FlowModel(name="openai/gpt-4o", default="anthropic/claude-x"),
+            )
+        ]
+    )
+    assert collect_auto_dependencies(spec) == [
+        _get_pip_string_with_version("anthropic"),
+        "inspect_evals",
+        _get_pip_string_with_version("openai"),
+    ]
+
+
+def test_779_flow_model_string_factory_is_the_model_id() -> None:
+    # a string factory is passed to get_model(model=...) and wins over name
+    spec = FlowSpec(
+        tasks=[
+            FlowTask(
+                name="inspect_evals/task_name",
+                model=FlowModel(name="anthropic/claude-x", factory="openai/gpt-4o"),
+            )
+        ]
+    )
+    assert collect_auto_dependencies(spec) == [
+        "inspect_evals",
+        _get_pip_string_with_version("openai"),
+    ]
+
+
+def test_779_fallback_models_do_not_add_providers() -> None:
+    # fallback_models are provider-native ids; a slash in one is part of the
+    # id (e.g. an OpenRouter model), not an inspect provider prefix
+    spec = FlowSpec(
+        tasks=[
+            FlowTask(
+                name="inspect_evals/task_name",
+                model="openai/gpt-4o",
+                config=GenerateConfig(fallback_models=["meta-llama/llama-3"]),
+            )
+        ]
+    )
+    assert collect_auto_dependencies(spec) == [
+        "inspect_evals",
+        _get_pip_string_with_version("openai"),
+    ]
+
+
+def test_779_scanner_file_path_adds_nothing() -> None:
+    spec = FlowSpec(
+        tasks=[FlowTask(name="inspect_evals/task_name", model="openai/gpt-4o")],
+        options=FlowOptions(scanner="scanner.yaml"),
+    )
+    assert collect_auto_dependencies(spec) == [
+        "inspect_evals",
+        _get_pip_string_with_version("openai"),
     ]
 
 


### PR DESCRIPTION
Fixes #779.

## Problem

With `execution_type="venv"` and auto-detected dependencies (the default), `collect_auto_dependencies` only walked `spec.tasks` and only read `FlowModel.name`. Two declared model sites were never visited:

- **Inline `options.scanner`** — the scanner runs inside the venv, but its `model` and `model_roles` providers were never installed. This fails mid-run with a provider import error instead of at environment setup.
- **`FlowModel.default`** — a declared reference to a possibly different provider that was statically under-counted. Latent today (see #778), but a gap in the dependency plan. (this may be removed shortly)

## Fix

Model provider detection now comes from `iter_model_refs(spec)` (added in #784), which is the single definition of where models appear in a spec. Task, role, default, and scanner models all flow through one walk, so the next new model field cannot be silently missed here.

- `kind="fallback"` refs are skipped: `GenerateConfig.fallback_models` entries are provider-native ids, not `provider/model` references, and must not drive provider installation.
- Refs with no static name (a scanner given as a file path, a callable factory) are skipped as before.
- `_collect_task_dependencies` keeps task name, solver, scorer, sandbox, and the task-scoped `INSPECT_EVAL_MODEL` rule. Its model branches are removed.
- `_collect_model_dependencies` now takes a plain `str`; the `FlowModel`/`Model` unwrapping is gone.

## Behavior changes

Strictly additive for the common cases: more providers get installed. Two edge cases differ:

- A `FlowModel` with a **string `factory`** now installs the factory string's provider rather than `name`'s. That string is the model id passed to `get_model`, so this is a correction; `name` was never what ran.
- A `FlowModel` with a **callable `factory`** and a `name` previously installed `name`'s provider and now installs nothing. `name` is ignored at runtime in that case, and unregistered callables are already rejected by portable-spec validation in venv mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
