### PR TITLE
build: regenerate types for inspect-ai 0.3.262 (stream_idle_timeout)

### DIFF
--- a/src/inspect_flow/_runner/task_log.py
+++ b/src/inspect_flow/_runner/task_log.py
@@ -161,7 +161,8 @@ def _task_fields(infos: list[TaskInfo]) -> list[_TaskField]:
         _simple_attr("working_limit"),
         _simple_attr("cost_limit"),
         # GenerateConfig fields included in task_identifier
-        # (all except max_connections, batch, timeout, attempt_timeout, max_retries)
+        # (all except max_connections, batch, timeout, attempt_timeout,
+        # stream_idle_timeout, max_retries)
         _config("temperature"),
         _config("top_p"),
         _config("max_tokens"),

--- a/src/inspect_flow/_runner/task_log.py
+++ b/src/inspect_flow/_runner/task_log.py
@@ -160,9 +160,9 @@ def _task_fields(infos: list[TaskInfo]) -> list[_TaskField]:
         _simple_attr("time_limit"),
         _simple_attr("working_limit"),
         _simple_attr("cost_limit"),
-        # GenerateConfig fields included in task_identifier
-        # (all except max_connections, batch, timeout, attempt_timeout,
-        # stream_idle_timeout, max_retries)
+        # Subset of GenerateConfig fields that affect task_identifier; see
+        # GENERATE_CONFIG_FIELDS_TO_EXCLUDE in inspect_ai._eval.evalset for
+        # the fields inspect excludes
         _config("temperature"),
         _config("top_p"),
         _config("max_tokens"),
@@ -181,7 +181,6 @@ def _task_fields(infos: list[TaskInfo]) -> list[_TaskField]:
             lambda info: getattr(info.config, "system_message", None),
             lambda v: "system_message=...",
         ),
-        _config("cache_prompt"),
         _config("reasoning_effort"),
         _config("reasoning_tokens"),
         _config("effort"),

--- a/src/inspect_flow/_types/generated.py
+++ b/src/inspect_flow/_types/generated.py
@@ -296,6 +296,8 @@ class GenerateConfigDict(TypedDict):
     """Timeout (in seconds) for an entire request (including retries)."""
     attempt_timeout: NotRequired[int | None]
     """Timeout (in seconds) for any given attempt (if exceeded, will abandon attempt and retry according to max_retries)."""
+    stream_idle_timeout: NotRequired[int | None]
+    """Timeout (in seconds) on silence within a streaming response — if a streaming attempt delivers no chunk for this long, the attempt is abandoned and retried according to max_retries. Setting it requests streaming (like on_stream); it has no effect on calls that do not stream."""
     max_connections: NotRequired[int | None]
     """Maximum number of concurrent connections to Model API (default is model specific)."""
     adaptive_connections: NotRequired[bool | int | AdaptiveConcurrency | None]

--- a/uv.lock
+++ b/uv.lock
@@ -1947,7 +1947,7 @@ wheels = [
 
 [[package]]
 name = "inspect-ai"
-version = "0.3.261"
+version = "0.3.262"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "agent-client-protocol" },
@@ -1993,9 +1993,9 @@ dependencies = [
     { name = "zipp" },
     { name = "zstandard" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f2/50/b80fb15dd5cd6c7a989bef1f574f895ea237a88fbb58448c7fd773f8fc69/inspect_ai-0.3.261.tar.gz", hash = "sha256:58d40586052589383ffb09c43b12835f39f05f982d2a4325afa46ac9fd9fe2bc", size = 35427927, upload-time = "2026-08-30T17:51:30.831Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8b/16/5a2acabbe583ee14190526f13b940a610457f50e830e997ebcdaf6f43f06/inspect_ai-0.3.262.tar.gz", hash = "sha256:6cecc88d0afe2e6f5b95dface68f8832cf25e8f9d218d93ec2f45d73ad4e4deb", size = 35753901, upload-time = "2026-09-03T00:56:53.623Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e3/19/a11c5b267f576c03af2701984b1e40a8f7874ec2d3e5940ba0e8447cdd85/inspect_ai-0.3.261-py3-none-any.whl", hash = "sha256:b30e4c2c4d380343072ec9e14019eae46e9e41401bed34d2ca1c79adeb700be6", size = 34134727, upload-time = "2026-08-30T17:51:21.291Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/1a/86f98d371fb5ab7b5f9996218133f10bb67ad8686548d70842e163140752/inspect_ai-0.3.262-py3-none-any.whl", hash = "sha256:13ae09ccc921edfb583a248f704f23aa81a5d5001a656a9f1cc9ecf4b8b008aa", size = 34262859, upload-time = "2026-09-03T00:56:42.34Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Fixes #802

inspect-ai 0.3.262 adds GenerateConfig.stream_idle_timeout. Bump uv.lock
to 0.3.262 and regenerate generated.py so the check-type-gen job passes
against both the locked release and inspect-ai main.

The original pyright errors in #802 (list.py / scan.py model_roles) were
already resolved by #804.

Fixes #802

Co-authored-by: Ransom Richardson <1209015+ransomr@users.noreply.github.com>
Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>