### PR TITLE
fix: remove non-functional FlowModel.default field (#778)

### DIFF
--- a/design/model_reference_introspection.md
+++ b/design/model_reference_introspection.md
@@ -11,23 +11,18 @@ Platforms like METR's Hawk need the set of models a `FlowSpec` **declares**. Not
 Those declarations are spread across the spec:
 
 - a `FlowTask`'s `model` and `model_roles`;
-- a `FlowModel`'s `name` and its `default` fallback;
 - `defaults.model` and `defaults.model_prefix`;
 - the `defaults.task` / `defaults.task_prefix` templates (each a `FlowTask` with its own `model` / `model_roles`);
 - `options.scanner.model` and `options.scanner.model_roles` (the scanner runs a model too); and
 - every `GenerateConfig.fallback_models` entry — note these are provider-native ids with no `provider/` prefix, so a host cannot compare them against the qualified names it authorizes without normalizing first.
 
-Reproducing that walk outside Flow fails in a specific way. It is not that hosts are careless — it is that a hand-written port is correct against the schema it was written for, and silently becomes incomplete as that schema grows. Hawk's integration carries a private port (`_iter_model_refs` + `_model_ref_to_names` + `_iter_flow_models` in `hawk/core/flow_config.py`): an early version missed `model_roles`, so grader models skipped every check; a later pass found `FlowModel.default` missing too; and `fallback_models` was never walked at all. `options.scanner` is the purest case — added in 0.11.0, after the version Hawk pins, so its port has no way to know the site exists. Nothing on the host's side detects any of this.
+Reproducing that walk outside Flow fails in a specific way. It is not that hosts are careless — it is that a hand-written port is correct against the schema it was written for, and silently becomes incomplete as that schema grows. Hawk's integration carries a private port (`_iter_model_refs` + `_model_ref_to_names` + `_iter_flow_models` in `hawk/core/flow_config.py`): an early version missed `model_roles`, so grader models skipped every check; a later pass found `FlowModel.default` (since removed in #778) missing too; and `fallback_models` was never walked at all. `options.scanner` is the purest case — added in 0.11.0, after the version Hawk pins, so its port has no way to know the site exists. Nothing on the host's side detects any of this.
 
 A miss is not an authorization bypass, for the reason above; it costs a deferred, harder-to-diagnose failure and a less precise log ACL. Neither justifies treating this as a security boundary, and treating it as one leads to chasing an unbounded set of ways a model can reach the runner (see Scope below).
 
-## The `.default` fallback
+## The former `.default` fallback
 
-`FlowModel.default` is a fully-qualified model name (e.g. `"openai/gpt-4o"`) that Flow passes to `get_model(default=...)`, documented as the fallback used when the named model or role is not found. A single `FlowModel` can therefore *declare* two different models — its `name` and its `default` — so the two are surfaced as distinct references and a host applies identical policy to each.
-
-Note that `default` does not currently take effect: a `FlowModel` with a `default` and no `name` raises `ValueError: Model name is required`, and when `name` is set Inspect resolves `default` only if `model is None`, which Flow never passes (issue #778). It is enumerated anyway, because the field is still in the schema and still user-facing: a spec can set it, so a host enumerating declared model references should see it. Over-counting a declared reference is the safe direction, and an enumeration API should not encode a bug as an omission.
-
-The likely resolution of #778 is to **remove** the field rather than make it work. When that lands, this handling retires with it — drop the `<path>.default` ref, the `"default"` variant of `kind`, and this section. Deliberately not done ahead of time: the field exists today, the snapshot test pins it, and a walk that skipped a live schema field would be under-reporting.
+`FlowModel.default` was documented as the fallback used when the named model or role was not found, but Flow always passed a name to `get_model`, so Inspect never read it. It was removed in #778. While it existed, this API enumerated it as its own `kind="default"` ref at `<path>.default`; that ref and `kind` variant retired with the field.
 
 ## Design
 
@@ -60,8 +55,6 @@ Reporting `name` while a `factory` decides the real model would let a caller dec
 
 Note `FlowModel` is the odd one out here: on every other Flow type a string `factory` is a *registry reference*, but `_create_model` passes it to `get_model(model=...)`, and inspect has no model-factory registry (only `modelapi` providers) — so for a model it is the model id, and anything not shaped `provider/model` raises. A factory-derived name is therefore genuinely enumerable. `from_factory` reports one anyway, so a host with its own no-factories policy can act on it without re-deriving this rule.
 
-A `FlowModel`'s `default` is *not* folded into its `name`; it is emitted as its own `SpecModelRef` at `<path>.default` so a host counts it without special-casing.
-
 ## Coverage
 
 One reusable model+roles walker applied to every task at `tasks[i]` (whether a `FlowTask` or an already-instantiated `Task`, whose `model` / `model_roles` resolve to live `Model`s that must still be counted). `defaults.task` / `task_prefix` templates and `defaults.model` / `model_prefix` need no walker of their own: they are merged into the tasks before iteration.
@@ -84,19 +77,17 @@ An unrecognized shape yields an unenumerable ref instead. That includes a comma-
 
 **`unenumerable`, not `name is None`, is the signal for "I cannot name this".** `name` is `None` for two unrelated reasons: a model binds but cannot be named (an unreadable site, or a callable `factory`), or the reference declares no model at all — post-merge that means a task-level `FlowModel` with neither `name` nor `factory`, a misconfigured spec that instantiation rejects ("Model name is required") rather than running anything. Only the first is something a host must refuse; `unenumerable` separates the two, and keeps the factory-precedence rule inside this API instead of pushing it back onto every caller. (Before iteration moved to the merged spec, the nameless case was also produced by perfectly ordinary `defaults.model` field templates, which is what made this distinction load-bearing; merging now dissolves those before the walk.)
 
-For every `FlowModel` encountered above with a set `default`, an additional `SpecModelRef` is emitted at `<path>.default` (`ref` is the fallback name string), inheriting the same `role`.
-
 Generation-config fallbacks:
 
 - every `GenerateConfig.fallback_models[i]` entry, at `<config>.fallback_models[i]`, inheriting the owning model's `role`.
 
-`GenerateConfig.fallback_models` names real models that handle requests after a classifier refusal, so — like `FlowModel.default` — each is a distinct model that runs and must be counted. Config is walked wherever it appears post-merge: `FlowTask` and live `Task` `config`, `FlowModel` and live `Model` `config` (at every model site above), and `options.scanner.generate_config`; `defaults.config` merges into each task's config before iteration. Note `apply_defaults` also hoists the default model's own config into the task config, so a fallback declared on `FlowModel.config` is reported at both merged locations — same name, two paths — and a fallback on a *callable-factory* model surfaces only at the task path, which is the one place it genuinely still applies (the model-level config is dead there, but the hoisted task-level copy governs generation).
+`GenerateConfig.fallback_models` names real models that handle requests after a classifier refusal, so each is a distinct model that runs and must be counted. Config is walked wherever it appears post-merge: `FlowTask` and live `Task` `config`, `FlowModel` and live `Model` `config` (at every model site above), and `options.scanner.generate_config`; `defaults.config` merges into each task's config before iteration. Note `apply_defaults` also hoists the default model's own config into the task config, so a fallback declared on `FlowModel.config` is reported at both merged locations — same name, two paths — and a fallback on a *callable-factory* model surfaces only at the task path, which is the one place it genuinely still applies (the model-level config is dead there, but the hoisted task-level copy governs generation).
 
 `GenerateConfig`-typed fields reload from a YAML/JSON wire spec as `GenerateConfig`, but `ScannerConfig.generate_config` is typed `Any` and survives the round-trip as a plain mapping. The walk therefore reads `fallback_models` from either a `GenerateConfig` or a mapping, so a scanner's fallback models are counted on the serialized path (the one a remote host actually submits) as well as in-process.
 
 ### How Hawk collapses onto this
 
-- `flow_model_names(spec)` → `{r.name for r in iter_model_refs(spec) if r.name and r.kind != "fallback"}` (the `.default` refs supply the fallback names; `kind == "fallback"` entries are provider-native ids in a different namespace, so they are filtered out rather than authorized as Inspect references);
+- `flow_model_names(spec)` → `{r.name for r in iter_model_refs(spec) if r.name and r.kind != "fallback"}` (`kind == "fallback"` entries are provider-native ids in a different namespace, so they are filtered out rather than authorized as Inspect references);
 - `enforce_model_guardrails(spec)` → iterate the refs whose `ref` is a `FlowModel`;
 - `options.scanner` models are now covered for free, closing a gap the private port had — for *enumeration*. Not for api-key scrubbing: a scanner model site yields a `str` or `Model`, never a `FlowModel`, so `ScannerConfig.model_args` (the same back door Hawk closes on `FlowModel.model_args`) still needs its own check.
 - List-valued task roles relax two invariants a host might have assumed: one path no longer maps to at most one model within a role (elements are indexed under the same `model_roles[role]` prefix), and one role no longer maps to one ref (each element carries the same `role`). Set-of-names collapsing — `{r.name for r in refs}`, what `flow_model_names` computes — is unaffected.

--- a/src/inspect_flow/_config/model_refs.py
+++ b/src/inspect_flow/_config/model_refs.py
@@ -14,7 +14,7 @@ from inspect_flow._types.flow_types import (
     NotGiven,
 )
 from inspect_flow._util.list_util import is_sequence
-from inspect_flow._util.not_given import default_none, is_set
+from inspect_flow._util.not_given import default_none
 
 
 # Not `frozen=True`: that generates a `__hash__`, and `ref` may be a mutable
@@ -51,14 +51,13 @@ class SpecModelRef:
     says it "does not apply to model roles"), so no role participates at that
     layer — the task's `model_roles` models generate with it too."""
 
-    kind: Literal["model", "default", "fallback"] = "model"
+    kind: Literal["model", "fallback"] = "model"
     """Which kind of reference this is, and hence which namespace `name` is in.
 
-    `"model"` and `"default"` (a `FlowModel.default`) are Inspect
-    `provider/model` references. `"fallback"` is a `GenerateConfig.fallback_models`
-    entry, which is a provider-native id with no provider prefix. A host
-    comparing or authorizing names across both must branch on this rather than
-    parse `path`."""
+    `"model"` is an Inspect `provider/model` reference. `"fallback"` is a
+    `GenerateConfig.fallback_models` entry, which is a provider-native id with
+    no provider prefix. A host comparing or authorizing names across both must
+    branch on this rather than parse `path`."""
 
     @property
     def name(self) -> str | None:
@@ -165,14 +164,9 @@ def iter_model_refs(spec: FlowSpec) -> Iterator[SpecModelRef]:
     `Task`), and `options.scanner`. A list-valued task role (one role bound to
     several models) yields one ref per element, at an indexed path
     (`tasks[0].model_roles['grader'][0]`), each carrying the role — so a role
-    may map to several refs. A `FlowModel`'s `default` fallback is
-    yielded as its own reference at `<path>.default`: it is a declared
-    reference naming a distinct model, enumerated because the field is still
-    in the schema even though Flow does not currently bind it (issue #778,
-    which will likely remove the field — this handling retires with it).
-    Likewise every `GenerateConfig.fallback_models` entry (on a task, model,
-    or scanner) is yielded at `<config>.fallback_models[i]`, because those
-    models handle requests after a classifier refusal.
+    may map to several refs. Every `GenerateConfig.fallback_models` entry (on
+    a task, model, or scanner) is yielded at `<config>.fallback_models[i]`,
+    because those models handle requests after a classifier refusal.
 
     Nothing is instantiated, installed, or read from disk — which is why a
     spec whose `includes` have not been expanded is rejected: includes
@@ -340,11 +334,11 @@ def _model_refs(
         yield SpecModelRef(path, None, role)
         return
     # A callable `factory` returns the Model itself, so `_create_model` returns
-    # before `get_model`, and this FlowModel's `default` and `role` are never
-    # applied — reporting them would name models (or bind roles) that cannot
-    # run. Its `config` is different: `apply_defaults` hoists it into the
-    # task-level config, which does govern generation, so its fallbacks are
-    # reported there by the task walk rather than at this dead model path.
+    # before `get_model`, and this FlowModel's `role` is never applied —
+    # reporting it would bind a role that cannot run. Its `config` is
+    # different: `apply_defaults` hoists it into the task-level config, which
+    # does govern generation, so its fallbacks are reported there by the task
+    # walk rather than at this dead model path.
     built_by_callable = isinstance(ref, FlowModel) and callable(_effective_factory(ref))
     if role is None and not isinstance(ref, str) and not built_by_callable:
         # A model outside model_roles can still bind a role: FlowModel.role is
@@ -354,8 +348,6 @@ def _model_refs(
     yield SpecModelRef(path, ref, role)
     if built_by_callable:
         return
-    if isinstance(ref, FlowModel) and is_set(ref.default):
-        yield SpecModelRef(f"{path}.default", ref.default, role, "default")
     if not isinstance(ref, str):
         yield from _fallback_model_refs(ref.config, f"{path}.config", role)
 

--- a/src/inspect_flow/_runner/instantiate.py
+++ b/src/inspect_flow/_runner/instantiate.py
@@ -263,7 +263,6 @@ def _create_model(task: FlowTask, model: FlowModel | Model) -> Model:
     return get_model(
         model=result.name,
         role=default_none(model.role),
-        default=default_none(model.default),
         config=model.config or GenerateConfig(),
         base_url=default_none(model.base_url),
         api_key=default_none(model.api_key),

--- a/src/inspect_flow/_types/flow_types.py
+++ b/src/inspect_flow/_types/flow_types.py
@@ -246,12 +246,7 @@ class FlowModel(FlowBase):
 
     role: str | None | NotGiven = Field(
         default=not_given,
-        description="Optional named role for model (e.g. for roles specified at the task or eval level). Provide a default as a fallback in the case where the role hasn't been externally specified.",
-    )
-
-    default: str | None | NotGiven = Field(
-        default=not_given,
-        description="Optional. Fallback model in case the specified model or role is not found. Should be a fully qualified model name (e.g. `openai/gpt-4o`).",
+        description="Optional named role for model (e.g. for roles specified at the task or eval level).",
     )
 
     config: GenerateConfig | None | NotGiven = Field(

--- a/src/inspect_flow/_types/generated.py
+++ b/src/inspect_flow/_types/generated.py
@@ -97,9 +97,7 @@ class FlowModelDict(TypedDict, closed=True):
     factory: NotRequired[FlowFactoryModel | str | NotGiven | None]
     """Factory function to create the model instance."""
     role: NotRequired[str | NotGiven | None]
-    """Optional named role for model (e.g. for roles specified at the task or eval level). Provide a default as a fallback in the case where the role hasn't been externally specified."""
-    default: NotRequired[str | NotGiven | None]
-    """Optional. Fallback model in case the specified model or role is not found. Should be a fully qualified model name (e.g. `openai/gpt-4o`)."""
+    """Optional named role for model (e.g. for roles specified at the task or eval level)."""
     config: NotRequired[GenerateConfig | NotGiven | None]
     """Model generation config. Highest precedence: overrides `config` on `FlowTask` and `defaults.config`."""
     base_url: NotRequired[str | NotGiven | None]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -674,6 +674,23 @@ def test_load_invalid() -> None:
     assert isinstance(e.value.__cause__, ValidationError)
 
 
+def test_load_rejects_removed_model_default(tmp_path: Path) -> None:
+    # FlowModel.default never took effect and was removed (#778); FlowBase
+    # forbids extra fields, so a spec still declaring it fails validation.
+    config = tmp_path / "flow.yml"
+    config.write_text(
+        "tasks:\n"
+        "  - name: t\n"
+        "    model:\n"
+        "      name: openai/gpt-4o\n"
+        "      default: openai/gpt-4o-mini\n"
+    )
+    with pytest.raises(FlowHandledError) as e:
+        load_spec(str(config))
+    assert isinstance(e.value.__cause__, ValidationError)
+    assert "Extra inputs are not permitted" in str(e.value.__cause__)
+
+
 def test_load_no_spec() -> None:
     config_path = str(Path(config_dir) / "dirty_repo_flow.py")
     with pytest.raises(ValueError):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -687,8 +687,11 @@ def test_load_rejects_removed_model_default(tmp_path: Path) -> None:
     )
     with pytest.raises(FlowHandledError) as e:
         load_spec(str(config))
