### PR TITLE
fix: collect venv auto-dependencies from string factory references

### DIFF
--- a/docs/advanced.qmd
+++ b/docs/advanced.qmd
@@ -81,6 +81,7 @@ In virtual environment mode, Flow automatically discovers and installs dependenc
 - **Package inference**: Detects packages from Flow type names in your config:
   - Models: `model="openai/gpt-4"` → installs `openai`
   - Tasks: `FlowTask(name="inspect_evals/mmlu")` → installs `inspect-evals`
+  - Factories: `FlowTask(factory="inspect_evals/mmlu")` (or `factory=FlowFactory("inspect_evals/mmlu")`) infers the same package. A registry-decorated callable factory (e.g. `factory=mmlu`) infers the package of its registry name. When both `name` and `factory` are given, `factory` decides the package, matching how the runner resolves the object
   - Note: Package inference only works with Flow types (`FlowTask`, `FlowModel`, etc.), not direct Inspect AI objects
 
 This means most workflows require no dependency configuration at all!

--- a/src/inspect_flow/_config/model_refs.py
+++ b/src/inspect_flow/_config/model_refs.py
@@ -12,6 +12,7 @@ from inspect_flow._types.flow_types import (
     FlowSpec,
     FlowTask,
     NotGiven,
+    R,
 )
 from inspect_flow._util.list_util import is_sequence
 from inspect_flow._util.not_given import default_none
@@ -93,10 +94,8 @@ class SpecModelRef:
             return self.ref
         if isinstance(self.ref, Model):
             return str(self.ref)
-        factory = _effective_factory(self.ref)
-        if factory is not None:
-            return factory if isinstance(factory, str) else None
-        return default_none(self.ref.name)
+        ref = effective_ref(self.ref.name, self.ref.factory)
+        return ref if isinstance(ref, str) else None
 
     @property
     def from_factory(self) -> bool:
