### PR TITLE
fix: resolve model provider dependencies through the inspect-ai registry

### DIFF
--- a/src/inspect_flow/_launcher/auto_dependencies.py
+++ b/src/inspect_flow/_launcher/auto_dependencies.py
@@ -7,6 +7,7 @@ from inspect_ai._util.registry import (
     registry_find,
     registry_info,
     registry_package_name,
+    registry_unqualified_name,
 )
 from inspect_ai.agent import Agent
 from inspect_ai.scorer import Scorer
@@ -147,8 +148,29 @@ def _collect_name_dependencies(
 
 def _collect_model_dependencies(name: str, dependencies: set[str]) -> None:
     split = name.split("/", maxsplit=1)
-    if len(split) == 2:
-        dependencies.update(_MODEL_PROVIDERS.get(split[0], [split[0]]))
+    if len(split) != 2:
+        return
+    provider = split[0]
+    package = _registered_provider_package(provider)
+    # Built-in providers register under inspect_ai, which is already installed;
+    # the table names the SDKs they actually need.
+    if package is None or package == "inspect_ai":
+        dependencies.update(_MODEL_PROVIDERS.get(provider, [provider]))
+    else:
+        dependencies.add(package)
+
+
+def _registered_provider_package(provider: str) -> str | None:
+    # get_model matches providers by unqualified name so they can be used from
+    # the command line without a package prefix; mirror that here.
+    entries = registry_find(
+        lambda info: (
+            info.type == "modelapi" and registry_unqualified_name(info) == provider
+        )
+    )
+    if not entries:
+        return None
+    return registry_package_name(registry_info(entries[0]).name)
 
 
 def _collect_maybe_sequence_dependencies(

--- a/src/inspect_flow/_launcher/auto_dependencies.py
+++ b/src/inspect_flow/_launcher/auto_dependencies.py
@@ -3,6 +3,7 @@ from logging import getLogger
 from typing import Any, Callable, Collection, Sequence
 
 from inspect_ai import Task
+from inspect_ai._util.entrypoints import ensure_entry_points
 from inspect_ai._util.registry import (
     registry_find,
     registry_info,
@@ -163,14 +164,17 @@ def _collect_model_dependencies(name: str, dependencies: set[str]) -> None:
 def _registered_provider_package(provider: str) -> str | None:
     # get_model matches providers by unqualified name so they can be used from
     # the command line without a package prefix; mirror that here.
+    # A provider module loaded by file path registers without a package prefix
+    # and would satisfy registry_find before it loads entry points, so load them
+    # up front and prefer the package-qualified entry, which names the dependency.
+    ensure_entry_points()
     entries = registry_find(
         lambda info: (
             info.type == "modelapi" and registry_unqualified_name(info) == provider
         )
     )
-    if not entries:
-        return None
-    return registry_package_name(registry_info(entries[0]).name)
+    packages = (registry_package_name(registry_info(e).name) for e in entries)
+    return next((p for p in packages if p), None)
 
 
 def _collect_maybe_sequence_dependencies(

--- a/tests/local_eval/src/local_eval/__init__.py
+++ b/tests/local_eval/src/local_eval/__init__.py
@@ -1,5 +1,6 @@
 from .my_filters import only_success
+from .my_provider import LocalEvalProvider
 from .noop import noop, noop2
 from .tools import add, my_agent
 
-__all__ = ["add", "my_agent", "noop", "noop2", "only_success"]
+__all__ = ["LocalEvalProvider", "add", "my_agent", "noop", "noop2", "only_success"]

--- a/tests/local_eval/src/local_eval/my_provider.py
+++ b/tests/local_eval/src/local_eval/my_provider.py
@@ -1,0 +1,20 @@
+from inspect_ai.model import (
+    ChatMessage,
+    GenerateConfig,
+    ModelAPI,
+    ModelOutput,
+    modelapi,
+)
+from inspect_ai.tool import ToolChoice, ToolInfo
+
+
+@modelapi(name="local_eval_provider")
+class LocalEvalProvider(ModelAPI):
+    async def generate(
+        self,
+        input: list[ChatMessage],
+        tools: list[ToolInfo],
+        tool_choice: ToolChoice,
+        config: GenerateConfig,
+    ) -> ModelOutput:
+        raise NotImplementedError

--- a/tests/test_venv.py
+++ b/tests/test_venv.py
@@ -12,6 +12,7 @@ import inspect_ai.model._providers.providers  # noqa: F401  registers @modelapi 
 import pytest
 from botocore.client import BaseClient
 from inspect_ai import ScannerConfig
+from inspect_ai._util.module import load_module
 from inspect_ai._util.registry import registry_find, registry_info
 from inspect_ai.model import GenerateConfig
 from inspect_ai.util import SandboxEnvironmentSpec
@@ -377,6 +378,9 @@ def test_818_registered_provider_resolves_to_its_package() -> None:
     # A third-party @modelapi provider is registered under its package, so the
     # registry names the dependency rather than the "prefix is a PyPI package"
     # guess, which would require a nonexistent "local_eval_provider" package.
+    # Loading the module by path (as a task file would be) registers the same
+    # provider again without a package; the qualified entry must still win.
+    load_module(Path("tests/local_eval/src/local_eval/my_provider.py"))
     spec = FlowSpec(tasks=[FlowTask(model="local_eval_provider/some-model")])
     assert collect_auto_dependencies(spec) == [get_pip_string("local_eval")]
 

--- a/tests/test_venv.py
+++ b/tests/test_venv.py
@@ -373,6 +373,14 @@ def test_819_model_providers_cover_inspect_ai_registry() -> None:
     assert builtin <= _MODEL_PROVIDERS.keys()
 
 
+def test_818_registered_provider_resolves_to_its_package() -> None:
+    # A third-party @modelapi provider is registered under its package, so the
+    # registry names the dependency rather than the "prefix is a PyPI package"
+    # guess, which would require a nonexistent "local_eval_provider" package.
+    spec = FlowSpec(tasks=[FlowTask(model="local_eval_provider/some-model")])
+    assert collect_auto_dependencies(spec) == [get_pip_string("local_eval")]
+
+
 def test_auto_dependency_list_valued_model_role() -> None:
     # a list-valued role binds several models to one role; every element's
     # provider package must be collected


### PR DESCRIPTION
## Summary

Fixes #818.

`_collect_model_dependencies` derived a model's venv dependency solely from the static `_MODEL_PROVIDERS` table and, on a miss, guessed that the provider prefix was itself a PyPI package. For a third-party `@modelapi` provider such as `custom-provider/some-model` registered by `my_package`, that produced the uninstallable dependency `custom-provider`.

Inspect AI's registry already records which package registered each provider, and `_collect_sandbox_type_dependencies` in the same module already uses it. This change resolves model providers the same way.

## Changes

- `src/inspect_flow/_launcher/auto_dependencies.py`: look the provider up in the `modelapi` registry by unqualified name (mirroring how `get_model` matches providers) and use the registering package as the dependency. Fall back to `_MODEL_PROVIDERS`, then the prefix guess, only when nothing is registered. Built-in providers still resolve through the table, because their registry package is `inspect_ai` rather than the SDK they actually need. `_MODEL_PROVIDERS` itself is unchanged.
- `tests/local_eval/src/local_eval/my_provider.py`: a minimal `@modelapi("local_eval_provider")` fixture registered by the existing `local_eval` test package.
- `tests/test_venv.py`: regression test asserting that `local_eval_provider/some-model` resolves to the `local_eval` package. It failed before the fix (returned `['local_eval_provider']`) and passes after.

## Validation

- `pytest tests/test_venv.py`: 41 passed, 7 skipped
- Related launcher/dependency/model tests: 112 passed
- `ruff check`, `ruff format --check`, and `pyright` on the changed files: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