-    assert isinstance(e.value.__cause__, ValidationError)
-    assert "Extra inputs are not permitted" in str(e.value.__cause__)
+    cause = e.value.__cause__
+    assert isinstance(cause, ValidationError)
+    assert ("extra_forbidden", ("FlowModel", "default")) in [
+        (err["type"], err["loc"][-2:]) for err in cause.errors()
+    ]
 
 
 def test_load_no_spec() -> None:

--- a/tests/test_model_refs.py
+++ b/tests/test_model_refs.py
@@ -53,20 +53,9 @@ def test_task_model_string() -> None:
     assert _refs(spec) == [("tasks[0].model", "openai/gpt-4o", None)]
 
 
-def test_task_model_flow_model_name_and_default() -> None:
-    # A FlowModel names up to two models: `name` and its `default` fallback.
-    # Both must surface, as separate refs, so a host counts each.
-    spec = FlowSpec(
-        tasks=[
-            FlowTask(
-                model=FlowModel(name="openai/gpt-4o", default="openai/gpt-4o-mini")
-            )
-        ]
-    )
-    assert _refs(spec) == [
-        ("tasks[0].model", "openai/gpt-4o", None),
-        ("tasks[0].model.default", "openai/gpt-4o-mini", None),
-    ]
+def test_task_model_flow_model_name() -> None:
+    spec = FlowSpec(tasks=[FlowTask(model=FlowModel(name="openai/gpt-4o"))])
+    assert _refs(spec) == [("tasks[0].model", "openai/gpt-4o", None)]
 
 
 def test_flow_model_factory_only_has_no_name() -> None:
