### PR TITLE
build: regenerate types for inspect-ai 0.3.263 (reasoning_mode docstring)

### DIFF
--- a/src/inspect_flow/_types/generated.py
+++ b/src/inspect_flow/_types/generated.py
@@ -351,7 +351,7 @@ class GenerateConfigDict(TypedDict):
     ]
     """Constrains effort on reasoning. Defaults vary by provider and model and not all models support all values (please consult provider documentation for details)."""
     reasoning_mode: NotRequired[Literal["standard", "pro"] | None]
-    """Reasoning mode. "pro" performs more model work for greater reliability on difficult tasks, at higher latency and token usage. OpenAI GPT-5.6+ models only ("standard" is the default)."""
+    """Reasoning mode. "pro" performs more model work for greater reliability on difficult tasks, at higher latency and token usage. OpenAI GPT-5.6 models only ("standard" is the default; GPT-6 does not support "pro")."""
     reasoning_tokens: NotRequired[int | None]
     """Maximum number of tokens to use for reasoning. Anthropic Claude models only."""
     reasoning_summary: NotRequired[
@@ -429,7 +429,7 @@ class GenerateConfigMatrixDict(TypedDict):
     ]
     """Constrains effort on reasoning. Defaults vary by provider and model and not all models support all values (please consult provider documentation for details)."""
     reasoning_mode: NotRequired[Sequence[Literal["standard", "pro"] | None] | None]
-    """Reasoning mode. "pro" performs more model work for greater reliability on difficult tasks, at higher latency and token usage. OpenAI GPT-5.6+ models only ("standard" is the default)."""
+    """Reasoning mode. "pro" performs more model work for greater reliability on difficult tasks, at higher latency and token usage. OpenAI GPT-5.6 models only ("standard" is the default; GPT-6 does not support "pro")."""
     reasoning_tokens: NotRequired[Sequence[int | None] | None]
     """Maximum number of tokens to use for reasoning. Anthropic Claude models only."""
     reasoning_summary: NotRequired[

--- a/uv.lock
+++ b/uv.lock
@@ -1947,7 +1947,7 @@ wheels = [
 
 [[package]]
 name = "inspect-ai"
-version = "0.3.262"
+version = "0.3.263"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "agent-client-protocol" },
@@ -1968,6 +1968,7 @@ dependencies = [
     { name = "jsonpath-ng" },
     { name = "jsonref" },
     { name = "jsonschema" },
+    { name = "markdown-it-py" },
     { name = "mmh3" },
     { name = "nest-asyncio2" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -1993,9 +1994,9 @@ dependencies = [
     { name = "zipp" },
     { name = "zstandard" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8b/16/5a2acabbe583ee14190526f13b940a610457f50e830e997ebcdaf6f43f06/inspect_ai-0.3.262.tar.gz", hash = "sha256:6cecc88d0afe2e6f5b95dface68f8832cf25e8f9d218d93ec2f45d73ad4e4deb", size = 35753901, upload-time = "2026-09-03T00:56:53.623Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/03/3bd61990e197e6e0a68ebd7f1496d0b80af6c1966eea0e48fcfc1ed3b793/inspect_ai-0.3.263.tar.gz", hash = "sha256:54553ca8bfe711853414b49d962e492a60fd4cac8df935be47287a4b719f92b1", size = 35796833, upload-time = "2026-09-04T01:38:04.104Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cc/1a/86f98d371fb5ab7b5f9996218133f10bb67ad8686548d70842e163140752/inspect_ai-0.3.262-py3-none-any.whl", hash = "sha256:13ae09ccc921edfb583a248f704f23aa81a5d5001a656a9f1cc9ecf4b8b008aa", size = 34262859, upload-time = "2026-09-03T00:56:42.34Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/c0/c12e505462462d5cc2b3fa98b6b2142c9589ebc0308144498f6e9de0c70c/inspect_ai-0.3.263-py3-none-any.whl", hash = "sha256:503e7ff509d77fcdf65989027a19fea966fb668deb88a234468c3290964fd86a", size = 34294681, upload-time = "2026-09-04T01:37:58.013Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Fixes #813

## Root cause

The Inspect AI Main CI canary ([run 33832241441](https://github.com/meridianlabs-ai/inspect_flow/actions/runs/33832241441)) failed only in `check-type-gen`. inspect-ai commit `3e2c8551` ("Support for OpenAI GPT-6 Astra", #5236) reworded the `GenerateConfig.reasoning_mode` docstring, so `type_gen.py` regenerates `generated.py` with two changed docstring lines. Lint, type check, and tests all passed against inspect-ai main.

This change is already released in inspect-ai 0.3.263 (03 September 2026); the released wheel produces byte-identical output to inspect-ai main. Flow's lock was still on 0.3.262, so this is a clean reconciliation rather than an in-flux change.

## Fix

- Bump `uv.lock` inspect-ai 0.3.262 -> 0.3.263 (only that entry).
- Regenerate `src/inspect_flow/_types/generated.py` (docstring-only diff, no type changes).

Regenerating against 0.3.263 and against inspect-ai main gives the same file, so `check-type-gen` passes in both the regular CI and the canary.

## Verification

`ruff format`, `ruff check --fix`, `pyright` (0 errors), `pytest` (793 passed, 8 skipped) all clean on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)