### PR TITLE
ci: resync the Claude dev-agent stub with agents#93 (@auto cost filter)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -152,21 +152,40 @@ jobs:
     # label event's actor is whoever added it. The hoisted marvin guard ate
     # that trigger (observed: inspect_ai#236). Labeling is safe to exempt:
     # the gate reads the label NAME (no quoted-token hazard), labeling needs
-    # triage access, and the action separately verifies the actor has write
-    # access before running. Comment/body paths keep the full guard.
+    # triage access, and the reusable workflow's trigger check verifies the
+    # labeler has write access before running. Comment/body paths keep the
+    # full guard.
+    # author_association filter (OWNER/MEMBER/COLLABORATOR) on the text
+    # paths: a COST filter, not the gate. On a public repo anyone can comment
+    # `@auto` on a PR; without this every such comment spun a runner. It is
+    # not authoritative — CONTRIBUTOR is anyone with a merged commit, and
+    # whether org members show as MEMBER depends on org settings — so the
+    # reusable workflow's trigger check (a fail-closed permission lookup on
+    # the actor, before any write) remains the authority. A collaborator
+    # whose association is reported looser than expected is dropped here
+    # silently; the trig check would refuse them anyway. The issue-body
+    # branch is scoped to `issues` events like the `claude` job's: an
+    # issue_comment payload also carries issue.body/author_association, so
+    # without the scope a member-authored issue mentioning @auto would let
+    # every comment from anyone spin a runner (refused by trig, but paid for).
     if: |
       ( github.event_name == 'issues' && github.event.action == 'labeled'
         && github.event.label.name == 'auto'
         && !endsWith(github.actor, '[bot]') ) ||
       ( github.actor != 'i-am-marvin' && !endsWith(github.actor, '[bot]') && (
         ( github.event.action == 'edited'
+          && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
           && contains(github.event.comment.body, '@auto')
           && !contains(github.event.changes.body.from, '@auto') ) ||
         ( github.event.action != 'edited' && (
-            contains(github.event.comment.body, '@auto') ||
-            contains(github.event.review.body, '@auto') ||
-            contains(github.event.issue.body, '@auto') ||
-            contains(github.event.issue.title, '@auto') ||
+            ( contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+              && contains(github.event.comment.body, '@auto') ) ||
+            ( contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)
+              && contains(github.event.review.body, '@auto') ) ||
+            ( github.event_name == 'issues'
+              && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association)
+              && ( contains(github.event.issue.body, '@auto')
+                || contains(github.event.issue.title, '@auto') ) ) ||
             github.event.label.name == 'auto'
         ) )
       ) )


### PR DESCRIPTION
Stub sync for [meridianlabs-ai/agents#93](https://github.com/meridianlabs-ai/agents/pull/93), which changed `examples/claude-stub.yml`: the `claude-auto` job's text paths (`@auto` in a comment / review / issue) now carry an `author_association` filter (OWNER/MEMBER/COLLABORATOR) so a stranger's `@auto` comment on a public repo no longer spins a runner, and the issue-body branch is scoped to `issues` events. It is a **cost filter, not the gate** — the reusable workflow's fail-closed permission lookup on the actor (also from agents#93, live at `@main`) remains the authority; the in-file comment spells this out.

**This repo:** Applies exactly the stub hunk from agents#93 (the file was otherwise already current with agents/examples/claude-stub.yml); this repo's deliberate deviations are untouched.

No behavior change for members/collaborators. Workflow-editing PR, so auto-review-on-open is skipped; `@review` requested by comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)