@@ -119,13 +108,12 @@ def test_from_factory_flags_names_taken_from_factory() -> None:
 
 def test_callable_factory_suppresses_fields_it_ignores() -> None:
     # A callable factory returns the Model itself, so _create_model returns
-    # before get_model and this FlowModel's default/role are dead — reporting
-    # them would gate on models that cannot run. Its config is NOT dead:
+    # before get_model and this FlowModel's role is dead — reporting it would
+    # bind a role that cannot run. Its config is NOT dead:
     # apply_defaults hoists it into the task-level config, which governs
     # generation, so the fallback surfaces there (and only there).
     fm = FlowModel(
         factory=_module_level_model_factory,
-        default="openai/never-runs",
         role="ignored",
         config=GenerateConfig(fallback_models=["claude-runs-via-task-config"]),
     )
@@ -176,7 +164,7 @@ def test_task_model_roles_carry_role() -> None:
                 model="openai/gpt-4o",
                 model_roles={
                     "grader": "anthropic/claude-3-5-sonnet",
-                    "red_team": FlowModel(name="openai/gpt-4o", default="openai/o1"),
+                    "red_team": FlowModel(name="openai/gpt-4o"),
                 },
             )
         ]
@@ -185,7 +173,6 @@ def test_task_model_roles_carry_role() -> None:
         ("tasks[0].model", "openai/gpt-4o", None),
         ("tasks[0].model_roles['grader']", "anthropic/claude-3-5-sonnet", "grader"),
         ("tasks[0].model_roles['red_team']", "openai/gpt-4o", "red_team"),
