### PR TITLE
chore: bump minor, not major, for pre-1.0 breaking changes

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -54,7 +54,8 @@
           "section": "Styles",
           "hidden": true
         }
-      ]
+      ],
+      "bump-minor-pre-major": true
     }
   }
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,6 +65,7 @@ headline the release notes:
 | --- | --- |
 | `feat:` | a user-facing feature — bumps the minor version |
 | `fix:` | a user-facing bug fix — bumps the patch version |
+| `feat!:` / `BREAKING CHANGE:` footer | bumps the minor version (pre-1.0 policy) and is called out in the release notes |
 | `perf:`, `revert:` | appear in the release notes (no bump on their own) |
 | `docs:`, `refactor:`, `chore:`, `build:`, `ci:`, `test:`, `style:` | hidden from the release notes |
 


### PR DESCRIPTION
## Problem

#810 landed with a `BREAKING CHANGE:` footer so the changelog would tell users to delete the removed `default:` key. release-please's default policy bumps the **major** version on a breaking change even on 0.x, so it retitled the pending release PR #807 from 0.13.0 to 1.0.0. We are not ready to declare 1.0.0 (I assume).

## Fix

Set `bump-minor-pre-major: true` in `.release-please-config.json`. A breaking change now bumps the minor version while flow is pre-1.0. `feat:` continues to bump minor and `fix:` patch, so flow's existing feature-driven release cadence is unchanged.

Once merged, release-please recomputes #807 from all commits since v0.12.0 under the new config and should retitle it back to 0.13.0, with the "⚠ BREAKING CHANGES" section retained. **Do not merge #807 until that happens.** If it does not retitle within a few minutes, re-run the Release workflow via `workflow_dispatch`.

## Why only one flag

The sibling repos (scout, swe, viz, petri_bloom, petri_dish) set both `bump-minor-pre-major` and `bump-patch-for-minor-pre-major`. Their migration PRs justify the pair as matching each repo's history (1–6% minor releases, so `feat:` bumps patch). Flow's history is the opposite: 12 of the last 20 releases were minors, and #749 explicitly preserved default semver as "flow's existing behavior, unchanged". Copying the second flag would silently change flow's cadence so features bump patch, which is a separate decision. This PR takes only the flag that fixes the breaking-change case.

## Docs

Adds a row to the CONTRIBUTING.md bump table for breaking changes, following the same table in inspect_petri's CONTRIBUTING.md. AGENTS.md is left alone; no sibling repo documents this there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