@@ -110,7 +109,8 @@ class SpecModelRef:
         unwrap `FlowFactory` and re-derive the precedence rule.
         """
         return (
-            isinstance(self.ref, FlowModel) and _effective_factory(self.ref) is not None
+            isinstance(self.ref, FlowModel)
+            and effective_factory(self.ref.factory) is not None
         )
 
     @property
@@ -138,14 +138,25 @@ class SpecModelRef:
         if self.ref is None:
             return True
         if isinstance(self.ref, FlowModel):
-            return callable(_effective_factory(self.ref))
+            return callable(effective_factory(self.ref.factory))
         return False
 
 
-def _effective_factory(model: FlowModel) -> Callable[..., Model] | str | None:
-    """The factory that decides the model, unwrapped from any `FlowFactory`."""
-    factory = default_none(model.factory)
+def effective_factory(
+    factory: FlowFactory[R] | Callable[..., R] | str | None | NotGiven,
+) -> Callable[..., R] | str | None:
+    """The factory that decides the object, unwrapped from any `FlowFactory`."""
+    factory = default_none(factory)
     return factory.factory if isinstance(factory, FlowFactory) else factory
+
+
+def effective_ref(
+    name: str | None | NotGiven,
+    factory: FlowFactory[R] | Callable[..., R] | str | None | NotGiven,
+) -> Callable[..., R] | str | None:
+    """What the runner resolves at this site: the factory if given, else `name`."""
+    factory = effective_factory(factory)
+    return default_none(name) if factory is None else factory
 
 
 def iter_model_refs(spec: FlowSpec) -> Iterator[SpecModelRef]:
@@ -339,7 +350,9 @@ def _model_refs(
     # different: `apply_defaults` hoists it into the task-level config, which
     # does govern generation, so its fallbacks are reported there by the task
     # walk rather than at this dead model path.
-    built_by_callable = isinstance(ref, FlowModel) and callable(_effective_factory(ref))
+    built_by_callable = isinstance(ref, FlowModel) and callable(
+        effective_factory(ref.factory)
+    )
     if role is None and not isinstance(ref, str) and not built_by_callable:
         # A model outside model_roles can still bind a role: FlowModel.role is
         # passed to get_model(role=...), and a live Model carries the role it

--- a/src/inspect_flow/_launcher/auto_dependencies.py
+++ b/src/inspect_flow/_launcher/auto_dependencies.py
@@ -15,7 +15,7 @@ from inspect_ai.util import SandboxEnvironmentType
 from inspect_ai.util._sandbox.registry import registry_match_sandboxenv
 from packaging.utils import canonicalize_name
 
-from inspect_flow._config.model_refs import iter_model_refs
+from inspect_flow._config.model_refs import effective_ref, iter_model_refs
 from inspect_flow._launcher.pip_string import get_pip_string
 from inspect_flow._types.flow_types import (
     FlowAgent,
@@ -26,6 +26,7 @@ from inspect_flow._types.flow_types import (
     FlowTask,
     NotGiven,
 )
+from inspect_flow._util.pydantic_util import callable_name, is_nameable_callable
 
 logger = getLogger(__name__)
 
@@ -95,7 +96,7 @@ def _collect_task_dependencies(
         _collect_env_model_dependencies(dependencies)
         return _collect_name_dependencies(task, dependencies)
 
-    _collect_name_dependencies(_effective_ref(task.name, task.factory), dependencies)
+    _collect_name_dependencies(_effective_name(task.name, task.factory), dependencies)
     _collect_maybe_sequence_dependencies(task.scorer, dependencies)
     _collect_maybe_sequence_dependencies(task.solver, dependencies)
     _collect_sandbox_dependencies(task.sandbox, dependencies)
@@ -112,19 +113,17 @@ def _collect_env_model_dependencies(
         _collect_model_dependencies(env_model, dependencies)
 
 
-def _effective_ref(
+def _effective_name(
     name: str | None | NotGiven,
     factory: FlowFactory[Any] | Callable[..., Any] | str | None | NotGiven,
-) -> str | None | NotGiven:
-    # Mirrors _call_factory: a string factory wins over name, and a callable
-    # factory leaves nothing static to install.
-    if isinstance(factory, FlowFactory):
-        factory = factory.factory
-    if isinstance(factory, str):
-        return factory
-    if callable(factory):
-        return None
-    return name
+) -> str | None:
+    # A registry callable is serialized as its pkg/name and resolved in the
+    # child through the registry, so its package is knowable; no other callable
+    # can be installed statically.
+    ref = effective_ref(name, factory)
+    if callable(ref):
+        return callable_name(ref) if is_nameable_callable(ref) else None
+    return ref
 
 
 def _collect_name_dependencies(
@@ -169,7 +168,7 @@ def _collect_maybe_sequence_dependencies(
         "validate_portable_spec should have ensured no Solver, Scorer, or Agent instances"
     )
     _collect_name_dependencies(
-        _effective_ref(solver.name, solver.factory), dependencies
+        _effective_name(solver.name, solver.factory), dependencies
     )
 
 

--- a/src/inspect_flow/_launcher/auto_dependencies.py
+++ b/src/inspect_flow/_launcher/auto_dependencies.py
@@ -1,6 +1,6 @@
 import os
 from logging import getLogger
-from typing import Collection, Sequence
+from typing import Any, Callable, Collection, Sequence
 
 from inspect_ai import Task
 from inspect_ai._util.registry import (
@@ -19,6 +19,7 @@ from inspect_flow._config.model_refs import iter_model_refs
 from inspect_flow._launcher.pip_string import get_pip_string
 from inspect_flow._types.flow_types import (
     FlowAgent,
+    FlowFactory,
     FlowScorer,
     FlowSolver,
     FlowSpec,
@@ -94,7 +95,7 @@ def _collect_task_dependencies(
         _collect_env_model_dependencies(dependencies)
         return _collect_name_dependencies(task, dependencies)
 
-    _collect_name_dependencies(task.name, dependencies)
+    _collect_name_dependencies(_effective_ref(task.name, task.factory), dependencies)
     _collect_maybe_sequence_dependencies(task.scorer, dependencies)
     _collect_maybe_sequence_dependencies(task.solver, dependencies)
     _collect_sandbox_dependencies(task.sandbox, dependencies)
@@ -109,6 +110,21 @@ def _collect_env_model_dependencies(
 ) -> None:
     if env_model := os.getenv("INSPECT_EVAL_MODEL"):
         _collect_model_dependencies(env_model, dependencies)
+
+
+def _effective_ref(
+    name: str | None | NotGiven,
+    factory: FlowFactory[Any] | Callable[..., Any] | str | None | NotGiven,
+) -> str | None | NotGiven:
+    # Mirrors _call_factory: a string factory wins over name, and a callable
+    # factory leaves nothing static to install.
+    if isinstance(factory, FlowFactory):
+        factory = factory.factory
+    if isinstance(factory, str):
+        return factory
+    if callable(factory):
+        return None
+    return name
 
 
 def _collect_name_dependencies(
@@ -152,7 +168,9 @@ def _collect_maybe_sequence_dependencies(
     assert isinstance(solver, (FlowSolver, FlowScorer, FlowAgent)), (
         "validate_portable_spec should have ensured no Solver, Scorer, or Agent instances"
     )
-    _collect_name_dependencies(solver.name, dependencies)
+    _collect_name_dependencies(
+        _effective_ref(solver.name, solver.factory), dependencies
+    )
 
 
 def _collect_sandbox_dependencies(

--- a/tests/test_venv.py
+++ b/tests/test_venv.py
@@ -14,6 +14,7 @@ from inspect_ai.model import GenerateConfig
 from inspect_ai.util import SandboxEnvironmentSpec
 from inspect_flow import (
     FlowDependencies,
+    FlowFactory,
     FlowModel,
     FlowOptions,
     FlowSolver,
@@ -381,6 +382,27 @@ def test_779_flow_model_string_factory_is_the_model_id() -> None:
         "inspect_evals",
         _get_pip_string_with_version("openai"),
     ]
+
+
+def test_820_string_factory_adds_registry_package() -> None:
+    # the runner resolves a string factory before name, so the package it
+    # references must be installed, whether given bare or via FlowFactory
+    for factory in ["inspect_evals/gsm8k", FlowFactory("inspect_evals/gsm8k")]:
+        spec = FlowSpec(
+            tasks=[
+                FlowTask(
+                    name="other_pkg/task_name",
+                    factory=factory,
+                    model="openai/gpt-4o",
+                    solver=FlowSolver(factory="my_solvers/react_plus"),
+                )
+            ]
+        )
+        assert collect_auto_dependencies(spec) == [
+            "inspect_evals",
+            "my_solvers",
+            _get_pip_string_with_version("openai"),
+        ]
 
 
 def test_779_fallback_models_do_not_add_providers() -> None:

--- a/tests/test_venv.py
+++ b/tests/test_venv.py
@@ -3,6 +3,7 @@ import subprocess
 import sys
 import tempfile
 import threading
+from functools import partial
 from pathlib import Path
 from typing import Any
 from unittest.mock import patch
@@ -27,8 +28,12 @@ from inspect_flow._launcher.freeze import (
     _deduplicate_freeze_requirements,
     write_flow_requirements,
 )
-from inspect_flow._launcher.pip_string import _get_pip_string_with_version
+from inspect_flow._launcher.pip_string import (
+    _get_pip_string_with_version,
+    get_pip_string,
+)
 from inspect_flow._launcher.venv import _create_venv, venv_launch
+from local_eval.noop import noop
 from rich.console import Console
 
 _test_action = RunAction("test")
@@ -403,6 +408,37 @@ def test_820_string_factory_adds_registry_package() -> None:
             "my_solvers",
             _get_pip_string_with_version("openai"),
         ]
+
+
+def test_820_registry_callable_factory_adds_its_package() -> None:
+    # a registry callable is serialized as its pkg/name and resolved in the
+    # child through the registry, so its package must be installed; name is
+    # never resolved when a callable factory is given
+    for factory in [noop, FlowFactory(noop)]:
+        spec = FlowSpec(
+            tasks=[
+                FlowTask(
+                    name="other_pkg/task_name", factory=factory, model="openai/gpt-4o"
+                )
+            ]
+        )
+        assert collect_auto_dependencies(spec) == [
+            get_pip_string("local_eval"),
+            _get_pip_string_with_version("openai"),
+        ]
+
+
+def test_820_unregistered_callable_factory_adds_nothing() -> None:
+    # a partial has no registry entry (and no __code__), so there is nothing
+    # static to install, and its name is never resolved either
+    spec = FlowSpec(
+        tasks=[
+            FlowTask(
+                name="other_pkg/task_name", factory=partial(noop), model="openai/gpt-4o"
+            )
+        ]
+    )
+    assert collect_auto_dependencies(spec) == [_get_pip_string_with_version("openai")]
 
 
 def test_779_fallback_models_do_not_add_providers() -> None:


### PR DESCRIPTION
Fixes #820

collect_auto_dependencies derived registry packages only from the name
field, so a FlowTask, FlowSolver, FlowScorer or FlowAgent that pointed at
a registry entry via factory (bare string or FlowFactory) contributed no
package and instantiation failed inside the venv. Apply the same
precedence the runner uses in _call_factory: a factory wins over name. A
string factory contributes its registry package, a registry callable the
package of its registry name (it is serialized as pkg/name and resolved
in the child through the registry), and any other callable nothing.

The "factory wins over name" rule now lives in one place
(_config/model_refs.py) shared by the model-ref walk and dependency
collection.

Co-authored-by: Craig Walton <294137043+craig-meridian@users.noreply.github.com>
Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>