-        ("tasks[0].model_roles['red_team'].default", "openai/o1", "red_team"),
     ]
 
 
@@ -232,10 +219,12 @@ def test_live_task_list_valued_model_role_enumerated() -> None:
 
 def test_model_prefix_defaults_apply_per_list_element() -> None:
     # Prefix defaults match each element's own name, so only the matching
-    # element gains the default fallback.
+    # element gains the template's config.
     spec = FlowSpec(
         defaults=FlowDefaults(
-            model_prefix={"openai/": FlowModel(default="openai/fallback")}
+            model_prefix={
+                "openai/": FlowModel(config=GenerateConfig(fallback_models=["fb"]))
+            }
         ),
         tasks=[
             FlowTask(
@@ -250,7 +239,7 @@ def test_model_prefix_defaults_apply_per_list_element() -> None:
     )
     assert _refs(spec) == [
         ("tasks[0].model_roles['grader'][0]", "openai/a", "grader"),
-        ("tasks[0].model_roles['grader'][0].default", "openai/fallback", "grader"),
+        ("tasks[0].model_roles['grader'][0].config.fallback_models[0]", "fb", "grader"),
         ("tasks[0].model_roles['grader'][1]", "anthropic/b", "grader"),
     ]
 
@@ -281,22 +270,21 @@ def test_live_model_name_is_qualified() -> None:
 def test_defaults_merge_into_tasks_before_iteration() -> None:
     # Defaults are partial templates, not declarations: iteration happens on
     # the apply_defaults-merged spec, so their values are reported at the tasks
-    # they actually land on — with the merged role and .default fallback.
+    # they actually land on — with the merged role (a prefix template wins
+    # over the generic one).
     spec = FlowSpec(
         tasks=[
             FlowTask(name="t", model="openai/gpt-4o"),
             FlowTask(name="u", model="anthropic/claude-3-5-sonnet"),
         ],
         defaults=FlowDefaults(
-            model=FlowModel(default="openai/gpt-4o-mini"),
+            model=FlowModel(role="generic"),
             model_prefix={"anthropic/": FlowModel(role="special")},
         ),
     )
     assert _refs(spec) == [
-        ("tasks[0].model", "openai/gpt-4o", None),
-        ("tasks[0].model.default", "openai/gpt-4o-mini", None),
+        ("tasks[0].model", "openai/gpt-4o", "generic"),
         ("tasks[1].model", "anthropic/claude-3-5-sonnet", "special"),
-        ("tasks[1].model.default", "openai/gpt-4o-mini", "special"),
     ]
 
 
@@ -326,7 +314,7 @@ def test_defaults_on_taskless_spec_yield_nothing() -> None:
     # runs, so it produces no references.
     spec = FlowSpec(
         defaults=FlowDefaults(
-            model=FlowModel(name="openai/gpt-4o", default="openai/gpt-4o-mini"),
+            model=FlowModel(name="openai/gpt-4o"),
             task=FlowTask(model_roles={"grader": "anthropic/claude-3-5-sonnet"}),
         )
     )
@@ -665,17 +653,13 @@ def test_hawk_style_consumption() -> None:
     spec = FlowSpec(
         tasks=[
             FlowTask(
-                model=FlowModel(name="openai/gpt-4o", default="openai/gpt-4o-mini"),
+                model=FlowModel(name="openai/gpt-4o"),
                 model_roles={"grader": "anthropic/claude-3-5-sonnet"},
             )
         ]
     )
     names = {r.name for r in iter_model_refs(spec) if r.name}
-    assert names == {
-        "openai/gpt-4o",
-        "openai/gpt-4o-mini",
-        "anthropic/claude-3-5-sonnet",
-    }
+    assert names == {"openai/gpt-4o", "anthropic/claude-3-5-sonnet"}
     flow_models = [r.ref for r in iter_model_refs(spec) if isinstance(r.ref, FlowModel)]
     assert len(flow_models) == 1
 
@@ -754,7 +738,6 @@ def test_kind_discriminates_reference_namespaces() -> None:
             FlowTask(
                 model=FlowModel(
                     name="anthropic/claude-opus-4-5",
-                    default="anthropic/claude-sonnet-4-5",
                     config=GenerateConfig(fallback_models=["claude-haiku-4-5"]),
                 )
             )
@@ -762,15 +745,13 @@ def test_kind_discriminates_reference_namespaces() -> None:
     )
     assert [(r.path, r.kind) for r in iter_model_refs(spec)] == [
         ("tasks[0].model", "model"),
-        ("tasks[0].model.default", "default"),
         ("tasks[0].model.config.fallback_models[0]", "fallback"),
         # apply_defaults hoists the model's config into task.config too.
         ("tasks[0].config.fallback_models[0]", "fallback"),
     ]
     # The Inspect-namespaced subset a host authorizes by `provider/model`.
     assert {r.name for r in iter_model_refs(spec) if r.kind != "fallback"} == {
-        "anthropic/claude-opus-4-5",
-        "anthropic/claude-sonnet-4-5",
+        "anthropic/claude-opus-4-5"
     }
 
 
@@ -789,8 +770,9 @@ def test_walk_over_loaded_spec(tmp_path: Path) -> None:
         "  - name: t\n"
         "    model: openai/gpt-4o\n"
         "defaults:\n"
-        "  model:\n"
-        "    default: openai/gpt-4o-mini\n"
+        "  task:\n"
+        "    model_roles:\n"
+        "      grader: openai/gpt-4o-mini\n"
     )
     spec = load_spec(str(config))
     assert {r.name for r in iter_model_refs(spec)} == {
@@ -888,7 +870,6 @@ def test_no_model_shaped_value_escapes_unclassified() -> None:
                 name="t",
                 model=FlowModel(
                     name="openai/a",
-                    default="openai/b",
                     config=GenerateConfig(fallback_models=["claude-x"]),
                 ),
                 model_roles={"grader": "openai/c"},
@@ -927,12 +908,10 @@ def test_no_model_shaped_value_escapes_unclassified() -> None:
     }
     # The converse gap is expected — this is why the oracle complements the
     # hand-written walk rather than replacing it. A live Task is not a pydantic
-    # model, so nothing generic reaches the models inside it; and `default` is
-    # not a *model*-named field, so a name heuristic cannot discover it either.
+    # model, so nothing generic reaches the models inside it.
     assert walked - candidates == {
         "tasks[1].model",
         "tasks[1].model_roles['g']",
-        "tasks[0].model.default",
     }
 
 
@@ -1012,7 +991,6 @@ def test_spec_fields_are_classified_for_models() -> None:
         "api_key",
         "base_url",
         "config",
-        "default",
         "factory",
         "flow_metadata",
         "memoize",

--- a/tests/test_venv.py
+++ b/tests/test_venv.py
@@ -367,22 +367,6 @@ def test_779_auto_dependency_inline_scanner_models() -> None:
     ]
 
 
-def test_779_auto_dependency_flow_model_default() -> None:
-    spec = FlowSpec(
-        tasks=[
-            FlowTask(
-                name="inspect_evals/task_name",
-                model=FlowModel(name="openai/gpt-4o", default="anthropic/claude-x"),
-            )
-        ]
-    )
-    assert collect_auto_dependencies(spec) == [
-        _get_pip_string_with_version("anthropic"),
-        "inspect_evals",
-        _get_pip_string_with_version("openai"),
-    ]
-
-
 def test_779_flow_model_string_factory_is_the_model_id() -> None:
     # a string factory is passed to get_model(model=...) and wins over name
     spec = FlowSpec(


### PR DESCRIPTION
Fixes #778.

## Problem

`FlowModel.default` was documented as "Fallback model in case the specified model or role is not found", but it never took effect. `_create_model` passed it to `get_model(default=...)`, which Inspect reads only when `model is None`. Flow always passes a name, so the argument was unreachable, and a `FlowModel` with `default` but no `name` raised "Model name is required" before ever reaching `get_model`. Config validation accepted the field silently, so users could declare a fallback that did nothing.

## Fix

Remove the field rather than make it work, as agreed on the issue.

- `FlowModel.default` deleted from `flow_types.py`; `generated.py` regenerated. The `role` description also loses its trailing "Provide a default as a fallback..." sentence, which referred to the removed field.
- `_create_model` no longer passes `default=` to `get_model`.
- `iter_model_refs` no longer yields a `<path>.default` reference, and `SpecModelRef.kind` is now `Literal["model", "fallback"]`. The `iter_model_refs` docstring drops the paragraph that speculated about this issue.
- `auto_dependencies.py` needs no change (it reads refs by name); the #809 test case (now on main) covering `default=` is removed.
- `tests/test_model_refs.py` rewritten where it used `default=`, keeping coverage of kind discrimination, defaults/prefix merging, list-valued roles, the loader path, and the field-name snapshot.
- New `test_load_rejects_removed_model_default` asserts a YAML spec with `default:` under a model fails at load with pydantic's extra-field error.
- `design/model_reference_introspection.md` keeps a short historical note about the field.

## Breaking change

`FlowBase` uses `extra="forbid"`, so any existing config that declares `default` under a model now fails validation at load. Since the field never had an effect, removing the key is a no-op for those configs. Hosts introspecting specs via `iter_model_refs` will no longer see `kind="default"` refs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

BREAKING CHANGE: `FlowModel.default` is removed. A config that declares `default` under a model now fails validation at load; delete the key, it never had any effect. `SpecModelRef.kind` no longer includes `"default"`.
